### PR TITLE
Fix auth permutation tests

### DIFF
--- a/databricks/auth_permutations_test.go
+++ b/databricks/auth_permutations_test.go
@@ -272,7 +272,7 @@ func TestConfig_AzureCliHost(t *testing.T) {
 		host:            "x",          // adb-123.4.azuredatabricks.net
 		azureResourceID: azResourceID, // skips ensureWorkspaceUrl
 		env: map[string]string{
-			"PATH": "testdata",
+			"PATH": testdataPath(),
 			"HOME": "testdata/azure",
 		},
 		assertAzure: true,
@@ -285,7 +285,7 @@ func TestConfig_AzureCliHost_Fail(t *testing.T) {
 	configFixture{
 		azureResourceID: azResourceID,
 		env: map[string]string{
-			"PATH": "testdata",
+			"PATH": testdataPath(),
 			"HOME": "testdata/azure",
 			"FAIL": "yes",
 		},
@@ -310,7 +310,7 @@ func TestConfig_AzureCliHost_PatConflict_WithConfigFilePresentWithoutDefaultProf
 		azureResourceID: azResourceID,
 		token:           "x",
 		env: map[string]string{
-			"PATH": "testdata",
+			"PATH": testdataPath(),
 			"HOME": "testdata/azure",
 		},
 		assertError: "validate: more than one authorization method configured: azure and pat. Config: token=***, azure_workspace_resource_id=/sub/rg/ws",
@@ -323,7 +323,7 @@ func TestConfig_AzureCliHostAndResourceID(t *testing.T) {
 		azureResourceID: azResourceID,
 		host:            "x",
 		env: map[string]string{
-			"PATH": "testdata",
+			"PATH": testdataPath(),
 			"HOME": "testdata/azure",
 		},
 		assertAzure: true,
@@ -338,7 +338,7 @@ func TestConfig_AzureCliHostAndResourceID_ConfigurationPrecedence(t *testing.T) 
 		azureResourceID: azResourceID,
 		host:            "x",
 		env: map[string]string{
-			"PATH":                      "testdata",
+			"PATH":                      testdataPath(),
 			"HOME":                      "testdata/azure",
 			"DATABRICKS_CONFIG_PROFILE": "justhost",
 		},
@@ -353,7 +353,7 @@ func TestConfig_AzureAndPasswordConflict(t *testing.T) { // TODO: this breaks
 		host:            "x",
 		azureResourceID: azResourceID,
 		env: map[string]string{
-			"PATH":                "testdata",
+			"PATH":                testdataPath(),
 			"HOME":                "testdata/azure",
 			"DATABRICKS_USERNAME": "x",
 		},

--- a/databricks/config_attributes.go
+++ b/databricks/config_attributes.go
@@ -22,6 +22,10 @@ func (a Attributes) DebugString(cfg *Config) string {
 		if attr.IsZero(cfg) {
 			continue
 		}
+		// Don't include internal fields in debug representation.
+		if attr.Internal {
+			continue
+		}
 		v := "***"
 		if !attr.Sensitive {
 			v = attr.GetString(cfg)


### PR DESCRIPTION
The auth permutation tests include assertions on error messages that include a debug representation of the configuration used in the test. This representation includes a couple internal fields (fields that aren't auth related) and can be omitted from the debug representation.

With this change all tests under `databricks` pass again:

```
% go test ./...
ok      github.com/databricks/databricks-sdk-go/databricks      (cached)
?       github.com/databricks/databricks-sdk-go/databricks/apierr       [no test files]
?       github.com/databricks/databricks-sdk-go/databricks/client       [no test files]
?       github.com/databricks/databricks-sdk-go/databricks/internal     [no test files]
?       github.com/databricks/databricks-sdk-go/databricks/logger       [no test files]
ok      github.com/databricks/databricks-sdk-go/databricks/openapi      (cached)
ok      github.com/databricks/databricks-sdk-go/databricks/openapi/code (cached)
?       github.com/databricks/databricks-sdk-go/databricks/openapi/gen  [no test files]
?       github.com/databricks/databricks-sdk-go/databricks/qa   [no test files]
ok      github.com/databricks/databricks-sdk-go/databricks/useragent    (cached)
```