### PR TITLE
Fix field annotation for use in query parameters

### DIFF
--- a/databricks/openapi/gen/model.go.tmpl
+++ b/databricks/openapi/gen/model.go.tmpl
@@ -18,7 +18,7 @@ const {{.Entity.PascalName}}{{.PascalName}} {{.Entity.PascalName}} = `{{.Content
 {{- define "field-tag" -}}
 	{{if .IsJson}}json:"{{.Name}}{{if not .Required}},omitempty{{end}}"{{end -}}
 	{{if .IsPath}} path:"{{.Name}}"{{end -}}
-	{{if .IsQuery}} query:"{{.Name}},omitempty"{{end -}}
+	{{if .IsQuery}} url:"{{.Name}},omitempty"{{end -}}
 {{- end -}}
 
 {{- define "type" -}}

--- a/service/clusters/model.go
+++ b/service/clusters/model.go
@@ -1184,7 +1184,7 @@ const GcpAttributesAvailabilityPreemptibleWithFallbackGcp GcpAttributesAvailabil
 
 type GetClusterRequest struct {
     // The cluster about which to retrieve information. 
-    ClusterId string ` query:"cluster_id,omitempty"`
+    ClusterId string ` url:"cluster_id,omitempty"`
 }
 
 
@@ -1615,7 +1615,7 @@ type ListClustersRequest struct {
     // Filter clusters based on what type of client it can be used for. Could 
     // be either NOTEBOOKS or JOBS. No input for this field will get all 
     // clusters in the workspace without filtering on its supported client 
-    CanUseClient string ` query:"can_use_client,omitempty"`
+    CanUseClient string ` url:"can_use_client,omitempty"`
 }
 
 

--- a/service/datasharing/model.go
+++ b/service/datasharing/model.go
@@ -355,7 +355,7 @@ type GetSharePermissionsResponse struct {
 
 type GetShareRequest struct {
     
-    IncludeSharedData bool ` query:"include_shared_data,omitempty"`
+    IncludeSharedData bool ` url:"include_shared_data,omitempty"`
     
     Name string ` path:"name"`
 }

--- a/service/dbfs/model.go
+++ b/service/dbfs/model.go
@@ -60,7 +60,7 @@ type FileInfo struct {
 type GetStatusRequest struct {
     // The path of the file or directory. The path should be the absolute DBFS 
     // path (e.g. &#34;/mnt/foo/&#34;). 
-    Path string ` query:"path,omitempty"`
+    Path string ` url:"path,omitempty"`
 }
 
 
@@ -79,7 +79,7 @@ type GetStatusResponse struct {
 type ListStatusRequest struct {
     // The path of the file or directory. The path should be the absolute DBFS 
     // path (e.g. &#34;/mnt/foo/&#34;). 
-    Path string ` query:"path,omitempty"`
+    Path string ` url:"path,omitempty"`
 }
 
 
@@ -121,12 +121,12 @@ type PutRequest struct {
 type ReadRequest struct {
     // The number of bytes to read starting from the offset. This has a limit 
     // of 1 MB, and a default value of 0.5 MB. 
-    Length int ` query:"length,omitempty"`
+    Length int ` url:"length,omitempty"`
     // The offset to read from in bytes. 
-    Offset int ` query:"offset,omitempty"`
+    Offset int ` url:"offset,omitempty"`
     // The path of the file to read. The path should be the absolute DBFS path 
     // (e.g. &#34;/mnt/foo/&#34;). 
-    Path string ` query:"path,omitempty"`
+    Path string ` url:"path,omitempty"`
 }
 
 

--- a/service/deltapipelines/model.go
+++ b/service/deltapipelines/model.go
@@ -200,13 +200,13 @@ type GetUpdateResponse struct {
 
 type ListUpdatesRequest struct {
     // Max number of entries to return in a single page. 
-    MaxResults int ` query:"max_results,omitempty"`
+    MaxResults int ` url:"max_results,omitempty"`
     // Page token returned by previous call 
-    PageToken string ` query:"page_token,omitempty"`
+    PageToken string ` url:"page_token,omitempty"`
     // The pipeline to return updates for. 
     PipelineId string ` path:"pipeline_id"`
     // If present, returns updates until and including this update_id. 
-    UntilUpdateId string ` query:"until_update_id,omitempty"`
+    UntilUpdateId string ` url:"until_update_id,omitempty"`
 }
 
 

--- a/service/groups/model.go
+++ b/service/groups/model.go
@@ -52,24 +52,24 @@ type Group struct {
 
 type ListGroupsRequest struct {
     // Comma-separated list of attributes to return in response. 
-    Attributes string ` query:"attributes,omitempty"`
+    Attributes string ` url:"attributes,omitempty"`
     // Desired number of results per page. 
-    Count int ` query:"count,omitempty"`
+    Count int ` url:"count,omitempty"`
     // Comma-separated list of attributes to exclude in response. 
-    ExcludedAttributes string ` query:"excludedAttributes,omitempty"`
+    ExcludedAttributes string ` url:"excludedAttributes,omitempty"`
     // Query by which the results have to be filtered. Supported operators are 
     // equals(`eq`), contains(`co`), starts with(`sw`) and not equals(`ne`). 
     // Additionally, simple expressions can be formed using logical operators - 
     // `and` and `or`. The [SCIM 
     // RFC](https://tools.ietf.org/html/rfc7644#section-3.4.2.2) has more 
     // details but we currently only support simple expressions. 
-    Filter string ` query:"filter,omitempty"`
+    Filter string ` url:"filter,omitempty"`
     // Attribute to sort the results. 
-    SortBy string ` query:"sortBy,omitempty"`
+    SortBy string ` url:"sortBy,omitempty"`
     // The order to sort the results. 
-    SortOrder ListGroupsSortOrder ` query:"sortOrder,omitempty"`
+    SortOrder ListGroupsSortOrder ` url:"sortOrder,omitempty"`
     // Specifies the index of the first result. First item is number 1. 
-    StartIndex int ` query:"startIndex,omitempty"`
+    StartIndex int ` url:"startIndex,omitempty"`
 }
 
 

--- a/service/instancepools/model.go
+++ b/service/instancepools/model.go
@@ -276,7 +276,7 @@ const FleetSpotOptionAllocationStrategyPrioritized FleetSpotOptionAllocationStra
 
 type GetInstancePoolRequest struct {
     // The instance pool about which to retrieve information. 
-    InstancePoolId string ` query:"instance_pool_id,omitempty"`
+    InstancePoolId string ` url:"instance_pool_id,omitempty"`
 }
 
 

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -197,9 +197,9 @@ type DeleteRunRequest struct {
 
 type ExportRunRequest struct {
     // The canonical identifier for the run. This field is required. 
-    RunId int64 ` query:"run_id,omitempty"`
+    RunId int64 ` url:"run_id,omitempty"`
     // Which views to export (CODE, DASHBOARDS, or ALL). Defaults to CODE. 
-    ViewsToExport ViewsToExport ` query:"views_to_export,omitempty"`
+    ViewsToExport ViewsToExport ` url:"views_to_export,omitempty"`
 }
 
 
@@ -218,7 +218,7 @@ type FileStorageInfo struct {
 type GetJobRequest struct {
     // The canonical identifier of the job to retrieve information about. This 
     // field is required. 
-    JobId int64 ` query:"job_id,omitempty"`
+    JobId int64 ` url:"job_id,omitempty"`
 }
 
 
@@ -246,7 +246,7 @@ type GetJobResponse struct {
 
 type GetRunOutputRequest struct {
     // The canonical identifier for the run. This field is required. 
-    RunId int64 ` query:"run_id,omitempty"`
+    RunId int64 ` url:"run_id,omitempty"`
 }
 
 
@@ -287,10 +287,10 @@ type GetRunOutputResponse struct {
 
 type GetRunRequest struct {
     // Whether to include the repair history in the response. 
-    IncludeHistory bool ` query:"include_history,omitempty"`
+    IncludeHistory bool ` url:"include_history,omitempty"`
     // The canonical identifier of the run for which to retrieve the metadata. 
     // This field is required. 
-    RunId int64 ` query:"run_id,omitempty"`
+    RunId int64 ` url:"run_id,omitempty"`
 }
 
 
@@ -639,13 +639,13 @@ type Library struct {
 
 type ListJobsRequest struct {
     // Whether to include task and cluster details in the response. 
-    ExpandTasks bool ` query:"expand_tasks,omitempty"`
+    ExpandTasks bool ` url:"expand_tasks,omitempty"`
     // The number of jobs to return. This value must be greater than 0 and less 
     // or equal to 25. The default value is 20. 
-    Limit int ` query:"limit,omitempty"`
+    Limit int ` url:"limit,omitempty"`
     // The offset of the first job to return, relative to the most recently 
     // created job. 
-    Offset int ` query:"offset,omitempty"`
+    Offset int ` url:"offset,omitempty"`
 }
 
 
@@ -662,33 +662,33 @@ type ListRunsRequest struct {
     // otherwise, lists both active and completed runs. An active run is a run 
     // in the `PENDING`, `RUNNING`, or `TERMINATING`. This field cannot be 
     // `true` when completed_only is `true`. 
-    ActiveOnly bool ` query:"active_only,omitempty"`
+    ActiveOnly bool ` url:"active_only,omitempty"`
     // If completed_only is `true`, only completed runs are included in the 
     // results; otherwise, lists both active and completed runs. This field 
     // cannot be `true` when active_only is `true`. 
-    CompletedOnly bool ` query:"completed_only,omitempty"`
+    CompletedOnly bool ` url:"completed_only,omitempty"`
     // Whether to include task and cluster details in the response. 
-    ExpandTasks bool ` query:"expand_tasks,omitempty"`
+    ExpandTasks bool ` url:"expand_tasks,omitempty"`
     // The job for which to list runs. If omitted, the Jobs service lists runs 
     // from all jobs. 
-    JobId int64 ` query:"job_id,omitempty"`
+    JobId int64 ` url:"job_id,omitempty"`
     // The number of runs to return. This value must be greater than 0 and less 
     // than 25\. The default value is 25\. If a request specifies a limit of 0, 
     // the service instead uses the maximum limit. 
-    Limit int ` query:"limit,omitempty"`
+    Limit int ` url:"limit,omitempty"`
     // The offset of the first run to return, relative to the most recent run. 
-    Offset int ` query:"offset,omitempty"`
+    Offset int ` url:"offset,omitempty"`
     // The type of runs to return. For a description of run types, see 
     // [Run](..dev-tools/api/latest/jobshtml#operation/JobsRunsGet). 
-    RunType ListRunsRunType ` query:"run_type,omitempty"`
+    RunType ListRunsRunType ` url:"run_type,omitempty"`
     // Show runs that started _at or after_ this value. The value must be a UTC 
     // timestamp in milliseconds. Can be combined with _start_time_to_ to 
     // filter by a time range. 
-    StartTimeFrom int ` query:"start_time_from,omitempty"`
+    StartTimeFrom int ` url:"start_time_from,omitempty"`
     // Show runs that started _at or before_ this value. The value must be a 
     // UTC timestamp in milliseconds. Can be combined with _start_time_from_ to 
     // filter by a time range. 
-    StartTimeTo int ` query:"start_time_to,omitempty"`
+    StartTimeTo int ` url:"start_time_to,omitempty"`
 }
 
 

--- a/service/libraries/model.go
+++ b/service/libraries/model.go
@@ -14,7 +14,7 @@ type ClusterLibraryStatuses struct {
 
 type ClusterStatusRequest struct {
     // Unique identifier of the cluster whose status should be retrieved. 
-    ClusterId string ` query:"cluster_id,omitempty"`
+    ClusterId string ` url:"cluster_id,omitempty"`
 }
 
 

--- a/service/repos/model.go
+++ b/service/repos/model.go
@@ -54,9 +54,9 @@ type ListReposRequest struct {
     // Token used to get the next page of results. If not specified, returns 
     // the first page of results as well as a next page token if there are more 
     // results. 
-    NextPageToken string ` query:"next_page_token,omitempty"`
+    NextPageToken string ` url:"next_page_token,omitempty"`
     // Filters repos that have paths starting with the given path prefix. 
-    PathPrefix string ` query:"path_prefix,omitempty"`
+    PathPrefix string ` url:"path_prefix,omitempty"`
 }
 
 

--- a/service/secrets/model.go
+++ b/service/secrets/model.go
@@ -74,9 +74,9 @@ type DeleteSecretRequest struct {
 
 type GetAclRequest struct {
     // The principal to fetch ACL information for. 
-    Principal string ` query:"principal,omitempty"`
+    Principal string ` url:"principal,omitempty"`
     // The name of the scope to fetch ACL information from. 
-    Scope string ` query:"scope,omitempty"`
+    Scope string ` url:"scope,omitempty"`
 }
 
 
@@ -99,7 +99,7 @@ const GetAclResponsePermissionManage GetAclResponsePermission = `MANAGE`
 
 type ListAclsRequest struct {
     // The name of the scope to fetch ACL information from. 
-    Scope string ` query:"scope,omitempty"`
+    Scope string ` url:"scope,omitempty"`
 }
 
 
@@ -117,7 +117,7 @@ type ListScopesResponse struct {
 
 type ListSecretsRequest struct {
     // The name of the scope to list secrets within. 
-    Scope string ` query:"scope,omitempty"`
+    Scope string ` url:"scope,omitempty"`
 }
 
 

--- a/service/serviceprincipals/model.go
+++ b/service/serviceprincipals/model.go
@@ -45,24 +45,24 @@ type ListServicePrincipalResponse struct {
 
 type ListServicePrincipalsRequest struct {
     // Comma-separated list of attributes to return in response. 
-    Attributes string ` query:"attributes,omitempty"`
+    Attributes string ` url:"attributes,omitempty"`
     // Desired number of results per page. 
-    Count int ` query:"count,omitempty"`
+    Count int ` url:"count,omitempty"`
     // Comma-separated list of attributes to exclude in response. 
-    ExcludedAttributes string ` query:"excludedAttributes,omitempty"`
+    ExcludedAttributes string ` url:"excludedAttributes,omitempty"`
     // Query by which the results have to be filtered. Supported operators are 
     // equals(`eq`), contains(`co`), starts with(`sw`) and not equals(`ne`). 
     // Additionally, simple expressions can be formed using logical operators - 
     // `and` and `or`. The [SCIM 
     // RFC](https://tools.ietf.org/html/rfc7644#section-3.4.2.2) has more 
     // details but we currently only support simple expressions. 
-    Filter string ` query:"filter,omitempty"`
+    Filter string ` url:"filter,omitempty"`
     // Attribute to sort the results. 
-    SortBy string ` query:"sortBy,omitempty"`
+    SortBy string ` url:"sortBy,omitempty"`
     // The order to sort the results. 
-    SortOrder ListServicePrincipalsSortOrder ` query:"sortOrder,omitempty"`
+    SortOrder ListServicePrincipalsSortOrder ` url:"sortOrder,omitempty"`
     // Specifies the index of the first result. First item is number 1. 
-    StartIndex int ` query:"startIndex,omitempty"`
+    StartIndex int ` url:"startIndex,omitempty"`
 }
 
 

--- a/service/unitycatalog/model.go
+++ b/service/unitycatalog/model.go
@@ -1208,7 +1208,7 @@ type GetMetastoreSummaryResponse struct {
 
 type GetPermissionsRequest struct {
     // Optional. List permissions granted to this principal. 
-    Principal string ` query:"principal,omitempty"`
+    Principal string ` url:"principal,omitempty"`
     // Required. Unique identifier (full name) of Securable (from URL). 
     SecurableFullName string ` path:"securable_full_name"`
     // Required. Type of Securable (from URL). 
@@ -1459,7 +1459,7 @@ type ListMetastoresResponse struct {
 
 type ListSchemasRequest struct {
     // Optional. Parent catalog for schemas of interest. 
-    CatalogName string ` query:"catalog_name,omitempty"`
+    CatalogName string ` url:"catalog_name,omitempty"`
 }
 
 
@@ -1477,10 +1477,10 @@ type ListStorageCredentialsResponse struct {
 
 type ListTablesRequest struct {
     // Required. Name of parent catalog for tables of interest. 
-    CatalogName string ` query:"catalog_name,omitempty"`
+    CatalogName string ` url:"catalog_name,omitempty"`
     // Required (for now -- may be optional for wildcard search in future). 
     // Parent schema of tables. 
-    SchemaName string ` query:"schema_name,omitempty"`
+    SchemaName string ` url:"schema_name,omitempty"`
 }
 
 

--- a/service/users/model.go
+++ b/service/users/model.go
@@ -32,25 +32,25 @@ type FetchUserRequest struct {
 
 type ListUsersRequest struct {
     // Comma-separated list of attributes to return in response. 
-    Attributes string ` query:"attributes,omitempty"`
+    Attributes string ` url:"attributes,omitempty"`
     // Desired number of results per page. 
-    Count int ` query:"count,omitempty"`
+    Count int ` url:"count,omitempty"`
     // Comma-separated list of attributes to exclude in response. 
-    ExcludedAttributes string ` query:"excludedAttributes,omitempty"`
+    ExcludedAttributes string ` url:"excludedAttributes,omitempty"`
     // Query by which the results have to be filtered. Supported operators are 
     // equals(`eq`), contains(`co`), starts with(`sw`) and not equals(`ne`). 
     // Additionally, simple expressions can be formed using logical operators - 
     // `and` and `or`. The [SCIM 
     // RFC](https://tools.ietf.org/html/rfc7644#section-3.4.2.2) has more 
     // details but we currently only support simple expressions. 
-    Filter string ` query:"filter,omitempty"`
+    Filter string ` url:"filter,omitempty"`
     // Attribute to sort the results. Multi-part paths are supported. For 
     // example, `userName`, `name.givenName`, and `emails`. 
-    SortBy string ` query:"sortBy,omitempty"`
+    SortBy string ` url:"sortBy,omitempty"`
     // The order to sort the results. 
-    SortOrder ListUsersSortOrder ` query:"sortOrder,omitempty"`
+    SortOrder ListUsersSortOrder ` url:"sortOrder,omitempty"`
     // Specifies the index of the first result. First item is number 1. 
-    StartIndex int ` query:"startIndex,omitempty"`
+    StartIndex int ` url:"startIndex,omitempty"`
 }
 
 

--- a/service/workspace/model.go
+++ b/service/workspace/model.go
@@ -20,14 +20,14 @@ type ExportRequest struct {
     // the exported file itself. Otherwise, the response contains content as 
     // base64 encoded string. See :ref:`workspace-api-export-example` for more 
     // information about how to use it. 
-    DirectDownload bool ` query:"direct_download,omitempty"`
+    DirectDownload bool ` url:"direct_download,omitempty"`
     // This specifies the format of the exported file. By default, this is 
     // ``SOURCE``. However it may be one of: ``SOURCE``, ``HTML``, ``JUPYTER``, 
     // ``DBC``. The value is case sensitive. 
-    Format string ` query:"format,omitempty"`
+    Format string ` url:"format,omitempty"`
     // The absolute path of the notebook or directory. Exporting directory is 
     // only support for ``DBC`` format. 
-    Path string ` query:"path,omitempty"`
+    Path string ` url:"path,omitempty"`
 }
 
 
@@ -40,7 +40,7 @@ type ExportResponse struct {
 
 type GetStatusRequest struct {
     // The absolute path of the notebook or directory. 
-    Path string ` query:"path,omitempty"`
+    Path string ` url:"path,omitempty"`
 }
 
 
@@ -166,9 +166,9 @@ const ImportRequestLanguageR ImportRequestLanguage = `R`
 
 type ListRequest struct {
     
-    NotebooksModifiedAfter int ` query:"notebooks_modified_after,omitempty"`
+    NotebooksModifiedAfter int ` url:"notebooks_modified_after,omitempty"`
     // The absolute path of the notebook or directory. 
-    Path string ` query:"path,omitempty"`
+    Path string ` url:"path,omitempty"`
 }
 
 


### PR DESCRIPTION
The function to generate query parameters uses the "url" field tag key.

See: https://pkg.go.dev/github.com/google/go-querystring/query#pkg-functions

This fixes a subset of test failures under `service/commands`.

* Before: `Get "http://127.0.0.1:61225/api/2.0/clusters/get?ClusterId=abc"`
* After: `Get "http://127.0.0.1:61225/api/2.0/clusters/get?cluster_id=abc"`