### PR TITLE
Clean up enum formatting

### DIFF
--- a/databricks/openapi/gen/model.go.tmpl
+++ b/databricks/openapi/gen/model.go.tmpl
@@ -4,7 +4,8 @@ package {{.Name}}
 
 // all definitions in this file are in alphabetical order
 {{range .Types}}
-{{.Comment "// " 80}}{{if .Fields -}}type {{.PascalName}} struct {
+{{.Comment "// " 80}}
+{{if .Fields -}}type {{.PascalName}} struct {
     {{- range .Fields}}
     {{.Comment "    // " 80}}
     {{.PascalName}} {{if .IsOptionalObject}}*{{end}}{{template "type" .Entity}} `{{template "field-tag" . }}`{{end}}

--- a/service/clusters/model.go
+++ b/service/clusters/model.go
@@ -4,6 +4,7 @@ package clusters
 
 // all definitions in this file are in alphabetical order
 
+
 type AutoScale struct {
     // The maximum number of workers to which the cluster can scale up when
     // overloaded. Note that ``max_workers`` must be strictly greater than
@@ -14,6 +15,7 @@ type AutoScale struct {
     // have after creation.
     MinWorkers int `json:"min_workers,omitempty"`
 }
+
 
 type AwsAttributes struct {
     // Availability type used for all subsequent nodes past the
@@ -91,6 +93,7 @@ type AwsAttributes struct {
 // Availability type used for all subsequent nodes past the ``first_on_demand``
 // ones. Note: If ``first_on_demand`` is zero, this availability type will be
 // used for the entire cluster.
+
 type AwsAttributesAvailability string
 const (
 	AwsAttributesAvailabilitySpot AwsAttributesAvailability = `SPOT`
@@ -99,11 +102,13 @@ const (
 )
 
 // The type of EBS volumes that will be launched with this cluster.
+
 type AwsAttributesEbsVolumeType string
 const (
 	AwsAttributesEbsVolumeTypeGeneralPurposeSsd AwsAttributesEbsVolumeType = `GENERAL_PURPOSE_SSD`
 	AwsAttributesEbsVolumeTypeThroughputOptimizedHdd AwsAttributesEbsVolumeType = `THROUGHPUT_OPTIMIZED_HDD`
 )
+
 
 type AwsCpalError struct {
     
@@ -117,6 +122,7 @@ type AwsCpalError struct {
     
     AwsSpotRequestStatus string `json:"aws_spot_request_status,omitempty"`
 }
+
 
 type AzureAttributes struct {
     // Availability type used for all subsequent nodes past the
@@ -147,12 +153,14 @@ type AzureAttributes struct {
 // Availability type used for all subsequent nodes past the ``first_on_demand``
 // ones. Note: If ``first_on_demand`` is zero (which only happens on pool
 // clusters), this availability type will be used for the entire cluster.
+
 type AzureAttributesAvailability string
 const (
 	AzureAttributesAvailabilitySpotAzure AzureAttributesAvailability = `SPOT_AZURE`
 	AzureAttributesAvailabilityOnDemandAzure AzureAttributesAvailability = `ON_DEMAND_AZURE`
 	AzureAttributesAvailabilitySpotWithFallbackAzure AzureAttributesAvailability = `SPOT_WITH_FALLBACK_AZURE`
 )
+
 
 type ChangeClusterOwnerRequest struct {
     
@@ -161,12 +169,14 @@ type ChangeClusterOwnerRequest struct {
     OwnerUsername string `json:"owner_username,omitempty"`
 }
 
+
 type ClientsTypes struct {
     // With jobs set, the cluster can be used for jobs
     Jobs bool `json:"jobs,omitempty"`
     // With notebooks set, this cluster can be used for notebooks
     Notebooks bool `json:"notebooks,omitempty"`
 }
+
 
 type ClusterAttributes struct {
     // Automatically terminates the cluster after it is inactive for this time
@@ -273,6 +283,7 @@ type ClusterAttributes struct {
 // Determines whether the cluster was created by a user through the UI, created
 // by the Databricks Jobs Scheduler, or through an API request. This is the same
 // as cluster_creator, but read only.
+
 type ClusterAttributesClusterSource string
 const (
 	ClusterAttributesClusterSourceUi ClusterAttributesClusterSource = `UI`
@@ -286,12 +297,14 @@ const (
 
 // Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 // unspecified, the runtime engine is inferred from spark_version.
+
 type ClusterAttributesRuntimeEngine string
 const (
 	ClusterAttributesRuntimeEngineNull ClusterAttributesRuntimeEngine = `NULL`
 	ClusterAttributesRuntimeEngineStandard ClusterAttributesRuntimeEngine = `STANDARD`
 	ClusterAttributesRuntimeEnginePhoton ClusterAttributesRuntimeEngine = `PHOTON`
 )
+
 
 type ClusterEvent struct {
     
@@ -307,6 +320,7 @@ type ClusterEvent struct {
     
     Type ClusterEventType `json:"type,omitempty"`
 }
+
 
 
 type ClusterEventType string
@@ -337,6 +351,7 @@ const (
 	ClusterEventTypeUnpinned ClusterEventType = `UNPINNED`
 	ClusterEventTypeNodeExcludedDecommissioned ClusterEventType = `NODE_EXCLUDED_DECOMMISSIONED`
 )
+
 
 type ClusterInfo struct {
     // Parameters needed in order to automatically scale clusters up and down
@@ -516,6 +531,7 @@ type ClusterInfo struct {
 // Determines whether the cluster was created by a user through the UI, created
 // by the Databricks Jobs Scheduler, or through an API request. This is the same
 // as cluster_creator, but read only.
+
 type ClusterInfoClusterSource string
 const (
 	ClusterInfoClusterSourceUi ClusterInfoClusterSource = `UI`
@@ -529,6 +545,7 @@ const (
 
 // Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 // unspecified, the runtime engine is inferred from spark_version.
+
 type ClusterInfoRuntimeEngine string
 const (
 	ClusterInfoRuntimeEngineNull ClusterInfoRuntimeEngine = `NULL`
@@ -537,6 +554,7 @@ const (
 )
 
 // Current state of the cluster.
+
 type ClusterInfoState string
 const (
 	ClusterInfoStatePending ClusterInfoState = `PENDING`
@@ -549,6 +567,7 @@ const (
 	ClusterInfoStateUnknown ClusterInfoState = `UNKNOWN`
 )
 
+
 type ClusterLogConf struct {
     // destination needs to be provided. e.g. ``{ &#34;dbfs&#34; : { &#34;destination&#34; :
     // &#34;dbfs:/home/cluster_log&#34; } }``
@@ -560,6 +579,7 @@ type ClusterLogConf struct {
     // data to the s3 destination.
     S3 *S3StorageInfo `json:"s3,omitempty"`
 }
+
 
 type ClusterSize struct {
     // Parameters needed in order to automatically scale clusters up and down
@@ -576,6 +596,7 @@ type ClusterSize struct {
     // will gradually increase from 5 to 10 as the new nodes are provisioned.
     NumWorkers int `json:"num_workers,omitempty"`
 }
+
 
 type CpalFailureResponse struct {
     
@@ -599,6 +620,7 @@ type CpalFailureResponse struct {
 }
 
 
+
 type CpalFailureResponseAwsCpalErrorCode string
 const (
 	CpalFailureResponseAwsCpalErrorCodeAwsServiceException CpalFailureResponseAwsCpalErrorCode = `AWS_SERVICE_EXCEPTION`
@@ -612,6 +634,7 @@ const (
 	CpalFailureResponseAwsCpalErrorCodeAwsInvalidInstanceTypeFailure CpalFailureResponseAwsCpalErrorCode = `AWS_INVALID_INSTANCE_TYPE_FAILURE`
 	CpalFailureResponseAwsCpalErrorCodeAwsMaxSpotInstanceCountExceeded CpalFailureResponseAwsCpalErrorCode = `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED`
 )
+
 
 
 type CpalFailureResponseAzureCpalErrorCode string
@@ -636,11 +659,13 @@ const (
 )
 
 
+
 type CpalFailureResponseDelegateErrorCode string
 const (
 	CpalFailureResponseDelegateErrorCodeDelegateUnexpectedException CpalFailureResponseDelegateErrorCode = `DELEGATE_UNEXPECTED_EXCEPTION`
 	CpalFailureResponseDelegateErrorCodeNoSuchWorkerEnvironmentException CpalFailureResponseDelegateErrorCode = `NO_SUCH_WORKER_ENVIRONMENT_EXCEPTION`
 )
+
 
 type CreateClusterRequest struct {
     // Note: This field won&#39;t be true for webapp requests. Only API users will
@@ -772,6 +797,7 @@ type CreateClusterRequest struct {
 // Determines whether the cluster was created by a user through the UI, created
 // by the Databricks Jobs Scheduler, or through an API request. This is the same
 // as cluster_creator, but read only.
+
 type CreateClusterRequestClusterSource string
 const (
 	CreateClusterRequestClusterSourceUi CreateClusterRequestClusterSource = `UI`
@@ -785,6 +811,7 @@ const (
 
 // Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 // unspecified, the runtime engine is inferred from spark_version.
+
 type CreateClusterRequestRuntimeEngine string
 const (
 	CreateClusterRequestRuntimeEngineNull CreateClusterRequestRuntimeEngine = `NULL`
@@ -792,10 +819,12 @@ const (
 	CreateClusterRequestRuntimeEnginePhoton CreateClusterRequestRuntimeEngine = `PHOTON`
 )
 
+
 type CreateClusterResponse struct {
     
     ClusterId string `json:"cluster_id,omitempty"`
 }
+
 
 type DataPlaneEventDetails struct {
     
@@ -809,21 +838,25 @@ type DataPlaneEventDetails struct {
 }
 
 
+
 type DataPlaneEventDetailsEventType string
 const (
 	DataPlaneEventDetailsEventTypeNodeBlacklisted DataPlaneEventDetailsEventType = `NODE_BLACKLISTED`
 	DataPlaneEventDetailsEventTypeNodeExcludedDecommissioned DataPlaneEventDetailsEventType = `NODE_EXCLUDED_DECOMMISSIONED`
 )
 
+
 type DbfsStorageInfo struct {
     // dbfs destination, e.g. ``dbfs:/my/path``
     Destination string `json:"destination,omitempty"`
 }
 
+
 type DeleteClusterRequest struct {
     // The cluster to be terminated.
     ClusterId string `json:"cluster_id"`
 }
+
 
 type EditClusterRequest struct {
     // Note: This field won&#39;t be true for webapp requests. Only API users will
@@ -957,6 +990,7 @@ type EditClusterRequest struct {
 // Determines whether the cluster was created by a user through the UI, created
 // by the Databricks Jobs Scheduler, or through an API request. This is the same
 // as cluster_creator, but read only.
+
 type EditClusterRequestClusterSource string
 const (
 	EditClusterRequestClusterSourceUi EditClusterRequestClusterSource = `UI`
@@ -970,12 +1004,14 @@ const (
 
 // Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 // unspecified, the runtime engine is inferred from spark_version.
+
 type EditClusterRequestRuntimeEngine string
 const (
 	EditClusterRequestRuntimeEngineNull EditClusterRequestRuntimeEngine = `NULL`
 	EditClusterRequestRuntimeEngineStandard EditClusterRequestRuntimeEngine = `STANDARD`
 	EditClusterRequestRuntimeEnginePhoton EditClusterRequestRuntimeEngine = `PHOTON`
 )
+
 
 type EventDetails struct {
     // * For created clusters, the attributes of the cluster. * For edited
@@ -1026,6 +1062,7 @@ type EventDetails struct {
 }
 
 // The cause of a change in target size.
+
 type EventDetailsCause string
 const (
 	EventDetailsCauseAutoscale EventDetailsCause = `AUTOSCALE`
@@ -1033,6 +1070,7 @@ const (
 	EventDetailsCauseAutorecovery EventDetailsCause = `AUTORECOVERY`
 	EventDetailsCauseReplaceBadNodes EventDetailsCause = `REPLACE_BAD_NODES`
 )
+
 
 type GcpAttributes struct {
     // This field determines whether the spark executors will be scheduled to
@@ -1051,6 +1089,7 @@ type GcpAttributes struct {
 // This field determines whether the spark executors will be scheduled to run on
 // preemptible VMs, on-demand VMs, or preemptible VMs with a fallback to
 // on-demand VMs if the former is unavailable.
+
 type GcpAttributesAvailability string
 const (
 	GcpAttributesAvailabilityPreemptibleGcp GcpAttributesAvailability = `PREEMPTIBLE_GCP`
@@ -1058,10 +1097,12 @@ const (
 	GcpAttributesAvailabilityPreemptibleWithFallbackGcp GcpAttributesAvailability = `PREEMPTIBLE_WITH_FALLBACK_GCP`
 )
 
+
 type GetClusterRequest struct {
     // The cluster about which to retrieve information.
     ClusterId string ` url:"cluster_id,omitempty"`
 }
+
 
 type GetClusterResponse struct {
     // Parameters needed in order to automatically scale clusters up and down
@@ -1241,6 +1282,7 @@ type GetClusterResponse struct {
 // Determines whether the cluster was created by a user through the UI, created
 // by the Databricks Jobs Scheduler, or through an API request. This is the same
 // as cluster_creator, but read only.
+
 type GetClusterResponseClusterSource string
 const (
 	GetClusterResponseClusterSourceUi GetClusterResponseClusterSource = `UI`
@@ -1254,6 +1296,7 @@ const (
 
 // Decides which runtime engine to be use, e.g. Standard vs. Photon. If
 // unspecified, the runtime engine is inferred from spark_version.
+
 type GetClusterResponseRuntimeEngine string
 const (
 	GetClusterResponseRuntimeEngineNull GetClusterResponseRuntimeEngine = `NULL`
@@ -1262,6 +1305,7 @@ const (
 )
 
 // Current state of the cluster.
+
 type GetClusterResponseState string
 const (
 	GetClusterResponseStatePending GetClusterResponseState = `PENDING`
@@ -1273,6 +1317,7 @@ const (
 	GetClusterResponseStateError GetClusterResponseState = `ERROR`
 	GetClusterResponseStateUnknown GetClusterResponseState = `UNKNOWN`
 )
+
 
 type GetEvents struct {
     // The ID of the cluster to retrieve events about.
@@ -1296,6 +1341,7 @@ type GetEvents struct {
     // from the beginning of time.
     StartTime int64 `json:"start_time,omitempty"`
 }
+
 
 
 type GetEventsEventTypesItem string
@@ -1328,11 +1374,13 @@ const (
 )
 
 // The order to list events in; either &#34;ASC&#34; or &#34;DESC&#34;. Defaults to &#34;DESC&#34;.
+
 type GetEventsOrder string
 const (
 	GetEventsOrderDesc GetEventsOrder = `DESC`
 	GetEventsOrderAsc GetEventsOrder = `ASC`
 )
+
 
 type GetEventsRequest struct {
     // The ID of the cluster to retrieve events about.
@@ -1356,6 +1404,7 @@ type GetEventsRequest struct {
     // from the beginning of time.
     StartTime int64 `json:"start_time,omitempty"`
 }
+
 
 
 type GetEventsRequestEventTypesItem string
@@ -1388,11 +1437,13 @@ const (
 )
 
 // The order to list events in; either &#34;ASC&#34; or &#34;DESC&#34;. Defaults to &#34;DESC&#34;.
+
 type GetEventsRequestOrder string
 const (
 	GetEventsRequestOrderDesc GetEventsRequestOrder = `DESC`
 	GetEventsRequestOrderAsc GetEventsRequestOrder = `ASC`
 )
+
 
 type GetEventsResponse struct {
     
@@ -1405,10 +1456,12 @@ type GetEventsResponse struct {
     TotalCount int64 `json:"total_count,omitempty"`
 }
 
+
 type GetSparkVersionsResponse struct {
     // All the available Spark versions.
     Versions []SparkVersion `json:"versions,omitempty"`
 }
+
 
 type ListAvailableZonesResponse struct {
     // The availability zone if no ``zone_id`` is provided in the cluster
@@ -1418,6 +1471,7 @@ type ListAvailableZonesResponse struct {
     Zones []string `json:"zones,omitempty"`
 }
 
+
 type ListClustersRequest struct {
     // Filter clusters based on what type of client it can be used for. Could be
     // either NOTEBOOKS or JOBS. No input for this field will get all clusters
@@ -1425,10 +1479,12 @@ type ListClustersRequest struct {
     CanUseClient string ` url:"can_use_client,omitempty"`
 }
 
+
 type ListClustersResponse struct {
     
     Clusters []ClusterInfo `json:"clusters,omitempty"`
 }
+
 
 type ListNodeTypesResponse struct {
     
@@ -1439,12 +1495,14 @@ type ListNodeTypesResponse struct {
     Success any /* ERROR */ `json:"success,omitempty"`
 }
 
+
 type LogAnalyticsInfo struct {
     
     LogAnalyticsPrimaryKey string `json:"log_analytics_primary_key,omitempty"`
     
     LogAnalyticsWorkspaceId string `json:"log_analytics_workspace_id,omitempty"`
 }
+
 
 type LogSyncStatus struct {
     // The timestamp of last attempt. If the last attempt fails,
@@ -1454,6 +1512,7 @@ type LogSyncStatus struct {
     // the response) if there is no exception in last attempted.
     LastException string `json:"last_exception,omitempty"`
 }
+
 
 type NodeType struct {
     // A string description associated with this node type, e.g., &#34;r3.xlarge&#34;.
@@ -1477,15 +1536,18 @@ type NodeType struct {
     NumCores float64 `json:"num_cores"`
 }
 
+
 type PermanentDeleteClusterRequest struct {
     // The cluster to be deleted.
     ClusterId string `json:"cluster_id"`
 }
 
+
 type PinClusterRequest struct {
     
     ClusterId string `json:"cluster_id"`
 }
+
 
 type ResizeClusterRequest struct {
     // Parameters needed in order to automatically scale clusters up and down
@@ -1505,12 +1567,14 @@ type ResizeClusterRequest struct {
     NumWorkers int `json:"num_workers,omitempty"`
 }
 
+
 type RestartClusterRequest struct {
     // The cluster to be started.
     ClusterId string `json:"cluster_id"`
     
     RestartUser string `json:"restart_user,omitempty"`
 }
+
 
 type S3StorageInfo struct {
     // (Optional) Set canned access control list for the logs, e.g.
@@ -1546,6 +1610,7 @@ type S3StorageInfo struct {
     Region string `json:"region,omitempty"`
 }
 
+
 type SparkNode struct {
     // The private IP address of the host instance.
     HostPrivateIp string `json:"host_private_ip,omitempty"`
@@ -1572,10 +1637,12 @@ type SparkNode struct {
     StartTimestamp int64 `json:"start_timestamp,omitempty"`
 }
 
+
 type SparkNodeAwsAttributes struct {
     // Whether this node is on an Amazon spot instance.
     IsSpot bool `json:"is_spot,omitempty"`
 }
+
 
 type SparkVersion struct {
     // Spark version key, for example &#34;2.1.x-scala2.11&#34;. This is the value which
@@ -1588,10 +1655,12 @@ type SparkVersion struct {
     Name string `json:"name,omitempty"`
 }
 
+
 type StartClusterRequest struct {
     // The cluster to be started.
     ClusterId string `json:"cluster_id"`
 }
+
 
 type TerminationReason struct {
     // status code indicating why the cluster was terminated
@@ -1604,6 +1673,7 @@ type TerminationReason struct {
 }
 
 // status code indicating why the cluster was terminated
+
 type TerminationReasonCode string
 const (
 	TerminationReasonCodeUnknown TerminationReasonCode = `UNKNOWN`
@@ -1688,6 +1758,7 @@ const (
 )
 
 // type of the termination
+
 type TerminationReasonType string
 const (
 	TerminationReasonTypeSuccess TerminationReasonType = `SUCCESS`
@@ -1696,10 +1767,12 @@ const (
 	TerminationReasonTypeCloudFailure TerminationReasonType = `CLOUD_FAILURE`
 )
 
+
 type UnpinClusterRequest struct {
     
     ClusterId string `json:"cluster_id"`
 }
+
 
 type WorkloadType struct {
     // defined what type of clients can use the cluster. E.g. Notebooks, Jobs

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -4,6 +4,7 @@ package jobs
 
 // all definitions in this file are in alphabetical order
 
+
 type AccessControlRequest struct {
     // Group name. There are two built-in groups: `users` for all users, and
     // `admins` for administrators.
@@ -16,6 +17,7 @@ type AccessControlRequest struct {
     UserName string `json:"user_name,omitempty"`
 }
 
+
 type AutoScale struct {
     // The maximum number of workers to which the cluster can scale up when
     // overloaded. max_workers must be strictly greater than min_workers.
@@ -26,16 +28,19 @@ type AutoScale struct {
     MinWorkers int `json:"min_workers,omitempty"`
 }
 
+
 type CancelAllRunsRequest struct {
     // The canonical identifier of the job to cancel all runs of. This field is
     // required.
     JobId int64 `json:"job_id"`
 }
 
+
 type CancelRunRequest struct {
     // This field is required.
     RunId int64 `json:"run_id"`
 }
+
 
 type ClusterInstance struct {
     // The canonical identifier for the cluster used by a run. This field is
@@ -54,11 +59,13 @@ type ClusterInstance struct {
     SparkContextId string `json:"spark_context_id,omitempty"`
 }
 
+
 type ClusterLogConf struct {
     // DBFS location of cluster log. Destination must be provided. For example,
     // `{ &#34;dbfs&#34; : { &#34;destination&#34; : &#34;dbfs:/home/cluster_log&#34; } }`
     Dbfs *DbfsStorageInfo `json:"dbfs,omitempty"`
 }
+
 
 type ClusterSpec struct {
     // If existing_cluster_id, the ID of an existing cluster that is used for
@@ -76,14 +83,17 @@ type ClusterSpec struct {
 // An object with key value pairs. The key length must be between 1 and 127
 // UTF-8 characters, inclusive. The value length must be less than or equal to
 // 255 UTF-8 characters.
+
 // Used to tell what is the format of the job. This field is ignored in
 // Create/Update/Reset calls. When using the Jobs API 2.1 this value is always
 // set to `&#34;MULTI_TASK&#34;`.
+
 type CreateJobFormat string
 const (
 	CreateJobFormatSingleTask CreateJobFormat = `SINGLE_TASK`
 	CreateJobFormatMultiTask CreateJobFormat = `MULTI_TASK`
 )
+
 
 type CreateJobRequest struct {
     // List of permissions to set on the job.
@@ -134,10 +144,12 @@ type CreateJobRequest struct {
     TimeoutSeconds int `json:"timeout_seconds,omitempty"`
 }
 
+
 type CreateJobResponse struct {
     // The canonical identifier for the newly created job.
     JobId int64 `json:"job_id,omitempty"`
 }
+
 
 type CronSchedule struct {
     // Indicate whether this schedule is paused or not.
@@ -155,26 +167,31 @@ type CronSchedule struct {
 }
 
 // Indicate whether this schedule is paused or not.
+
 type CronSchedulePauseStatus string
 const (
 	CronSchedulePauseStatusPaused CronSchedulePauseStatus = `PAUSED`
 	CronSchedulePauseStatusUnpaused CronSchedulePauseStatus = `UNPAUSED`
 )
 
+
 type DbfsStorageInfo struct {
     // DBFS destination. Example: `dbfs:/my/path`
     Destination string `json:"destination,omitempty"`
 }
+
 
 type DeleteJobRequest struct {
     // The canonical identifier of the job to delete. This field is required.
     JobId int64 `json:"job_id"`
 }
 
+
 type DeleteRunRequest struct {
     // The canonical identifier of the run for which to retrieve the metadata.
     RunId int64 `json:"run_id,omitempty"`
 }
+
 
 type ExportRunRequest struct {
     // The canonical identifier for the run. This field is required.
@@ -183,21 +200,25 @@ type ExportRunRequest struct {
     ViewsToExport ViewsToExport ` url:"views_to_export,omitempty"`
 }
 
+
 type ExportRunResponse struct {
     // The exported content in HTML format (one for every view item).
     Views []ViewItem `json:"views,omitempty"`
 }
+
 
 type FileStorageInfo struct {
     // File destination. Example: `file:/my/file.sh`
     Destination string `json:"destination,omitempty"`
 }
 
+
 type GetJobRequest struct {
     // The canonical identifier of the job to retrieve information about. This
     // field is required.
     JobId int64 ` url:"job_id,omitempty"`
 }
+
 
 type GetJobResponse struct {
     // The time at which this job was created in epoch milliseconds
@@ -219,10 +240,12 @@ type GetJobResponse struct {
     Settings *JobSettings `json:"settings,omitempty"`
 }
 
+
 type GetRunOutputRequest struct {
     // The canonical identifier for the run. This field is required.
     RunId int64 ` url:"run_id,omitempty"`
 }
+
 
 type GetRunOutputResponse struct {
     // An error message indicating why a task failed or why output is not
@@ -258,6 +281,7 @@ type GetRunOutputResponse struct {
     NotebookOutput *NotebookOutput `json:"notebook_output,omitempty"`
 }
 
+
 type GetRunRequest struct {
     // Whether to include the repair history in the response.
     IncludeHistory bool ` url:"include_history,omitempty"`
@@ -265,6 +289,7 @@ type GetRunRequest struct {
     // This field is required.
     RunId int64 ` url:"run_id,omitempty"`
 }
+
 
 type GetRunResponse struct {
     // The sequence number of this run attempt for a triggered job run. The
@@ -346,7 +371,8 @@ type GetRunResponse struct {
 }
 
 // Read-only state of the remote repository at the time the job was run. This
-// field is only included on job runs.type GitSnapshot struct {
+// field is only included on job runs.
+type GitSnapshot struct {
     // Commit that was used to execute the run. If git_branch was specified,
     // this points to the HEAD of the branch at the time of the run; if git_tag
     // was specified, this points to the commit the tag points to.
@@ -354,7 +380,8 @@ type GetRunResponse struct {
 }
 
 // An optional specification for a remote repository containing the notebooks
-// used by this job&#39;s notebook tasks.type GitSource struct {
+// used by this job&#39;s notebook tasks.
+type GitSource struct {
     // Name of the branch to be checked out and used by this job. This field
     // cannot be specified in conjunction with git_tag or git_commit. The
     // maximum length is 255 characters.
@@ -379,6 +406,7 @@ type GetRunResponse struct {
 
 // Unique identifier of the service used to host the Git repository. The value
 // is case insensitive.
+
 type GitSourceGitProvider string
 const (
 	GitSourceGitProviderGithub GitSourceGitProvider = `gitHub`
@@ -391,6 +419,7 @@ const (
 	GitSourceGitProviderAwscodecommit GitSourceGitProvider = `awsCodeCommit`
 )
 
+
 type InitScriptInfo struct {
     // DBFS location of init script. Destination must be provided. For example,
     // `{ &#34;dbfs&#34; : { &#34;destination&#34; : &#34;dbfs:/home/init_script&#34; } }`
@@ -399,6 +428,7 @@ type InitScriptInfo struct {
     // `{ &#34;file&#34; : { &#34;destination&#34; : &#34;file:/my/local/file.sh&#34; } }`
     File *FileStorageInfo `json:"file,omitempty"`
 }
+
 
 type Job struct {
     // The time at which this job was created in epoch milliseconds
@@ -414,6 +444,7 @@ type Job struct {
     Settings *JobSettings `json:"settings,omitempty"`
 }
 
+
 type JobCluster struct {
     // A unique name for the job cluster. This field is required and must be
     // unique within the job. `JobTaskSettings` may refer to this field to
@@ -422,6 +453,7 @@ type JobCluster struct {
     
     NewCluster *NewCluster `json:"new_cluster,omitempty"`
 }
+
 
 type JobEmailNotifications struct {
     // If true, do not send email to recipients specified in `on_failure` if the
@@ -445,6 +477,7 @@ type JobEmailNotifications struct {
     // and notifications are not sent.
     OnSuccess []string `json:"on_success,omitempty"`
 }
+
 
 type JobSettings struct {
     // An optional set of email addresses that is notified when runs of this job
@@ -496,11 +529,13 @@ type JobSettings struct {
 // Used to tell what is the format of the job. This field is ignored in
 // Create/Update/Reset calls. When using the Jobs API 2.1 this value is always
 // set to `&#34;MULTI_TASK&#34;`.
+
 type JobSettingsFormat string
 const (
 	JobSettingsFormatSingleTask JobSettingsFormat = `SINGLE_TASK`
 	JobSettingsFormatMultiTask JobSettingsFormat = `MULTI_TASK`
 )
+
 
 type JobTaskSettings struct {
     
@@ -561,6 +596,7 @@ type JobTaskSettings struct {
     TimeoutSeconds int `json:"timeout_seconds,omitempty"`
 }
 
+
 type Library struct {
     // If cran, specification of a CRAN library to be installed.
     Cran *RCranLibrary `json:"cran,omitempty"`
@@ -580,6 +616,7 @@ type Library struct {
     Whl string `json:"whl,omitempty"`
 }
 
+
 type ListJobsRequest struct {
     // Whether to include task and cluster details in the response.
     ExpandTasks bool ` url:"expand_tasks,omitempty"`
@@ -591,12 +628,14 @@ type ListJobsRequest struct {
     Offset int ` url:"offset,omitempty"`
 }
 
+
 type ListJobsResponse struct {
     
     HasMore bool `json:"has_more,omitempty"`
     // The list of jobs.
     Jobs []Job `json:"jobs,omitempty"`
 }
+
 
 type ListRunsRequest struct {
     // If active_only is `true`, only active runs are included in the results;
@@ -632,6 +671,7 @@ type ListRunsRequest struct {
     StartTimeTo int ` url:"start_time_to,omitempty"`
 }
 
+
 type ListRunsResponse struct {
     // If true, additional runs matching the provided filter are available for
     // listing.
@@ -641,12 +681,14 @@ type ListRunsResponse struct {
 }
 
 
+
 type ListRunsRunType string
 const (
 	ListRunsRunTypeJobRun ListRunsRunType = `JOB_RUN`
 	ListRunsRunTypeWorkflowRun ListRunsRunType = `WORKFLOW_RUN`
 	ListRunsRunTypeSubmitRun ListRunsRunType = `SUBMIT_RUN`
 )
+
 
 type MavenLibrary struct {
     // Gradle-style Maven coordinates. For example: `org.jsoup:jsoup:1.7.2`.
@@ -660,6 +702,7 @@ type MavenLibrary struct {
     // Central Repository and Spark Packages are searched.
     Repo string `json:"repo,omitempty"`
 }
+
 
 type NewCluster struct {
     // If autoscale, the required parameters to automatically scale clusters up
@@ -737,6 +780,7 @@ type NewCluster struct {
     SshPublicKeys []string `json:"ssh_public_keys,omitempty"`
 }
 
+
 type NotebookOutput struct {
     // The value passed to
     // [dbutils.notebook.exit()](..notebooks/notebook-workflowshtml#notebook-workflows-exit).
@@ -747,6 +791,7 @@ type NotebookOutput struct {
     // Whether or not the result was truncated.
     Truncated bool `json:"truncated,omitempty"`
 }
+
 
 type NotebookTask struct {
     // Base parameters to be used for each run of this job. If the run is
@@ -770,6 +815,7 @@ type NotebookTask struct {
 }
 
 // Permission level to grant.
+
 type PermissionLevel string
 const (
 	PermissionLevelCanManage PermissionLevel = `CAN_MANAGE`
@@ -778,10 +824,12 @@ const (
 	PermissionLevelIsOwner PermissionLevel = `IS_OWNER`
 )
 
+
 type PipelineParams struct {
     // If true, triggers a full refresh on the delta live table.
     FullRefresh bool `json:"full_refresh,omitempty"`
 }
+
 
 type PipelineTask struct {
     // If true, a full refresh will be triggered on the delta live table.
@@ -789,6 +837,7 @@ type PipelineTask struct {
     // The full name of the pipeline task to execute.
     PipelineId string `json:"pipeline_id,omitempty"`
 }
+
 
 type PythonPyPiLibrary struct {
     // The name of the PyPI package to install. An optional exact version
@@ -799,6 +848,7 @@ type PythonPyPiLibrary struct {
     // default pip index is used.
     Repo string `json:"repo,omitempty"`
 }
+
 
 type PythonWheelTask struct {
     // Named entry point to use, if it does not exist in the metadata of the
@@ -816,6 +866,7 @@ type PythonWheelTask struct {
     Parameters []string `json:"parameters,omitempty"`
 }
 
+
 type RCranLibrary struct {
     // The name of the CRAN package to install. This field is required.
     Package string `json:"package"`
@@ -823,6 +874,7 @@ type RCranLibrary struct {
     // default CRAN repo is used.
     Repo string `json:"repo,omitempty"`
 }
+
 
 type RepairHistoryItem struct {
     // The end time of the (repaired) run.
@@ -844,11 +896,13 @@ type RepairHistoryItem struct {
 
 // The repair history item type. Indicates whether a run is the original run or
 // a repair run.
+
 type RepairHistoryItemType string
 const (
 	RepairHistoryItemTypeOriginal RepairHistoryItemType = `ORIGINAL`
 	RepairHistoryItemTypeRepair RepairHistoryItemType = `REPAIR`
 )
+
 
 type RepairRunRequest struct {
     // A list of parameters for jobs with Spark JAR tasks, for example
@@ -914,10 +968,12 @@ type RepairRunRequest struct {
     SparkSubmitParams []string `json:"spark_submit_params,omitempty"`
 }
 
+
 type RepairRunResponse struct {
     // The ID of the repair.
     RepairId int64 `json:"repair_id,omitempty"`
 }
+
 
 type ResetJobRequest struct {
     // The canonical identifier of the job to reset. This field is required.
@@ -927,6 +983,7 @@ type ResetJobRequest struct {
     // to active runs. Changes to other fields are applied to future runs only.
     NewSettings *JobSettings `json:"new_settings,omitempty"`
 }
+
 
 type Run struct {
     // The sequence number of this run attempt for a triggered job run. The
@@ -1019,6 +1076,7 @@ type Run struct {
 // over a long period. If a run on a new cluster ends in the `INTERNAL_ERROR`
 // state, the Jobs service terminates the cluster as soon as possible. This
 // state is terminal.
+
 type RunLifeCycleState string
 const (
 	RunLifeCycleStatePending RunLifeCycleState = `PENDING`
@@ -1028,6 +1086,7 @@ const (
 	RunLifeCycleStateSkipped RunLifeCycleState = `SKIPPED`
 	RunLifeCycleStateInternalError RunLifeCycleState = `INTERNAL_ERROR`
 )
+
 
 type RunNowRequest struct {
     // An optional token to guarantee the idempotency of job run requests. If a
@@ -1097,6 +1156,7 @@ type RunNowRequest struct {
     SparkSubmitParams []string `json:"spark_submit_params,omitempty"`
 }
 
+
 type RunNowResponse struct {
     // A unique identifier for this job run. This is set to the same value as
     // `run_id`.
@@ -1104,6 +1164,7 @@ type RunNowResponse struct {
     // The globally unique ID of the newly triggered run.
     RunId int64 `json:"run_id,omitempty"`
 }
+
 
 type RunParameters struct {
     // A list of parameters for jobs with Spark JAR tasks, for example
@@ -1164,6 +1225,7 @@ type RunParameters struct {
 // * `SUCCESS`: The task completed successfully. * `FAILED`: The task completed
 // with an error. * `TIMEDOUT`: The run was stopped after reaching the timeout.
 // * `CANCELED`: The run was canceled at user request.
+
 type RunResultState string
 const (
 	RunResultStateSuccess RunResultState = `SUCCESS`
@@ -1172,7 +1234,8 @@ const (
 	RunResultStateCanceled RunResultState = `CANCELED`
 )
 
-// The result and lifecycle state of the run.type RunState struct {
+// The result and lifecycle state of the run.
+type RunState struct {
     // A description of a run?s current location in the run lifecycle. This
     // field is always available in the response.
     LifeCycleState RunLifeCycleState `json:"life_cycle_state,omitempty"`
@@ -1185,6 +1248,7 @@ const (
     // the run timed out.
     UserCancelledOrTimedout bool `json:"user_cancelled_or_timedout,omitempty"`
 }
+
 
 type RunSubmitTaskSettings struct {
     
@@ -1222,6 +1286,7 @@ type RunSubmitTaskSettings struct {
     // behavior is to have no timeout.
     TimeoutSeconds int `json:"timeout_seconds,omitempty"`
 }
+
 
 type RunTask struct {
     // The sequence number of this run attempt for a triggered job run. The
@@ -1304,6 +1369,7 @@ type RunTask struct {
 // [dbutils.notebook.run](..dev-tools/databricks-utilshtml#dbutils-workflow). *
 // `SUBMIT_RUN` \- Submit run. A run created with [Run
 // now](..dev-tools/api/latest/jobshtml#operation/JobsRunNow).
+
 type RunType string
 const (
 	RunTypeJobRun RunType = `JOB_RUN`
@@ -1313,8 +1379,11 @@ const (
 
 // An arbitrary object where the object key is a configuration propery name and
 // the value is a configuration property value.
+
 // An arbitrary object where the object key is an environment variable name and
 // the value is an environment variable value.
+
+
 type SparkJarTask struct {
     // Deprecated since 04/2016\. Provide a `jar` through the `libraries` field
     // instead. For an example, see
@@ -1331,6 +1400,7 @@ type SparkJarTask struct {
     Parameters []string `json:"parameters,omitempty"`
 }
 
+
 type SparkPythonTask struct {
     // Command line parameters passed to the Python file. Use [Task parameter
     // variables](..jobshtml#parameter-variables) to set parameters containing
@@ -1340,12 +1410,14 @@ type SparkPythonTask struct {
     PythonFile string `json:"python_file"`
 }
 
+
 type SparkSubmitTask struct {
     // Command-line parameters passed to spark submit. Use [Task parameter
     // variables](..jobshtml#parameter-variables) to set parameters containing
     // information about job runs.
     Parameters []string `json:"parameters,omitempty"`
 }
+
 
 type SubmitRunRequest struct {
     // List of permissions to set on the job.
@@ -1372,6 +1444,7 @@ type SubmitRunRequest struct {
     TimeoutSeconds int `json:"timeout_seconds,omitempty"`
 }
 
+
 type SubmitRunResponse struct {
     // The canonical identifier for the newly submitted run.
     RunId int64 `json:"run_id,omitempty"`
@@ -1381,7 +1454,9 @@ type SubmitRunResponse struct {
 // tasks specified in this field must complete successfully before executing
 // this task. The key is `task_key`, and the value is the name assigned to the
 // dependent task. This field is required when a job consists of more than one
-// task.type TaskDependencies []TaskDependenciesItem
+// task.
+type TaskDependencies []TaskDependenciesItem
+
 
 type TaskDependenciesItem struct {
     
@@ -1393,12 +1468,14 @@ type TaskDependenciesItem struct {
 // occurs you triggered a single run on demand through the UI or the API. *
 // `RETRY`: Indicates a run that is triggered as a retry of a previously failed
 // run. This occurs when you request to re-run the job in case of failures.
+
 type TriggerType string
 const (
 	TriggerTypePeriodic TriggerType = `PERIODIC`
 	TriggerTypeOneTime TriggerType = `ONE_TIME`
 	TriggerTypeRetry TriggerType = `RETRY`
 )
+
 
 type UpdateJobRequest struct {
     // Remove top-level fields in the job settings. Removing nested fields is
@@ -1414,6 +1491,7 @@ type UpdateJobRequest struct {
     NewSettings *JobSettings `json:"new_settings,omitempty"`
 }
 
+
 type ViewItem struct {
     // Content of the view.
     Content string `json:"content,omitempty"`
@@ -1426,6 +1504,7 @@ type ViewItem struct {
 }
 
 // * `NOTEBOOK`: Notebook view item. * `DASHBOARD`: Dashboard view item.
+
 type ViewType string
 const (
 	ViewTypeNotebook ViewType = `NOTEBOOK`
@@ -1434,6 +1513,7 @@ const (
 
 // * `CODE`: Code view of the notebook. * `DASHBOARDS`: All dashboard views of
 // the notebook. * `ALL`: All views of the notebook.
+
 type ViewsToExport string
 const (
 	ViewsToExportCode ViewsToExport = `CODE`


### PR DESCRIPTION
See https://github.com/databricks/databricks-sdk-go/issues/44

Just adds some better formatting to the autogenerated code (which was annoying me :P)

tested manually that sdk clusters API client works post these changes

In rare cases we lose out on enum level useful comments like:
```
// Permission level to grant.

type PermissionLevel string
const (
	PermissionLevelCanManage PermissionLevel = `CAN_MANAGE`
	PermissionLevelCanManageRun PermissionLevel = `CAN_MANAGE_RUN`
	PermissionLevelCanView PermissionLevel = `CAN_VIEW`
	PermissionLevelIsOwner PermissionLevel = `IS_OWNER`
)

// Permission to manage the job.
const PermissionLevelCanManage PermissionLevel = `CAN_MANAGE`
// Permission to run and/or manage runs for the job.
const PermissionLevelCanManageRun PermissionLevel = `CAN_MANAGE_RUN`
// Permission to view the settings of the job.
const PermissionLevelCanView PermissionLevel = `CAN_VIEW`
// Perimssion that represents ownership of the job.
const PermissionLevelIsOwner PermissionLevel = `IS_OWNER
```

But it also cleans up a lot of mess and improves readibility. Should we not do this ? I can look if there is a way to get best of both worlds (assert that the comments are different and only then display them). Is this worth spending energy on ?


