### PR TITLE
Disable DBFS integration tests on GCP

### DIFF
--- a/internal/dbfs_test.go
+++ b/internal/dbfs_test.go
@@ -15,9 +15,8 @@ import (
 func TestAccListDbfsIntegration(t *testing.T) {
 	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
 	t.Log(env)
-	// We skip dbfs tests for gcp because dbfs rest api is disabled on gcp
 	if env == "gcp" {
-		return
+		t.Skip("dbfs tests are skipped because dbfs rest api is disabled on gcp")
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Tested dbfs test gets skipped now on gcp-prod manually