### PR TITLE
Fixed quotes in generated comments

### DIFF
--- a/databricks/openapi/code/entity.go
+++ b/databricks/openapi/code/entity.go
@@ -6,6 +6,7 @@ type Field struct {
 	Named
 	Required bool
 	Entity   *Entity
+	Of       *Entity
 	IsJson   bool
 	IsPath   bool
 	IsQuery  bool
@@ -48,11 +49,12 @@ func (e *Entity) IsNumber() bool {
 }
 
 func (e *Entity) IsObject() bool {
-	return len(e.fields) > 0
+	return e.MapValue == nil && len(e.fields) > 0
 }
 
 func (e *Entity) Fields() (fields []Field) {
 	for _, v := range e.fields {
+		v.Of = e
 		fields = append(fields, v)
 	}
 	slices.SortFunc(fields, func(a, b Field) bool {

--- a/databricks/openapi/gen/main.go
+++ b/databricks/openapi/gen/main.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html/template"
+	"text/template"
 	"io"
 	"io/fs"
 	"os"

--- a/service/clusterpolicies/model.go
+++ b/service/clusterpolicies/model.go
@@ -42,7 +42,7 @@ type GetPolicyResponse struct {
 	// Creation time. The timestamp (in millisecond) when this Cluster Policy
 	// was created.
 	CreatedAtTimestamp int64 `json:"created_at_timestamp,omitempty"`
-	// Creator user name. The field won&#39;t be included in the response if the
+	// Creator user name. The field won't be included in the response if the
 	// user has already been deleted.
 	CreatorUserName string `json:"creator_user_name,omitempty"`
 	// Policy definition document expressed in Databricks Cluster Policy
@@ -63,7 +63,7 @@ type Policy struct {
 	// Creation time. The timestamp (in millisecond) when this Cluster Policy
 	// was created.
 	CreatedAtTimestamp int64 `json:"created_at_timestamp,omitempty"`
-	// Creator user name. The field won&#39;t be included in the response if the
+	// Creator user name. The field won't be included in the response if the
 	// user has already been deleted.
 	CreatorUserName string `json:"creator_user_name,omitempty"`
 	// Policy definition document expressed in Databricks Cluster Policy

--- a/service/clusters/api.go
+++ b/service/clusters/api.go
@@ -37,14 +37,14 @@ func (a *ClustersAPI) ChangeOwner(ctx context.Context, request ChangeClusterOwne
 // (account limits, spot price, ...) or transient network issues. If Databricks
 // acquires at least 85% of the requested on-demand nodes, cluster creation will
 // succeed. Otherwise the cluster will terminate with an informative error
-// message. An example request: .. code:: { &#34;cluster_name&#34;: &#34;my-cluster&#34;,
-// &#34;spark_version&#34;: &#34;2.0.x-scala2.10&#34;, &#34;node_type_id&#34;: &#34;r3.xlarge&#34;,
-// &#34;spark_conf&#34;: { &#34;spark.speculation&#34;: true }, &#34;aws_attributes&#34;: {
-// &#34;availability&#34;: &#34;SPOT&#34;, &#34;zone_id&#34;: &#34;us-west-2a&#34; }, &#34;num_workers&#34;: 25 } See
+// message. An example request: .. code:: { "cluster_name": "my-cluster",
+// "spark_version": "2.0.x-scala2.10", "node_type_id": "r3.xlarge",
+// "spark_conf": { "spark.speculation": true }, "aws_attributes": {
+// "availability": "SPOT", "zone_id": "us-west-2a" }, "num_workers": 25 } See
 // below as an example for an autoscaling cluster. Note that this cluster will
-// start with `2` nodes, the minimum. .. code:: { &#34;cluster_name&#34;:
-// &#34;autoscaling-cluster&#34;, &#34;spark_version&#34;: &#34;2.0.x-scala2.10&#34;, &#34;node_type_id&#34;:
-// &#34;r3.xlarge&#34;, &#34;autoscale&#34; : { &#34;min_workers&#34;: 2, &#34;max_workers&#34;: 50 } }
+// start with `2` nodes, the minimum. .. code:: { "cluster_name":
+// "autoscaling-cluster", "spark_version": "2.0.x-scala2.10", "node_type_id":
+// "r3.xlarge", "autoscale" : { "min_workers": 2, "max_workers": 50 } }
 func (a *ClustersAPI) Create(ctx context.Context, request CreateCluster) (*CreateClusterResponse, error) {
 	var createClusterResponse CreateClusterResponse
 	path := "/api/2.0/clusters/create"
@@ -87,7 +87,7 @@ func (a *ClustersAPI) CreateAndWait(ctx context.Context, request CreateCluster, 
 // asynchronously. Once the termination has completed, the cluster will be in a
 // “TERMINATED“ state. If the cluster is already in a “TERMINATING“ or
 // “TERMINATED“ state, nothing will happen. An example request: .. code:: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+// "cluster_id": "1202-211320-brick1" }
 func (a *ClustersAPI) Delete(ctx context.Context, request DeleteCluster) error {
 	path := "/api/2.0/clusters/delete"
 	err := a.client.Post(ctx, path, request, nil)
@@ -129,7 +129,7 @@ func (a *ClustersAPI) DeleteAndWait(ctx context.Context, request DeleteCluster, 
 // asynchronously. Once the termination has completed, the cluster will be in a
 // “TERMINATED“ state. If the cluster is already in a “TERMINATING“ or
 // “TERMINATED“ state, nothing will happen. An example request: .. code:: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+// "cluster_id": "1202-211320-brick1" }
 func (a *ClustersAPI) DeleteByClusterId(ctx context.Context, clusterId string) error {
 	return a.Delete(ctx, DeleteCluster{
 		ClusterId: clusterId,
@@ -150,9 +150,9 @@ func (a *ClustersAPI) DeleteByClusterIdAndWait(ctx context.Context, clusterId st
 // it is started using the “clusters/start“ API, the new attributes will take
 // effect. An attempt to edit a cluster in any other state will be rejected with
 // an “INVALID_STATE“ error code. Clusters created by the Databricks Jobs
-// service cannot be edited. An example request: .. code:: { &#34;cluster_id&#34;:
-// &#34;1202-211320-brick1&#34;, &#34;num_workers&#34;: 10, &#34;spark_version&#34;: &#34;3.3.x-scala2.11&#34;,
-// &#34;node_type_id&#34;: &#34;i3.2xlarge&#34; }
+// service cannot be edited. An example request: .. code:: { "cluster_id":
+// "1202-211320-brick1", "num_workers": 10, "spark_version": "3.3.x-scala2.11",
+// "node_type_id": "i3.2xlarge" }
 func (a *ClustersAPI) Edit(ctx context.Context, request EditCluster) error {
 	path := "/api/2.0/clusters/edit"
 	err := a.client.Post(ctx, path, request, nil)
@@ -194,15 +194,15 @@ func (a *ClustersAPI) EditAndWait(ctx context.Context, request EditCluster, time
 // paginated. If there are more events to read, the response includes all the
 // parameters necessary to request the next page of events. An example request:
 // “/clusters/events?cluster_id=1202-211320-brick1“ An example response: {
-// &#34;events&#34;: [ { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;, &#34;timestamp&#34;: 1509572145487,
-// &#34;event_type&#34;: &#34;RESTARTING&#34;, &#34;event_details&#34;: { &#34;username&#34;: &#34;admin&#34; } }, ... {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;, &#34;timestamp&#34;: 1509505807923, &#34;event_type&#34;:
-// &#34;TERMINATING&#34;, &#34;event_details&#34;: { &#34;termination_reason&#34;: { &#34;code&#34;:
-// &#34;USER_REQUEST&#34;, &#34;parameters&#34;: [ &#34;username&#34;: &#34;admin&#34; ] } } ], &#34;next_page&#34;: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;, &#34;end_time&#34;: 1509572145487, &#34;order&#34;:
-// &#34;DESC&#34;, &#34;offset&#34;: 50 }, &#34;total_count&#34;: 303 } Example request to retrieve the
+// "events": [ { "cluster_id": "1202-211320-brick1", "timestamp": 1509572145487,
+// "event_type": "RESTARTING", "event_details": { "username": "admin" } }, ... {
+// "cluster_id": "1202-211320-brick1", "timestamp": 1509505807923, "event_type":
+// "TERMINATING", "event_details": { "termination_reason": { "code":
+// "USER_REQUEST", "parameters": [ "username": "admin" ] } } ], "next_page": {
+// "cluster_id": "1202-211320-brick1", "end_time": 1509572145487, "order":
+// "DESC", "offset": 50 }, "total_count": 303 } Example request to retrieve the
 // next page of events
-// “/clusters/events?cluster_id=1202-211320-brick1&amp;end_time=1509572145487&amp;order=DESC&amp;offset=50“
+// “/clusters/events?cluster_id=1202-211320-brick1&end_time=1509572145487&order=DESC&offset=50“
 func (a *ClustersAPI) Events(ctx context.Context, request GetEvents) (*GetEventsResponse, error) {
 	var getEventsResponse GetEventsResponse
 	path := "/api/2.0/clusters/events"
@@ -317,7 +317,7 @@ func (a *ClustersAPI) ListZones(ctx context.Context) (*ListAvailableZonesRespons
 // are asynchronously removed. In addition, users will no longer see permanently
 // deleted clusters in the cluster list, and API users can no longer perform any
 // action on permanently deleted clusters. An example request: .. code:: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+// "cluster_id": "1202-211320-brick1" }
 func (a *ClustersAPI) PermanentDelete(ctx context.Context, request PermanentDeleteCluster) error {
 	path := "/api/2.0/clusters/permanent-delete"
 	err := a.client.Post(ctx, path, request, nil)
@@ -328,7 +328,7 @@ func (a *ClustersAPI) PermanentDelete(ctx context.Context, request PermanentDele
 // are asynchronously removed. In addition, users will no longer see permanently
 // deleted clusters in the cluster list, and API users can no longer perform any
 // action on permanently deleted clusters. An example request: .. code:: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+// "cluster_id": "1202-211320-brick1" }
 func (a *ClustersAPI) PermanentDeleteByClusterId(ctx context.Context, clusterId string) error {
 	return a.PermanentDelete(ctx, PermanentDeleteCluster{
 		ClusterId: clusterId,
@@ -357,7 +357,7 @@ func (a *ClustersAPI) PinByClusterId(ctx context.Context, clusterId string) erro
 
 // Resizes a cluster to have a desired number of workers. This will fail unless
 // the cluster is in a “RUNNING“ state. An example request: .. code:: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;, &#34;num_workers&#34;: 30 }
+// "cluster_id": "1202-211320-brick1", "num_workers": 30 }
 func (a *ClustersAPI) Resize(ctx context.Context, request ResizeCluster) error {
 	path := "/api/2.0/clusters/resize"
 	err := a.client.Post(ctx, path, request, nil)
@@ -397,7 +397,7 @@ func (a *ClustersAPI) ResizeAndWait(ctx context.Context, request ResizeCluster, 
 
 // Restarts a Spark cluster given its id. If the cluster is not currently in a
 // “RUNNING“ state, nothing will happen. An example request: .. code:: {
-// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+// "cluster_id": "1202-211320-brick1" }
 func (a *ClustersAPI) Restart(ctx context.Context, request RestartCluster) error {
 	path := "/api/2.0/clusters/restart"
 	err := a.client.Post(ctx, path, request, nil)
@@ -450,8 +450,8 @@ func (a *ClustersAPI) SparkVersions(ctx context.Context) (*GetSparkVersionsRespo
 // the previous cluster was an autoscaling cluster, the current cluster starts
 // with the minimum number of nodes. - If the cluster is not currently in a
 // “TERMINATED“ state, nothing will happen. - Clusters launched to run a job
-// cannot be started. An example request: .. code:: { &#34;cluster_id&#34;:
-// &#34;1202-211320-brick1&#34; }
+// cannot be started. An example request: .. code:: { "cluster_id":
+// "1202-211320-brick1" }
 func (a *ClustersAPI) Start(ctx context.Context, request StartCluster) error {
 	path := "/api/2.0/clusters/start"
 	err := a.client.Post(ctx, path, request, nil)
@@ -495,8 +495,8 @@ func (a *ClustersAPI) StartAndWait(ctx context.Context, request StartCluster, ti
 // the previous cluster was an autoscaling cluster, the current cluster starts
 // with the minimum number of nodes. - If the cluster is not currently in a
 // “TERMINATED“ state, nothing will happen. - Clusters launched to run a job
-// cannot be started. An example request: .. code:: { &#34;cluster_id&#34;:
-// &#34;1202-211320-brick1&#34; }
+// cannot be started. An example request: .. code:: { "cluster_id":
+// "1202-211320-brick1" }
 func (a *ClustersAPI) StartByClusterId(ctx context.Context, clusterId string) error {
 	return a.Start(ctx, StartCluster{
 		ClusterId: clusterId,

--- a/service/clusters/interface.go
+++ b/service/clusters/interface.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// &lt;needs content added&gt;
+// <needs content added>
 //
 // This is the high-level interface, that contains generated methods.
 //
@@ -27,14 +27,14 @@ type ClustersService interface {
 	// issues. If Databricks acquires at least 85% of the requested on-demand
 	// nodes, cluster creation will succeed. Otherwise the cluster will
 	// terminate with an informative error message. An example request: ..
-	// code:: { &#34;cluster_name&#34;: &#34;my-cluster&#34;, &#34;spark_version&#34;:
-	// &#34;2.0.x-scala2.10&#34;, &#34;node_type_id&#34;: &#34;r3.xlarge&#34;, &#34;spark_conf&#34;: {
-	// &#34;spark.speculation&#34;: true }, &#34;aws_attributes&#34;: { &#34;availability&#34;: &#34;SPOT&#34;,
-	// &#34;zone_id&#34;: &#34;us-west-2a&#34; }, &#34;num_workers&#34;: 25 } See below as an example
+	// code:: { "cluster_name": "my-cluster", "spark_version":
+	// "2.0.x-scala2.10", "node_type_id": "r3.xlarge", "spark_conf": {
+	// "spark.speculation": true }, "aws_attributes": { "availability": "SPOT",
+	// "zone_id": "us-west-2a" }, "num_workers": 25 } See below as an example
 	// for an autoscaling cluster. Note that this cluster will start with `2`
-	// nodes, the minimum. .. code:: { &#34;cluster_name&#34;: &#34;autoscaling-cluster&#34;,
-	// &#34;spark_version&#34;: &#34;2.0.x-scala2.10&#34;, &#34;node_type_id&#34;: &#34;r3.xlarge&#34;,
-	// &#34;autoscale&#34; : { &#34;min_workers&#34;: 2, &#34;max_workers&#34;: 50 } }
+	// nodes, the minimum. .. code:: { "cluster_name": "autoscaling-cluster",
+	// "spark_version": "2.0.x-scala2.10", "node_type_id": "r3.xlarge",
+	// "autoscale" : { "min_workers": 2, "max_workers": 50 } }
 	Create(ctx context.Context, createCluster CreateCluster) (*CreateClusterResponse, error)
 	// Create and wait to reach RUNNING state
 	CreateAndWait(ctx context.Context, request CreateCluster, timeout ...time.Duration) (*ClusterInfo, error)
@@ -42,7 +42,7 @@ type ClustersService interface {
 	// asynchronously. Once the termination has completed, the cluster will be
 	// in a ``TERMINATED`` state. If the cluster is already in a ``TERMINATING``
 	// or ``TERMINATED`` state, nothing will happen. An example request: ..
-	// code:: { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+	// code:: { "cluster_id": "1202-211320-brick1" }
 	Delete(ctx context.Context, deleteCluster DeleteCluster) error
 	// Delete and wait to reach TERMINATED state
 	DeleteAndWait(ctx context.Context, request DeleteCluster, timeout ...time.Duration) (*ClusterInfo, error)
@@ -57,8 +57,8 @@ type ClustersService interface {
 	// attributes will take effect. An attempt to edit a cluster in any other
 	// state will be rejected with an ``INVALID_STATE`` error code. Clusters
 	// created by the Databricks Jobs service cannot be edited. An example
-	// request: .. code:: { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;, &#34;num_workers&#34;:
-	// 10, &#34;spark_version&#34;: &#34;3.3.x-scala2.11&#34;, &#34;node_type_id&#34;: &#34;i3.2xlarge&#34; }
+	// request: .. code:: { "cluster_id": "1202-211320-brick1", "num_workers":
+	// 10, "spark_version": "3.3.x-scala2.11", "node_type_id": "i3.2xlarge" }
 	Edit(ctx context.Context, editCluster EditCluster) error
 	// Edit and wait to reach RUNNING state
 	EditAndWait(ctx context.Context, request EditCluster, timeout ...time.Duration) (*ClusterInfo, error)
@@ -66,16 +66,16 @@ type ClustersService interface {
 	// paginated. If there are more events to read, the response includes all
 	// the parameters necessary to request the next page of events. An example
 	// request: ``/clusters/events?cluster_id=1202-211320-brick1`` An example
-	// response: { &#34;events&#34;: [ { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;,
-	// &#34;timestamp&#34;: 1509572145487, &#34;event_type&#34;: &#34;RESTARTING&#34;, &#34;event_details&#34;:
-	// { &#34;username&#34;: &#34;admin&#34; } }, ... { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;,
-	// &#34;timestamp&#34;: 1509505807923, &#34;event_type&#34;: &#34;TERMINATING&#34;, &#34;event_details&#34;:
-	// { &#34;termination_reason&#34;: { &#34;code&#34;: &#34;USER_REQUEST&#34;, &#34;parameters&#34;: [
-	// &#34;username&#34;: &#34;admin&#34; ] } } ], &#34;next_page&#34;: { &#34;cluster_id&#34;:
-	// &#34;1202-211320-brick1&#34;, &#34;end_time&#34;: 1509572145487, &#34;order&#34;: &#34;DESC&#34;,
-	// &#34;offset&#34;: 50 }, &#34;total_count&#34;: 303 } Example request to retrieve the next
+	// response: { "events": [ { "cluster_id": "1202-211320-brick1",
+	// "timestamp": 1509572145487, "event_type": "RESTARTING", "event_details":
+	// { "username": "admin" } }, ... { "cluster_id": "1202-211320-brick1",
+	// "timestamp": 1509505807923, "event_type": "TERMINATING", "event_details":
+	// { "termination_reason": { "code": "USER_REQUEST", "parameters": [
+	// "username": "admin" ] } } ], "next_page": { "cluster_id":
+	// "1202-211320-brick1", "end_time": 1509572145487, "order": "DESC",
+	// "offset": 50 }, "total_count": 303 } Example request to retrieve the next
 	// page of events
-	// ``/clusters/events?cluster_id=1202-211320-brick1&amp;end_time=1509572145487&amp;order=DESC&amp;offset=50``
+	// ``/clusters/events?cluster_id=1202-211320-brick1&end_time=1509572145487&order=DESC&offset=50``
 	Events(ctx context.Context, getEvents GetEvents) (*GetEventsResponse, error)
 
 	// Retrieves the information for a cluster given its identifier. Clusters
@@ -110,7 +110,7 @@ type ClustersService interface {
 	// resources are asynchronously removed. In addition, users will no longer
 	// see permanently deleted clusters in the cluster list, and API users can
 	// no longer perform any action on permanently deleted clusters. An example
-	// request: .. code:: { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+	// request: .. code:: { "cluster_id": "1202-211320-brick1" }
 	PermanentDelete(ctx context.Context, permanentDeleteCluster PermanentDeleteCluster) error
 
 	PermanentDeleteByClusterId(ctx context.Context, clusterId string) error
@@ -123,13 +123,13 @@ type ClustersService interface {
 	PinByClusterId(ctx context.Context, clusterId string) error
 	// Resizes a cluster to have a desired number of workers. This will fail
 	// unless the cluster is in a ``RUNNING`` state. An example request: ..
-	// code:: { &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34;, &#34;num_workers&#34;: 30 }
+	// code:: { "cluster_id": "1202-211320-brick1", "num_workers": 30 }
 	Resize(ctx context.Context, resizeCluster ResizeCluster) error
 	// Resize and wait to reach RUNNING state
 	ResizeAndWait(ctx context.Context, request ResizeCluster, timeout ...time.Duration) (*ClusterInfo, error)
 	// Restarts a Spark cluster given its id. If the cluster is not currently in
 	// a ``RUNNING`` state, nothing will happen. An example request: .. code:: {
-	// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+	// "cluster_id": "1202-211320-brick1" }
 	Restart(ctx context.Context, restartCluster RestartCluster) error
 	// Restart and wait to reach RUNNING state
 	RestartAndWait(ctx context.Context, request RestartCluster, timeout ...time.Duration) (*ClusterInfo, error)
@@ -144,7 +144,7 @@ type ClustersService interface {
 	// starts with the minimum number of nodes. - If the cluster is not
 	// currently in a ``TERMINATED`` state, nothing will happen. - Clusters
 	// launched to run a job cannot be started. An example request: .. code:: {
-	// &#34;cluster_id&#34;: &#34;1202-211320-brick1&#34; }
+	// "cluster_id": "1202-211320-brick1" }
 	Start(ctx context.Context, startCluster StartCluster) error
 	// Start and wait to reach RUNNING state
 	StartAndWait(ctx context.Context, request StartCluster, timeout ...time.Duration) (*ClusterInfo, error)

--- a/service/clusters/model.go
+++ b/service/clusters/model.go
@@ -34,13 +34,13 @@ type AwsAttributes struct {
 	// EBS volumes are specified, then the Spark configuration
 	// ``spark.local.dir`` will be overridden.
 	EbsVolumeCount int `json:"ebs_volume_count,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	EbsVolumeIops int `json:"ebs_volume_iops,omitempty"`
 	// The size of each EBS volume (in GiB) launched for each instance. For
 	// general purpose SSD, this value must be within the range 100 - 4096. For
 	// throughput optimized HDD, this value must be within the range 500 - 4096.
 	EbsVolumeSize int `json:"ebs_volume_size,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	EbsVolumeThroughput int `json:"ebs_volume_throughput,omitempty"`
 	// The type of EBS volumes that will be launched with this cluster.
 	EbsVolumeType AwsAttributesEbsVolumeType `json:"ebs_volume_type,omitempty"`
@@ -62,7 +62,7 @@ type AwsAttributes struct {
 	// ommitted, we will pull in the default from the conf if it exists.
 	InstanceProfileArn string `json:"instance_profile_arn,omitempty"`
 	// The bid price for AWS spot instances, as a percentage of the
-	// corresponding instance type&#39;s on-demand price. For example, if this field
+	// corresponding instance type's on-demand price. For example, if this field
 	// is set to 50, and the cluster needs a new ``r3.xlarge`` spot instance,
 	// then the bid price is half of the price of on-demand ``r3.xlarge``
 	// instances. Similarly, if this field is set to 200, the bid price is twice
@@ -75,12 +75,12 @@ type AwsAttributes struct {
 	// CommonConf.maxSpotBidPricePercent.
 	SpotBidPricePercent int `json:"spot_bid_price_percent,omitempty"`
 	// Identifier for the availability zone/datacenter in which the cluster
-	// resides. This string will be of a form like &#34;us-west-2a&#34;. The provided
+	// resides. This string will be of a form like "us-west-2a". The provided
 	// availability zone must be in the same region as the Databricks
-	// deployment. For example, &#34;us-west-2a&#34; is not a valid zone id if the
-	// Databricks deployment resides in the &#34;us-east-1&#34; region. This is an
+	// deployment. For example, "us-west-2a" is not a valid zone id if the
+	// Databricks deployment resides in the "us-east-1" region. This is an
 	// optional field at cluster creation, and if not specified, a default zone
-	// will be used. If the zone specified is &#34;auto&#34;, will try to place cluster
+	// will be used. If the zone specified is "auto", will try to place cluster
 	// in a zone with high availability, and will retry placement in a different
 	// AZ if there is not enough capacity. See [[AutoAZHelper.scala]] for more
 	// details. The list of available zones as well as the default value can be
@@ -128,7 +128,7 @@ type AzureAttributes struct {
 	// the bid cannot be higher than the on-demand price of the instance. If not
 	// specified, the default value is -1, which specifies that the instance
 	// cannot be evicted on the basis of price, and only on the basis of
-	// availability. Further, the value should &gt; 0 or -1.
+	// availability. Further, the value should > 0 or -1.
 	SpotBidMaxPrice float64 `json:"spot_bid_max_price,omitempty"`
 }
 
@@ -144,7 +144,7 @@ const AzureAttributesAvailabilitySpotAzure AzureAttributesAvailability = `SPOT_A
 const AzureAttributesAvailabilitySpotWithFallbackAzure AzureAttributesAvailability = `SPOT_WITH_FALLBACK_AZURE`
 
 type ChangeClusterOwner struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	ClusterId string `json:"cluster_id"`
 	// New owner of the cluster_id after this RPC.
 	OwnerUsername string `json:"owner_username,omitempty"`
@@ -187,7 +187,7 @@ type ClusterAttributes struct {
 	// destination of driver logs is ``$destination/$clusterId/driver``, while
 	// the destination of executor logs is ``$destination/$clusterId/executor``.
 	ClusterLogConf *ClusterLogConf `json:"cluster_log_conf,omitempty"`
-	// Cluster name requested by the user. This doesn&#39;t have to be unique. If
+	// Cluster name requested by the user. This doesn't have to be unique. If
 	// not specified at creation, the cluster name will be an empty string.
 	ClusterName string `json:"cluster_name,omitempty"`
 	// Determines whether the cluster was created by a user through the UI,
@@ -198,7 +198,7 @@ type ClusterAttributes struct {
 	// resources (e.g., AWS instances and EBS volumes) with these tags in
 	// addition to ``default_tags``. Notes: - Currently, Databricks allows at
 	// most 45 custom tags - Clusters can only reuse cloud resources if the
-	// resources&#39; tags are a subset of the cluster tags
+	// resources' tags are a subset of the cluster tags
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// The optional ID of the instance pool for the driver of the cluster
 	// belongs. The pool cluster uses the instance pool with id
@@ -215,14 +215,14 @@ type ClusterAttributes struct {
 	// different from the spark_version (index 2). The spark_version is the raw
 	// string provided by the user through API or UI, which could map to a
 	// different effective_spark_version running in the dataplane, depending on
-	// the cluster&#39;s instance type or the runtimeEngine parameter.
+	// the cluster's instance type or the runtimeEngine parameter.
 	EffectiveSparkVersion string `json:"effective_spark_version,omitempty"`
 	// Autoscaling Local Storage: when enabled, this cluster will dynamically
 	// acquire additional disk space when its Spark workers are running low on
 	// disk space. This feature requires specific AWS permissions to function
 	// correctly - refer to the User Guide for more details.
 	EnableElasticDisk bool `json:"enable_elastic_disk,omitempty"`
-	// Whether to enable LUKS on cluster VMs&#39; local disks
+	// Whether to enable LUKS on cluster VMs' local disks
 	EnableLocalDiskEncryption bool `json:"enable_local_disk_encryption,omitempty"`
 	// Attributes related to clusters running on Google Cloud Platform. If not
 	// specified at cluster creation, a set of default values will be used.
@@ -247,23 +247,23 @@ type ClusterAttributes struct {
 	// configuration key-value pairs. Users can also pass in a string of extra
 	// JVM options to the driver and the executors via
 	// ``spark.driver.extraJavaOptions`` and ``spark.executor.extraJavaOptions``
-	// respectively. Example Spark confs: ``{&#34;spark.speculation&#34;: true,
-	// &#34;spark.streaming.ui.retainedBatches&#34;: 5}`` or
-	// ``{&#34;spark.driver.extraJavaOptions&#34;: &#34;-verbose:gc -XX:&#43;PrintGCDetails&#34;}``
+	// respectively. Example Spark confs: ``{"spark.speculation": true,
+	// "spark.streaming.ui.retainedBatches": 5}`` or
+	// ``{"spark.driver.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails"}``
 	SparkConf map[string]string `json:"spark_conf,omitempty"`
 	// An object containing a set of optional, user-specified environment
 	// variable key-value pairs. Please note that key-value pair of the form
-	// (X,Y) will be exported as is (i.e., ``export X=&#39;Y&#39;``) while launching the
+	// (X,Y) will be exported as is (i.e., ``export X='Y'``) while launching the
 	// driver and workers. In order to specify an additional set of
 	// ``SPARK_DAEMON_JAVA_OPTS``, we recommend appending them to
 	// ``$SPARK_DAEMON_JAVA_OPTS`` as shown in the example below. This ensures
 	// that all default databricks managed environmental variables are included
-	// as well. Example Spark environment variables: ``{&#34;SPARK_WORKER_MEMORY&#34;:
-	// &#34;28000m&#34;, &#34;SPARK_LOCAL_DIRS&#34;: &#34;/local_disk0&#34;}`` or
-	// ``{&#34;SPARK_DAEMON_JAVA_OPTS&#34;: &#34;$SPARK_DAEMON_JAVA_OPTS
-	// -Dspark.shuffle.service.enabled=true&#34;}``
+	// as well. Example Spark environment variables: ``{"SPARK_WORKER_MEMORY":
+	// "28000m", "SPARK_LOCAL_DIRS": "/local_disk0"}`` or
+	// ``{"SPARK_DAEMON_JAVA_OPTS": "$SPARK_DAEMON_JAVA_OPTS
+	// -Dspark.shuffle.service.enabled=true"}``
 	SparkEnvVars map[string]string `json:"spark_env_vars,omitempty"`
-	// The Spark version of the cluster, e.g. &#34;3.3.x-scala2.11&#34;. A list of
+	// The Spark version of the cluster, e.g. "3.3.x-scala2.11". A list of
 	// available Spark versions can be retrieved by using the
 	// :ref:`clusterClusterServicelistSparkVersions` API call. This is the Spark
 	// version provided from the user input (API/UI) and may be different from
@@ -308,21 +308,21 @@ const ClusterAttributesRuntimeEnginePhoton ClusterAttributesRuntimeEngine = `PHO
 const ClusterAttributesRuntimeEngineStandard ClusterAttributesRuntimeEngine = `STANDARD`
 
 type ClusterEvent struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	ClusterId string `json:"cluster_id"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	DataPlaneEventDetails *DataPlaneEventDetails `json:"data_plane_event_details,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	Details *EventDetails `json:"details,omitempty"`
 	// The timestamp when the event occurred, stored as the number of
 	// milliseconds since the Unix epoch. If not provided, this will be assigned
 	// by the Timeline service.
 	Timestamp int64 `json:"timestamp,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	Type ClusterEventType `json:"type,omitempty"`
 }
 
-// &lt;needs content added&gt;
+// <needs content added>
 type ClusterEventType string
 
 const ClusterEventTypeAutoscalingStatsReport ClusterEventType = `AUTOSCALING_STATS_REPORT`
@@ -410,26 +410,26 @@ type ClusterInfo struct {
 	ClusterLogStatus *LogSyncStatus `json:"cluster_log_status,omitempty"`
 	// Total amount of cluster memory, in megabytes
 	ClusterMemoryMb int64 `json:"cluster_memory_mb,omitempty"`
-	// Cluster name requested by the user. This doesn&#39;t have to be unique. If
+	// Cluster name requested by the user. This doesn't have to be unique. If
 	// not specified at creation, the cluster name will be an empty string.
 	ClusterName string `json:"cluster_name,omitempty"`
 	// Determines whether the cluster was created by a user through the UI,
 	// created by the Databricks Jobs Scheduler, or through an API request. This
 	// is the same as cluster_creator, but read only.
 	ClusterSource ClusterInfoClusterSource `json:"cluster_source,omitempty"`
-	// Creator user name. The field won&#39;t be included in the response if the
+	// Creator user name. The field won't be included in the response if the
 	// user has already been deleted.
 	CreatorUserName string `json:"creator_user_name,omitempty"`
 	// Additional tags for cluster resources. Databricks will tag all cluster
 	// resources (e.g., AWS instances and EBS volumes) with these tags in
 	// addition to ``default_tags``. Notes: - Currently, Databricks allows at
 	// most 45 custom tags - Clusters can only reuse cloud resources if the
-	// resources&#39; tags are a subset of the cluster tags
+	// resources' tags are a subset of the cluster tags
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// Tags that are added by Databricks regardless of any ``custom_tags``,
-	// including: - Vendor: Databricks - Creator: &lt;username_of_creator&gt; -
-	// ClusterName: &lt;name_of_cluster&gt; - ClusterId: &lt;id_of_cluster&gt; - Name:
-	// &lt;Databricks internal use&gt;
+	// including: - Vendor: Databricks - Creator: <username_of_creator> -
+	// ClusterName: <name_of_cluster> - ClusterId: <id_of_cluster> - Name:
+	// <Databricks internal use>
 	DefaultTags map[string]string `json:"default_tags,omitempty"`
 	// Node on which the Spark driver resides. The driver node contains the
 	// Spark master and the Databricks application that manages the per-notebook
@@ -450,14 +450,14 @@ type ClusterInfo struct {
 	// different from the spark_version (index 2). The spark_version is the raw
 	// string provided by the user through API or UI, which could map to a
 	// different effective_spark_version running in the dataplane, depending on
-	// the cluster&#39;s instance type or the runtimeEngine parameter.
+	// the cluster's instance type or the runtimeEngine parameter.
 	EffectiveSparkVersion string `json:"effective_spark_version,omitempty"`
 	// Autoscaling Local Storage: when enabled, this cluster will dynamically
 	// acquire additional disk space when its Spark workers are running low on
 	// disk space. This feature requires specific AWS permissions to function
 	// correctly - refer to the User Guide for more details.
 	EnableElasticDisk bool `json:"enable_elastic_disk,omitempty"`
-	// Whether to enable LUKS on cluster VMs&#39; local disks
+	// Whether to enable LUKS on cluster VMs' local disks
 	EnableLocalDiskEncryption bool `json:"enable_local_disk_encryption,omitempty"`
 	// Nodes on which the Spark executors reside.
 	Executors []SparkNode `json:"executors,omitempty"`
@@ -485,7 +485,7 @@ type ClusterInfo struct {
 	NodeTypeId string `json:"node_type_id,omitempty"`
 	// Number of worker nodes that this cluster should have. A cluster has one
 	// Spark Driver and ``num_workers`` Executors for a total of ``num_workers``
-	// &#43; 1 Spark nodes. Note: When reading the properties of a cluster, this
+	// + 1 Spark nodes. Note: When reading the properties of a cluster, this
 	// field reflects the desired number of workers rather than the actual
 	// current number of workers. For instance, if a cluster is resized from 5
 	// to 10 workers, this field will immediately be updated to reflect the
@@ -501,9 +501,9 @@ type ClusterInfo struct {
 	// configuration key-value pairs. Users can also pass in a string of extra
 	// JVM options to the driver and the executors via
 	// ``spark.driver.extraJavaOptions`` and ``spark.executor.extraJavaOptions``
-	// respectively. Example Spark confs: ``{&#34;spark.speculation&#34;: true,
-	// &#34;spark.streaming.ui.retainedBatches&#34;: 5}`` or
-	// ``{&#34;spark.driver.extraJavaOptions&#34;: &#34;-verbose:gc -XX:&#43;PrintGCDetails&#34;}``
+	// respectively. Example Spark confs: ``{"spark.speculation": true,
+	// "spark.streaming.ui.retainedBatches": 5}`` or
+	// ``{"spark.driver.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails"}``
 	SparkConf map[string]string `json:"spark_conf,omitempty"`
 	// A canonical SparkContext identifier. This value *does* change when the
 	// Spark driver restarts. The pair `(cluster_id, spark_context_id)` is a
@@ -511,17 +511,17 @@ type ClusterInfo struct {
 	SparkContextId int64 `json:"spark_context_id,omitempty"`
 	// An object containing a set of optional, user-specified environment
 	// variable key-value pairs. Please note that key-value pair of the form
-	// (X,Y) will be exported as is (i.e., ``export X=&#39;Y&#39;``) while launching the
+	// (X,Y) will be exported as is (i.e., ``export X='Y'``) while launching the
 	// driver and workers. In order to specify an additional set of
 	// ``SPARK_DAEMON_JAVA_OPTS``, we recommend appending them to
 	// ``$SPARK_DAEMON_JAVA_OPTS`` as shown in the example below. This ensures
 	// that all default databricks managed environmental variables are included
-	// as well. Example Spark environment variables: ``{&#34;SPARK_WORKER_MEMORY&#34;:
-	// &#34;28000m&#34;, &#34;SPARK_LOCAL_DIRS&#34;: &#34;/local_disk0&#34;}`` or
-	// ``{&#34;SPARK_DAEMON_JAVA_OPTS&#34;: &#34;$SPARK_DAEMON_JAVA_OPTS
-	// -Dspark.shuffle.service.enabled=true&#34;}``
+	// as well. Example Spark environment variables: ``{"SPARK_WORKER_MEMORY":
+	// "28000m", "SPARK_LOCAL_DIRS": "/local_disk0"}`` or
+	// ``{"SPARK_DAEMON_JAVA_OPTS": "$SPARK_DAEMON_JAVA_OPTS
+	// -Dspark.shuffle.service.enabled=true"}``
 	SparkEnvVars map[string]string `json:"spark_env_vars,omitempty"`
-	// The Spark version of the cluster, e.g. &#34;3.3.x-scala2.11&#34;. A list of
+	// The Spark version of the cluster, e.g. "3.3.x-scala2.11". A list of
 	// available Spark versions can be retrieved by using the
 	// :ref:`clusterClusterServicelistSparkVersions` API call. This is the Spark
 	// version provided from the user input (API/UI) and may be different from
@@ -599,12 +599,12 @@ const ClusterInfoStateTerminating ClusterInfoState = `TERMINATING`
 const ClusterInfoStateUnknown ClusterInfoState = `UNKNOWN`
 
 type ClusterLogConf struct {
-	// destination needs to be provided. e.g. ``{ &#34;dbfs&#34; : { &#34;destination&#34; :
-	// &#34;dbfs:/home/cluster_log&#34; } }``
+	// destination needs to be provided. e.g. ``{ "dbfs" : { "destination" :
+	// "dbfs:/home/cluster_log" } }``
 	Dbfs *DbfsStorageInfo `json:"dbfs,omitempty"`
 	// destination and either region or endpoint should also be provided. e.g.
-	// ``{ &#34;s3&#34;: { &#34;destination&#34; : &#34;s3://cluster_log_bucket/prefix&#34;, &#34;region&#34; :
-	// &#34;us-west-2&#34; } }`` Cluster iam role is used to access s3, please make sure
+	// ``{ "s3": { "destination" : "s3://cluster_log_bucket/prefix", "region" :
+	// "us-west-2" } }`` Cluster iam role is used to access s3, please make sure
 	// the cluster iam role in ``instance_profile_arn`` has permission to write
 	// data to the s3 destination.
 	S3 *S3StorageInfo `json:"s3,omitempty"`
@@ -617,7 +617,7 @@ type ClusterSize struct {
 	Autoscale *AutoScale `json:"autoscale,omitempty"`
 	// Number of worker nodes that this cluster should have. A cluster has one
 	// Spark Driver and ``num_workers`` Executors for a total of ``num_workers``
-	// &#43; 1 Spark nodes. Note: When reading the properties of a cluster, this
+	// + 1 Spark nodes. Note: When reading the properties of a cluster, this
 	// field reflects the desired number of workers rather than the actual
 	// current number of workers. For instance, if a cluster is resized from 5
 	// to 10 workers, this field will immediately be updated to reflect the
@@ -627,7 +627,7 @@ type ClusterSize struct {
 }
 
 type CreateCluster struct {
-	// Note: This field won&#39;t be true for webapp requests. Only API users will
+	// Note: This field won't be true for webapp requests. Only API users will
 	// check this field.
 	ApplyPolicyDefaultValues bool `json:"apply_policy_default_values,omitempty"`
 	// Parameters needed in order to automatically scale clusters up and down
@@ -653,7 +653,7 @@ type CreateCluster struct {
 	// destination of driver logs is ``$destination/$clusterId/driver``, while
 	// the destination of executor logs is ``$destination/$clusterId/executor``.
 	ClusterLogConf *ClusterLogConf `json:"cluster_log_conf,omitempty"`
-	// Cluster name requested by the user. This doesn&#39;t have to be unique. If
+	// Cluster name requested by the user. This doesn't have to be unique. If
 	// not specified at creation, the cluster name will be an empty string.
 	ClusterName string `json:"cluster_name,omitempty"`
 	// Determines whether the cluster was created by a user through the UI,
@@ -664,7 +664,7 @@ type CreateCluster struct {
 	// resources (e.g., AWS instances and EBS volumes) with these tags in
 	// addition to ``default_tags``. Notes: - Currently, Databricks allows at
 	// most 45 custom tags - Clusters can only reuse cloud resources if the
-	// resources&#39; tags are a subset of the cluster tags
+	// resources' tags are a subset of the cluster tags
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// The optional ID of the instance pool for the driver of the cluster
 	// belongs. The pool cluster uses the instance pool with id
@@ -681,14 +681,14 @@ type CreateCluster struct {
 	// different from the spark_version (index 2). The spark_version is the raw
 	// string provided by the user through API or UI, which could map to a
 	// different effective_spark_version running in the dataplane, depending on
-	// the cluster&#39;s instance type or the runtimeEngine parameter.
+	// the cluster's instance type or the runtimeEngine parameter.
 	EffectiveSparkVersion string `json:"effective_spark_version,omitempty"`
 	// Autoscaling Local Storage: when enabled, this cluster will dynamically
 	// acquire additional disk space when its Spark workers are running low on
 	// disk space. This feature requires specific AWS permissions to function
 	// correctly - refer to the User Guide for more details.
 	EnableElasticDisk bool `json:"enable_elastic_disk,omitempty"`
-	// Whether to enable LUKS on cluster VMs&#39; local disks
+	// Whether to enable LUKS on cluster VMs' local disks
 	EnableLocalDiskEncryption bool `json:"enable_local_disk_encryption,omitempty"`
 	// Attributes related to clusters running on Google Cloud Platform. If not
 	// specified at cluster creation, a set of default values will be used.
@@ -706,7 +706,7 @@ type CreateCluster struct {
 	NodeTypeId string `json:"node_type_id,omitempty"`
 	// Number of worker nodes that this cluster should have. A cluster has one
 	// Spark Driver and ``num_workers`` Executors for a total of ``num_workers``
-	// &#43; 1 Spark nodes. Note: When reading the properties of a cluster, this
+	// + 1 Spark nodes. Note: When reading the properties of a cluster, this
 	// field reflects the desired number of workers rather than the actual
 	// current number of workers. For instance, if a cluster is resized from 5
 	// to 10 workers, this field will immediately be updated to reflect the
@@ -722,23 +722,23 @@ type CreateCluster struct {
 	// configuration key-value pairs. Users can also pass in a string of extra
 	// JVM options to the driver and the executors via
 	// ``spark.driver.extraJavaOptions`` and ``spark.executor.extraJavaOptions``
-	// respectively. Example Spark confs: ``{&#34;spark.speculation&#34;: true,
-	// &#34;spark.streaming.ui.retainedBatches&#34;: 5}`` or
-	// ``{&#34;spark.driver.extraJavaOptions&#34;: &#34;-verbose:gc -XX:&#43;PrintGCDetails&#34;}``
+	// respectively. Example Spark confs: ``{"spark.speculation": true,
+	// "spark.streaming.ui.retainedBatches": 5}`` or
+	// ``{"spark.driver.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails"}``
 	SparkConf map[string]string `json:"spark_conf,omitempty"`
 	// An object containing a set of optional, user-specified environment
 	// variable key-value pairs. Please note that key-value pair of the form
-	// (X,Y) will be exported as is (i.e., ``export X=&#39;Y&#39;``) while launching the
+	// (X,Y) will be exported as is (i.e., ``export X='Y'``) while launching the
 	// driver and workers. In order to specify an additional set of
 	// ``SPARK_DAEMON_JAVA_OPTS``, we recommend appending them to
 	// ``$SPARK_DAEMON_JAVA_OPTS`` as shown in the example below. This ensures
 	// that all default databricks managed environmental variables are included
-	// as well. Example Spark environment variables: ``{&#34;SPARK_WORKER_MEMORY&#34;:
-	// &#34;28000m&#34;, &#34;SPARK_LOCAL_DIRS&#34;: &#34;/local_disk0&#34;}`` or
-	// ``{&#34;SPARK_DAEMON_JAVA_OPTS&#34;: &#34;$SPARK_DAEMON_JAVA_OPTS
-	// -Dspark.shuffle.service.enabled=true&#34;}``
+	// as well. Example Spark environment variables: ``{"SPARK_WORKER_MEMORY":
+	// "28000m", "SPARK_LOCAL_DIRS": "/local_disk0"}`` or
+	// ``{"SPARK_DAEMON_JAVA_OPTS": "$SPARK_DAEMON_JAVA_OPTS
+	// -Dspark.shuffle.service.enabled=true"}``
 	SparkEnvVars map[string]string `json:"spark_env_vars,omitempty"`
-	// The Spark version of the cluster, e.g. &#34;3.3.x-scala2.11&#34;. A list of
+	// The Spark version of the cluster, e.g. "3.3.x-scala2.11". A list of
 	// available Spark versions can be retrieved by using the
 	// :ref:`clusterClusterServicelistSparkVersions` API call. This is the Spark
 	// version provided from the user input (API/UI) and may be different from
@@ -787,17 +787,17 @@ const CreateClusterRuntimeEnginePhoton CreateClusterRuntimeEngine = `PHOTON`
 const CreateClusterRuntimeEngineStandard CreateClusterRuntimeEngine = `STANDARD`
 
 type DataPlaneEventDetails struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	EventType DataPlaneEventDetailsEventType `json:"event_type,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	ExecutorFailures int `json:"executor_failures,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	HostId string `json:"host_id,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	Timestamp int64 `json:"timestamp,omitempty"`
 }
 
-// &lt;needs content added&gt;
+// <needs content added>
 type DataPlaneEventDetailsEventType string
 
 const DataPlaneEventDetailsEventTypeNodeBlacklisted DataPlaneEventDetailsEventType = `NODE_BLACKLISTED`
@@ -815,7 +815,7 @@ type DeleteCluster struct {
 }
 
 type EditCluster struct {
-	// Note: This field won&#39;t be true for webapp requests. Only API users will
+	// Note: This field won't be true for webapp requests. Only API users will
 	// check this field.
 	ApplyPolicyDefaultValues bool `json:"apply_policy_default_values,omitempty"`
 	// Parameters needed in order to automatically scale clusters up and down
@@ -834,7 +834,7 @@ type EditCluster struct {
 	// Attributes related to clusters running on Microsoft Azure. If not
 	// specified at cluster creation, a set of default values will be used.
 	AzureAttributes *AzureAttributes `json:"azure_attributes,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	ClusterId string `json:"cluster_id"`
 	// The configuration for delivering spark logs to a long-term storage
 	// destination. Two kinds of destinations (dbfs and s3) are supported. Only
@@ -843,7 +843,7 @@ type EditCluster struct {
 	// destination of driver logs is ``$destination/$clusterId/driver``, while
 	// the destination of executor logs is ``$destination/$clusterId/executor``.
 	ClusterLogConf *ClusterLogConf `json:"cluster_log_conf,omitempty"`
-	// Cluster name requested by the user. This doesn&#39;t have to be unique. If
+	// Cluster name requested by the user. This doesn't have to be unique. If
 	// not specified at creation, the cluster name will be an empty string.
 	ClusterName string `json:"cluster_name,omitempty"`
 	// Determines whether the cluster was created by a user through the UI,
@@ -854,7 +854,7 @@ type EditCluster struct {
 	// resources (e.g., AWS instances and EBS volumes) with these tags in
 	// addition to ``default_tags``. Notes: - Currently, Databricks allows at
 	// most 45 custom tags - Clusters can only reuse cloud resources if the
-	// resources&#39; tags are a subset of the cluster tags
+	// resources' tags are a subset of the cluster tags
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// The optional ID of the instance pool for the driver of the cluster
 	// belongs. The pool cluster uses the instance pool with id
@@ -871,14 +871,14 @@ type EditCluster struct {
 	// different from the spark_version (index 2). The spark_version is the raw
 	// string provided by the user through API or UI, which could map to a
 	// different effective_spark_version running in the dataplane, depending on
-	// the cluster&#39;s instance type or the runtimeEngine parameter.
+	// the cluster's instance type or the runtimeEngine parameter.
 	EffectiveSparkVersion string `json:"effective_spark_version,omitempty"`
 	// Autoscaling Local Storage: when enabled, this cluster will dynamically
 	// acquire additional disk space when its Spark workers are running low on
 	// disk space. This feature requires specific AWS permissions to function
 	// correctly - refer to the User Guide for more details.
 	EnableElasticDisk bool `json:"enable_elastic_disk,omitempty"`
-	// Whether to enable LUKS on cluster VMs&#39; local disks
+	// Whether to enable LUKS on cluster VMs' local disks
 	EnableLocalDiskEncryption bool `json:"enable_local_disk_encryption,omitempty"`
 	// Attributes related to clusters running on Google Cloud Platform. If not
 	// specified at cluster creation, a set of default values will be used.
@@ -896,7 +896,7 @@ type EditCluster struct {
 	NodeTypeId string `json:"node_type_id,omitempty"`
 	// Number of worker nodes that this cluster should have. A cluster has one
 	// Spark Driver and ``num_workers`` Executors for a total of ``num_workers``
-	// &#43; 1 Spark nodes. Note: When reading the properties of a cluster, this
+	// + 1 Spark nodes. Note: When reading the properties of a cluster, this
 	// field reflects the desired number of workers rather than the actual
 	// current number of workers. For instance, if a cluster is resized from 5
 	// to 10 workers, this field will immediately be updated to reflect the
@@ -912,23 +912,23 @@ type EditCluster struct {
 	// configuration key-value pairs. Users can also pass in a string of extra
 	// JVM options to the driver and the executors via
 	// ``spark.driver.extraJavaOptions`` and ``spark.executor.extraJavaOptions``
-	// respectively. Example Spark confs: ``{&#34;spark.speculation&#34;: true,
-	// &#34;spark.streaming.ui.retainedBatches&#34;: 5}`` or
-	// ``{&#34;spark.driver.extraJavaOptions&#34;: &#34;-verbose:gc -XX:&#43;PrintGCDetails&#34;}``
+	// respectively. Example Spark confs: ``{"spark.speculation": true,
+	// "spark.streaming.ui.retainedBatches": 5}`` or
+	// ``{"spark.driver.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails"}``
 	SparkConf map[string]string `json:"spark_conf,omitempty"`
 	// An object containing a set of optional, user-specified environment
 	// variable key-value pairs. Please note that key-value pair of the form
-	// (X,Y) will be exported as is (i.e., ``export X=&#39;Y&#39;``) while launching the
+	// (X,Y) will be exported as is (i.e., ``export X='Y'``) while launching the
 	// driver and workers. In order to specify an additional set of
 	// ``SPARK_DAEMON_JAVA_OPTS``, we recommend appending them to
 	// ``$SPARK_DAEMON_JAVA_OPTS`` as shown in the example below. This ensures
 	// that all default databricks managed environmental variables are included
-	// as well. Example Spark environment variables: ``{&#34;SPARK_WORKER_MEMORY&#34;:
-	// &#34;28000m&#34;, &#34;SPARK_LOCAL_DIRS&#34;: &#34;/local_disk0&#34;}`` or
-	// ``{&#34;SPARK_DAEMON_JAVA_OPTS&#34;: &#34;$SPARK_DAEMON_JAVA_OPTS
-	// -Dspark.shuffle.service.enabled=true&#34;}``
+	// as well. Example Spark environment variables: ``{"SPARK_WORKER_MEMORY":
+	// "28000m", "SPARK_LOCAL_DIRS": "/local_disk0"}`` or
+	// ``{"SPARK_DAEMON_JAVA_OPTS": "$SPARK_DAEMON_JAVA_OPTS
+	// -Dspark.shuffle.service.enabled=true"}``
 	SparkEnvVars map[string]string `json:"spark_env_vars,omitempty"`
-	// The Spark version of the cluster, e.g. &#34;3.3.x-scala2.11&#34;. A list of
+	// The Spark version of the cluster, e.g. "3.3.x-scala2.11". A list of
 	// available Spark versions can be retrieved by using the
 	// :ref:`clusterClusterServicelistSparkVersions` API call. This is the Spark
 	// version provided from the user input (API/UI) and may be different from
@@ -939,7 +939,7 @@ type EditCluster struct {
 	// cluster. The corresponding private keys can be used to login with the
 	// user name ``ubuntu`` on port ``2200``. Up to 10 keys can be specified.
 	SshPublicKeys []string `json:"ssh_public_keys,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	WorkloadType *WorkloadType `json:"workload_type,omitempty"`
 }
 
@@ -984,16 +984,16 @@ type EventDetails struct {
 	CurrentNumVcpus int `json:"current_num_vcpus,omitempty"`
 	// The current number of nodes in the cluster.
 	CurrentNumWorkers int `json:"current_num_workers,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	DidNotExpandReason string `json:"did_not_expand_reason,omitempty"`
 	// Current disk size in bytes
 	DiskSize int64 `json:"disk_size,omitempty"`
-	// More details about the change in driver&#39;s state
+	// More details about the change in driver's state
 	DriverStateMessage string `json:"driver_state_message,omitempty"`
 	// Whether or not a blocklisted node should be terminated. For
 	// ClusterEventType NODE_BLACKLISTED.
 	EnableTerminationForNodeBlocklisted bool `json:"enable_termination_for_node_blocklisted,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	FreeSpace int64 `json:"free_space,omitempty"`
 	// Instance Id where the event originated from
 	InstanceId string `json:"instance_id,omitempty"`
@@ -1072,7 +1072,7 @@ type GetEvents struct {
 	// is specified and the results are requested in descending order, the
 	// end_time field is required.
 	Offset int64 `json:"offset,omitempty"`
-	// The order to list events in; either &#34;ASC&#34; or &#34;DESC&#34;. Defaults to &#34;DESC&#34;.
+	// The order to list events in; either "ASC" or "DESC". Defaults to "DESC".
 	Order GetEventsOrder `json:"order,omitempty"`
 	// The start time in epoch milliseconds. If empty, returns events starting
 	// from the beginning of time.
@@ -1131,7 +1131,7 @@ const GetEventsEventTypesItemUnpinned GetEventsEventTypesItem = `UNPINNED`
 
 const GetEventsEventTypesItemUpsizeCompleted GetEventsEventTypesItem = `UPSIZE_COMPLETED`
 
-// The order to list events in; either &#34;ASC&#34; or &#34;DESC&#34;. Defaults to &#34;DESC&#34;.
+// The order to list events in; either "ASC" or "DESC". Defaults to "DESC".
 type GetEventsOrder string
 
 const GetEventsOrderAsc GetEventsOrder = `ASC`
@@ -1139,7 +1139,7 @@ const GetEventsOrderAsc GetEventsOrder = `ASC`
 const GetEventsOrderDesc GetEventsOrder = `DESC`
 
 type GetEventsResponse struct {
-	// &lt;content needs to be added&gt;
+	// <content needs to be added>
 	Events []ClusterEvent `json:"events,omitempty"`
 	// The parameters required to retrieve the next page of events. Omitted if
 	// there are no more events to read.
@@ -1158,12 +1158,12 @@ type ListAvailableZonesResponse struct {
 	// The availability zone if no ``zone_id`` is provided in the cluster
 	// creation request.
 	DefaultZone string `json:"default_zone,omitempty"`
-	// The list of available zones (e.g., [&#39;us-west-2c&#39;, &#39;us-east-2&#39;]).
+	// The list of available zones (e.g., ['us-west-2c', 'us-east-2']).
 	Zones []string `json:"zones,omitempty"`
 }
 
 type ListClustersResponse struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	Clusters []ClusterInfo `json:"clusters,omitempty"`
 }
 
@@ -1173,9 +1173,9 @@ type ListNodeTypesResponse struct {
 }
 
 type LogAnalyticsInfo struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	LogAnalyticsPrimaryKey string `json:"log_analytics_primary_key,omitempty"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	LogAnalyticsWorkspaceId string `json:"log_analytics_workspace_id,omitempty"`
 }
 
@@ -1202,12 +1202,12 @@ type NodeInstanceType struct {
 
 type NodeType struct {
 	Category string `json:"category,omitempty"`
-	// A string description associated with this node type, e.g., &#34;r3.xlarge&#34;.
+	// A string description associated with this node type, e.g., "r3.xlarge".
 	Description string `json:"description"`
 
 	DisplayOrder int `json:"display_order,omitempty"`
 	// An identifier for the type of hardware that this node runs on, e.g.,
-	// &#34;r3.2xlarge&#34; in AWS.
+	// "r3.2xlarge" in AWS.
 	InstanceTypeId string `json:"instance_type_id"`
 	// Whether the node type is deprecated. Non-deprecated node types offer
 	// greater performance.
@@ -1253,7 +1253,7 @@ type PermanentDeleteCluster struct {
 }
 
 type PinCluster struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	ClusterId string `json:"cluster_id"`
 }
 
@@ -1266,7 +1266,7 @@ type ResizeCluster struct {
 	ClusterId string `json:"cluster_id"`
 	// Number of worker nodes that this cluster should have. A cluster has one
 	// Spark Driver and ``num_workers`` Executors for a total of ``num_workers``
-	// &#43; 1 Spark nodes. Note: When reading the properties of a cluster, this
+	// + 1 Spark nodes. Note: When reading the properties of a cluster, this
 	// field reflects the desired number of workers rather than the actual
 	// current number of workers. For instance, if a cluster is resized from 5
 	// to 10 workers, this field will immediately be updated to reflect the
@@ -1278,7 +1278,7 @@ type ResizeCluster struct {
 type RestartCluster struct {
 	// The cluster to be started.
 	ClusterId string `json:"cluster_id"`
-	// &lt;needs content added&gt;
+	// <needs content added>
 	RestartUser string `json:"restart_user,omitempty"`
 }
 
@@ -1331,8 +1331,8 @@ type SparkNode struct {
 	// Public DNS address of this node. This address can be used to access the
 	// Spark JDBC server on the driver node. To communicate with the JDBC
 	// server, traffic must be manually authorized by adding security group
-	// rules to the &#34;worker-unmanaged&#34; security group via the AWS console.
-	// Actually it&#39;s the public DNS address of the host instance.
+	// rules to the "worker-unmanaged" security group via the AWS console.
+	// Actually it's the public DNS address of the host instance.
 	PublicDns string `json:"public_dns,omitempty"`
 	// The timestamp (in millisecond) when the Spark node is launched. The
 	// start_timestamp is set right before the container is being launched. The
@@ -1348,13 +1348,13 @@ type SparkNodeAwsAttributes struct {
 }
 
 type SparkVersion struct {
-	// Spark version key, for example &#34;2.1.x-scala2.11&#34;. This is the value which
-	// should be provided as the &#34;spark_version&#34; when creating a new cluster.
-	// Note that the exact Spark version may change over time for a &#34;wildcard&#34;
-	// version (i.e., &#34;2.1.x-scala2.11&#34; is a &#34;wildcard&#34; version) with minor bug
+	// Spark version key, for example "2.1.x-scala2.11". This is the value which
+	// should be provided as the "spark_version" when creating a new cluster.
+	// Note that the exact Spark version may change over time for a "wildcard"
+	// version (i.e., "2.1.x-scala2.11" is a "wildcard" version) with minor bug
 	// fixes.
 	Key string `json:"key,omitempty"`
-	// A descriptive name for this Spark version, for example &#34;Spark 2.1&#34;.
+	// A descriptive name for this Spark version, for example "Spark 2.1".
 	Name string `json:"name,omitempty"`
 }
 
@@ -1546,7 +1546,7 @@ const TerminationReasonTypeServiceFault TerminationReasonType = `SERVICE_FAULT`
 const TerminationReasonTypeSuccess TerminationReasonType = `SUCCESS`
 
 type UnpinCluster struct {
-	// &lt;needs content added&gt;
+	// <needs content added>
 	ClusterId string `json:"cluster_id"`
 }
 

--- a/service/dbfs/api.go
+++ b/service/dbfs/api.go
@@ -22,7 +22,7 @@ type DbfsAPI struct {
 // handle does not exist, this call will throw an exception with
 // “RESOURCE_DOES_NOT_EXIST“. If the block of data exceeds 1 MB, this call
 // will throw an exception with “MAX_BLOCK_SIZE_EXCEEDED“. Example of request:
-// .. code:: { &#34;data&#34;: &#34;ZGF0YWJyaWNrcwo=&#34;, &#34;handle&#34;: 7904256 }
+// .. code:: { "data": "ZGF0YWJyaWNrcwo=", "handle": 7904256 }
 func (a *DbfsAPI) AddBlock(ctx context.Context, request AddBlockRequest) error {
 	path := "/api/2.0/dbfs/add-block"
 	err := a.client.Post(ctx, path, request, nil)
@@ -90,9 +90,9 @@ func (a *DbfsAPI) GetStatusByPath(ctx context.Context, path string) (*GetStatusR
 
 // Lists the contents of a directory, or details of the file. If the file or
 // directory does not exist, this call will throw an exception with
-// “RESOURCE_DOES_NOT_EXIST“. Example of reply: .. code:: { &#34;files&#34;: [ {
-// &#34;path&#34;: &#34;/a.cpp&#34;, &#34;is_dir&#34;: false, &#34;file_size&#34;: 261 }, { &#34;path&#34;:
-// &#34;/databricks-results&#34;, &#34;is_dir&#34;: true, &#34;file_size&#34;: 0 } ] }
+// “RESOURCE_DOES_NOT_EXIST“. Example of reply: .. code:: { "files": [ {
+// "path": "/a.cpp", "is_dir": false, "file_size": 261 }, { "path":
+// "/databricks-results", "is_dir": true, "file_size": 0 } ] }
 func (a *DbfsAPI) List(ctx context.Context, request ListStatusRequest) (*ListStatusResponse, error) {
 	var listStatusResponse ListStatusResponse
 	path := "/api/2.0/dbfs/list"
@@ -102,9 +102,9 @@ func (a *DbfsAPI) List(ctx context.Context, request ListStatusRequest) (*ListSta
 
 // Lists the contents of a directory, or details of the file. If the file or
 // directory does not exist, this call will throw an exception with
-// “RESOURCE_DOES_NOT_EXIST“. Example of reply: .. code:: { &#34;files&#34;: [ {
-// &#34;path&#34;: &#34;/a.cpp&#34;, &#34;is_dir&#34;: false, &#34;file_size&#34;: 261 }, { &#34;path&#34;:
-// &#34;/databricks-results&#34;, &#34;is_dir&#34;: true, &#34;file_size&#34;: 0 } ] }
+// “RESOURCE_DOES_NOT_EXIST“. Example of reply: .. code:: { "files": [ {
+// "path": "/a.cpp", "is_dir": false, "file_size": 261 }, { "path":
+// "/databricks-results", "is_dir": true, "file_size": 0 } ] }
 func (a *DbfsAPI) ListByPath(ctx context.Context, path string) (*ListStatusResponse, error) {
 	return a.List(ctx, ListStatusRequest{
 		Path: path,
@@ -148,13 +148,13 @@ func (a *DbfsAPI) Move(ctx context.Context, request MoveRequest) error {
 // Uploads a file through the use of multipart form post. It is mainly used for
 // streaming uploads, but can also be used as a convenient single call for data
 // upload. Example usage: .. code:: curl -u USER:PASS -F contents=@localsrc -F
-// path=&#34;PATH&#34; https://XX.cloud.databricks.com/api/2.0/dbfs/put Please note that
+// path="PATH" https://XX.cloud.databricks.com/api/2.0/dbfs/put Please note that
 // “localsrc“ is the path to a local file to upload and this usage is only
 // supported with multipart form post (i.e. using -F or --form with curl).
 // Alternatively you can pass contents as base64 string. Examples: .. code::
-// curl -u USER:PASS -F contents=&#34;BASE64&#34; -F path=&#34;PATH&#34;
+// curl -u USER:PASS -F contents="BASE64" -F path="PATH"
 // https://XX.cloud.databricks.com/api/2.0/dbfs/put .. code:: curl -u USER:PASS
-// -H &#34;Content-Type: application/json&#34; -d &#39;{&#34;path&#34;:&#34;PATH&#34;,&#34;contents&#34;:&#34;BASE64&#34;}&#39;
+// -H "Content-Type: application/json" -d '{"path":"PATH","contents":"BASE64"}'
 // https://XX.cloud.databricks.com/api/2.0/dbfs/put“ Amount of data that can be
 // passed using contents (i.e. not streaming) parameter is limited to 1 MB,
 // “MAX_BLOCK_SIZE_EXCEEDED“ will be thrown if exceeded. Please use streaming
@@ -171,7 +171,7 @@ func (a *DbfsAPI) Put(ctx context.Context, request PutRequest) error {
 // directory, the read length is negative, or if the offset is negative, this
 // call will throw an exception with “INVALID_PARAMETER_VALUE“. If the read
 // length exceeds 1 MB, this call will throw an exception with
-// “MAX_READ_SIZE_EXCEEDED“. If “offset &#43; length“ exceeds the number of
+// “MAX_READ_SIZE_EXCEEDED“. If “offset + length“ exceeds the number of
 // bytes in a file, we will read contents until the end of file.
 func (a *DbfsAPI) Read(ctx context.Context, request ReadRequest) (*ReadResponse, error) {
 	var readResponse ReadResponse

--- a/service/dbfs/interface.go
+++ b/service/dbfs/interface.go
@@ -14,7 +14,7 @@ type DbfsService interface {
 	// the handle does not exist, this call will throw an exception with
 	// ``RESOURCE_DOES_NOT_EXIST``. If the block of data exceeds 1 MB, this call
 	// will throw an exception with ``MAX_BLOCK_SIZE_EXCEEDED``. Example of
-	// request: .. code:: { &#34;data&#34;: &#34;ZGF0YWJyaWNrcwo=&#34;, &#34;handle&#34;: 7904256 }
+	// request: .. code:: { "data": "ZGF0YWJyaWNrcwo=", "handle": 7904256 }
 	AddBlock(ctx context.Context, addBlockRequest AddBlockRequest) error
 
 	// Closes the stream specified by the input handle. If the handle does not
@@ -46,9 +46,9 @@ type DbfsService interface {
 	GetStatusByPath(ctx context.Context, path string) (*GetStatusResponse, error)
 	// Lists the contents of a directory, or details of the file. If the file or
 	// directory does not exist, this call will throw an exception with
-	// ``RESOURCE_DOES_NOT_EXIST``. Example of reply: .. code:: { &#34;files&#34;: [ {
-	// &#34;path&#34;: &#34;/a.cpp&#34;, &#34;is_dir&#34;: false, &#34;file_size&#34;: 261 }, { &#34;path&#34;:
-	// &#34;/databricks-results&#34;, &#34;is_dir&#34;: true, &#34;file_size&#34;: 0 } ] }
+	// ``RESOURCE_DOES_NOT_EXIST``. Example of reply: .. code:: { "files": [ {
+	// "path": "/a.cpp", "is_dir": false, "file_size": 261 }, { "path":
+	// "/databricks-results", "is_dir": true, "file_size": 0 } ] }
 	List(ctx context.Context, listStatusRequest ListStatusRequest) (*ListStatusResponse, error)
 
 	ListByPath(ctx context.Context, path string) (*ListStatusResponse, error)
@@ -71,15 +71,15 @@ type DbfsService interface {
 	// Uploads a file through the use of multipart form post. It is mainly used
 	// for streaming uploads, but can also be used as a convenient single call
 	// for data upload. Example usage: .. code:: curl -u USER:PASS -F
-	// contents=@localsrc -F path=&#34;PATH&#34;
+	// contents=@localsrc -F path="PATH"
 	// https://XX.cloud.databricks.com/api/2.0/dbfs/put Please note that
 	// ``localsrc`` is the path to a local file to upload and this usage is only
 	// supported with multipart form post (i.e. using -F or --form with curl).
 	// Alternatively you can pass contents as base64 string. Examples: .. code::
-	// curl -u USER:PASS -F contents=&#34;BASE64&#34; -F path=&#34;PATH&#34;
+	// curl -u USER:PASS -F contents="BASE64" -F path="PATH"
 	// https://XX.cloud.databricks.com/api/2.0/dbfs/put .. code:: curl -u
-	// USER:PASS -H &#34;Content-Type: application/json&#34; -d
-	// &#39;{&#34;path&#34;:&#34;PATH&#34;,&#34;contents&#34;:&#34;BASE64&#34;}&#39;
+	// USER:PASS -H "Content-Type: application/json" -d
+	// '{"path":"PATH","contents":"BASE64"}'
 	// https://XX.cloud.databricks.com/api/2.0/dbfs/put`` Amount of data that
 	// can be passed using contents (i.e. not streaming) parameter is limited to
 	// 1 MB, ``MAX_BLOCK_SIZE_EXCEEDED`` will be thrown if exceeded. Please use
@@ -93,7 +93,7 @@ type DbfsService interface {
 	// a directory, the read length is negative, or if the offset is negative,
 	// this call will throw an exception with ``INVALID_PARAMETER_VALUE``. If
 	// the read length exceeds 1 MB, this call will throw an exception with
-	// ``MAX_READ_SIZE_EXCEEDED``. If ``offset &#43; length`` exceeds the number of
+	// ``MAX_READ_SIZE_EXCEEDED``. If ``offset + length`` exceeds the number of
 	// bytes in a file, we will read contents until the end of file.
 	Read(ctx context.Context, readRequest ReadRequest) (*ReadResponse, error)
 }

--- a/service/dbfs/model.go
+++ b/service/dbfs/model.go
@@ -21,7 +21,7 @@ type CreateRequest struct {
 	// The flag that specifies whether to overwrite existing file/files.
 	Overwrite bool `json:"overwrite,omitempty"`
 	// The path of the new file. The path should be the absolute DBFS path (e.g.
-	// &#34;/mnt/foo.txt&#34;).
+	// "/mnt/foo.txt").
 	Path string `json:"path"`
 }
 
@@ -33,9 +33,9 @@ type CreateResponse struct {
 
 type DeleteRequest struct {
 	// The path of the file or directory to delete. The path should be the
-	// absolute DBFS path (e.g. &#34;/mnt/foo/&#34;).
+	// absolute DBFS path (e.g. "/mnt/foo/").
 	Path string `json:"path"`
-	// Whether or not to recursively delete the directory&#39;s contents. Deleting
+	// Whether or not to recursively delete the directory's contents. Deleting
 	// empty directories can be done without providing the recursive flag.
 	Recursive bool `json:"recursive,omitempty"`
 }
@@ -53,7 +53,7 @@ type FileInfo struct {
 
 type GetStatusRequest struct {
 	// The path of the file or directory. The path should be the absolute DBFS
-	// path (e.g. &#34;/mnt/foo/&#34;).
+	// path (e.g. "/mnt/foo/").
 	Path string ` url:"path,omitempty"`
 }
 
@@ -70,28 +70,28 @@ type GetStatusResponse struct {
 
 type ListStatusRequest struct {
 	// The path of the file or directory. The path should be the absolute DBFS
-	// path (e.g. &#34;/mnt/foo/&#34;).
+	// path (e.g. "/mnt/foo/").
 	Path string ` url:"path,omitempty"`
 }
 
 type ListStatusResponse struct {
-	// A list of FileInfo&#39;s that describe contents of directory or file. See
+	// A list of FileInfo's that describe contents of directory or file. See
 	// example above.
 	Files []FileInfo `json:"files,omitempty"`
 }
 
 type MkDirsRequest struct {
 	// The path of the new directory. The path should be the absolute DBFS path
-	// (e.g. &#34;/mnt/foo/&#34;).
+	// (e.g. "/mnt/foo/").
 	Path string `json:"path"`
 }
 
 type MoveRequest struct {
 	// The destination path of the file or directory. The path should be the
-	// absolute DBFS path (e.g. &#34;/mnt/bar/&#34;).
+	// absolute DBFS path (e.g. "/mnt/bar/").
 	DestinationPath string `json:"destination_path"`
 	// The source path of the file or directory. The path should be the absolute
-	// DBFS path (e.g. &#34;/mnt/foo/&#34;).
+	// DBFS path (e.g. "/mnt/foo/").
 	SourcePath string `json:"source_path"`
 }
 
@@ -101,7 +101,7 @@ type PutRequest struct {
 	// The flag that specifies whether to overwrite existing file/files.
 	Overwrite bool `json:"overwrite,omitempty"`
 	// The path of the new file. The path should be the absolute DBFS path (e.g.
-	// &#34;/mnt/foo/&#34;).
+	// "/mnt/foo/").
 	Path string `json:"path"`
 }
 
@@ -112,7 +112,7 @@ type ReadRequest struct {
 	// The offset to read from in bytes.
 	Offset int ` url:"offset,omitempty"`
 	// The path of the file to read. The path should be the absolute DBFS path
-	// (e.g. &#34;/mnt/foo/&#34;).
+	// (e.g. "/mnt/foo/").
 	Path string ` url:"path,omitempty"`
 }
 

--- a/service/deltapipelines/model.go
+++ b/service/deltapipelines/model.go
@@ -9,8 +9,8 @@ type CreatePipelineRequest struct {
 	// pipeline.
 	AllowDuplicateNames bool `json:"allow_duplicate_names,omitempty"`
 	// Catalog in UC to add tables to. If target is specified, tables in this
-	// pipeline will be published to a &#34;target&#34; schema inside catalog (i.e.
-	// &lt;catalog&gt;.&lt;target&gt;.&lt;table&gt;).
+	// pipeline will be published to a "target" schema inside catalog (i.e.
+	// <catalog>.<target>.<table>).
 	Catalog string `json:"catalog,omitempty"`
 	// DLT Release Channel that specifies which version to use.
 	Channel string `json:"channel,omitempty"`
@@ -66,8 +66,8 @@ type EditPipelineRequest struct {
 	// of another pipeline.
 	AllowDuplicateNames bool `json:"allow_duplicate_names,omitempty"`
 	// Catalog in UC to add tables to. If target is specified, tables in this
-	// pipeline will be published to a &#34;target&#34; schema inside catalog (i.e.
-	// &lt;catalog&gt;.&lt;target&gt;.&lt;table&gt;).
+	// pipeline will be published to a "target" schema inside catalog (i.e.
+	// <catalog>.<target>.<table>).
 	Catalog string `json:"catalog,omitempty"`
 	// DLT Release Channel that specifies which version to use.
 	Channel string `json:"channel,omitempty"`
@@ -211,7 +211,7 @@ type NotebookLibrary struct {
 }
 
 type PipelineCluster struct {
-	// Note: This field won&#39;t be persisted. Only API users will check this
+	// Note: This field won't be persisted. Only API users will check this
 	// field.
 	ApplyPolicyDefaultValues bool `json:"apply_policy_default_values,omitempty"`
 	// Parameters needed in order to automatically scale clusters up and down
@@ -235,7 +235,7 @@ type PipelineCluster struct {
 	// resources (e.g., AWS instances and EBS volumes) with these tags in
 	// addition to ``default_tags``. Notes: - Currently, Databricks allows at
 	// most 45 custom tags - Clusters can only reuse cloud resources if the
-	// resources&#39; tags are a subset of the cluster tags
+	// resources' tags are a subset of the cluster tags
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// The optional ID of the instance pool for the driver of the cluster
 	// belongs. The pool cluster uses the instance pool with id
@@ -260,7 +260,7 @@ type PipelineCluster struct {
 	NodeTypeId string `json:"node_type_id,omitempty"`
 	// Number of worker nodes that this cluster should have. A cluster has one
 	// Spark Driver and ``num_workers`` Executors for a total of ``num_workers``
-	// &#43; 1 Spark nodes. Note: When reading the properties of a cluster, this
+	// + 1 Spark nodes. Note: When reading the properties of a cluster, this
 	// field reflects the desired number of workers rather than the actual
 	// current number of workers. For instance, if a cluster is resized from 5
 	// to 10 workers, this field will immediately be updated to reflect the
@@ -273,21 +273,21 @@ type PipelineCluster struct {
 	// configuration key-value pairs. Users can also pass in a string of extra
 	// JVM options to the driver and the executors via
 	// ``spark.driver.extraJavaOptions`` and ``spark.executor.extraJavaOptions``
-	// respectively. Example Spark confs: ``{&#34;spark.speculation&#34;: true,
-	// &#34;spark.streaming.ui.retainedBatches&#34;: 5}`` or
-	// ``{&#34;spark.driver.extraJavaOptions&#34;: &#34;-verbose:gc -XX:&#43;PrintGCDetails&#34;}``
+	// respectively. Example Spark confs: ``{"spark.speculation": true,
+	// "spark.streaming.ui.retainedBatches": 5}`` or
+	// ``{"spark.driver.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails"}``
 	SparkConf map[string]string `json:"spark_conf,omitempty"`
 	// An object containing a set of optional, user-specified environment
 	// variable key-value pairs. Please note that key-value pair of the form
-	// (X,Y) will be exported as is (i.e., ``export X=&#39;Y&#39;``) while launching the
+	// (X,Y) will be exported as is (i.e., ``export X='Y'``) while launching the
 	// driver and workers. In order to specify an additional set of
 	// ``SPARK_DAEMON_JAVA_OPTS``, we recommend appending them to
 	// ``$SPARK_DAEMON_JAVA_OPTS`` as shown in the example below. This ensures
 	// that all default databricks managed environmental variables are included
-	// as well. Example Spark environment variables: ``{&#34;SPARK_WORKER_MEMORY&#34;:
-	// &#34;28000m&#34;, &#34;SPARK_LOCAL_DIRS&#34;: &#34;/local_disk0&#34;}`` or
-	// ``{&#34;SPARK_DAEMON_JAVA_OPTS&#34;: &#34;$SPARK_DAEMON_JAVA_OPTS
-	// -Dspark.shuffle.service.enabled=true&#34;}``
+	// as well. Example Spark environment variables: ``{"SPARK_WORKER_MEMORY":
+	// "28000m", "SPARK_LOCAL_DIRS": "/local_disk0"}`` or
+	// ``{"SPARK_DAEMON_JAVA_OPTS": "$SPARK_DAEMON_JAVA_OPTS
+	// -Dspark.shuffle.service.enabled=true"}``
 	SparkEnvVars map[string]string `json:"spark_env_vars,omitempty"`
 	// SSH public key contents that will be added to each Spark node in this
 	// cluster. The corresponding private keys can be used to login with the
@@ -297,21 +297,21 @@ type PipelineCluster struct {
 
 type PipelineLibrary struct {
 	// URI of the jar to be installed. Currently only DBFS and S3 URIs are
-	// supported. For example: ``{ &#34;jar&#34;: &#34;dbfs:/mnt/databricks/library.jar&#34; }``
-	// or ``{ &#34;jar&#34;: &#34;s3://my-bucket/library.jar&#34; }``. If S3 is used, please
+	// supported. For example: ``{ "jar": "dbfs:/mnt/databricks/library.jar" }``
+	// or ``{ "jar": "s3://my-bucket/library.jar" }``. If S3 is used, please
 	// make sure the cluster has read access on the library. You may need to
 	// launch the cluster with an IAM role to access the S3 URI.
 	Jar string `json:"jar,omitempty"`
 	// Specification of a maven library to be installed. For example: ``{
-	// &#34;coordinates&#34;: &#34;org.jsoup:jsoup:1.7.2&#34; }``
+	// "coordinates": "org.jsoup:jsoup:1.7.2" }``
 	Maven *PipelinesMavenLibrary `json:"maven,omitempty"`
 	// The path to a notebook that defines a pipeline and is stored in the
-	// Databricks workspace. For example: ``{ &#34;notebook&#34; : { &#34;path&#34; :
-	// &#34;/my-pipeline-notebook-path&#34; } }``. Currently, only Scala notebooks are
+	// Databricks workspace. For example: ``{ "notebook" : { "path" :
+	// "/my-pipeline-notebook-path" } }``. Currently, only Scala notebooks are
 	// supported, and pipelines must be defined in a package cell.
 	Notebook *NotebookLibrary `json:"notebook,omitempty"`
-	// URI of the wheel to be installed. For example: ``{ &#34;whl&#34;: &#34;dbfs:/my/whl&#34;
-	// }`` or ``{ &#34;whl&#34;: &#34;s3://my-bucket/whl&#34; }``. If S3 is used, please make
+	// URI of the wheel to be installed. For example: ``{ "whl": "dbfs:/my/whl"
+	// }`` or ``{ "whl": "s3://my-bucket/whl" }``. If S3 is used, please make
 	// sure the cluster has read access on the library. You may need to launch
 	// the cluster with an IAM role to access the S3 URI.
 	Whl string `json:"whl,omitempty"`
@@ -319,8 +319,8 @@ type PipelineLibrary struct {
 
 type PipelineSpec struct {
 	// Catalog in UC to add tables to. If target is specified, tables in this
-	// pipeline will be published to a &#34;target&#34; schema inside catalog (i.e.
-	// &lt;catalog&gt;.&lt;target&gt;.&lt;table&gt;).
+	// pipeline will be published to a "target" schema inside catalog (i.e.
+	// <catalog>.<target>.<table>).
 	Catalog string `json:"catalog,omitempty"`
 	// DLT Release Channel that specifies which version to use.
 	Channel string `json:"channel,omitempty"`
@@ -375,12 +375,12 @@ type PipelinesAutoScale struct {
 }
 
 type PipelinesClusterLogConf struct {
-	// destination needs to be provided. e.g. ``{ &#34;dbfs&#34; : { &#34;destination&#34; :
-	// &#34;dbfs:/home/cluster_log&#34; } }``
+	// destination needs to be provided. e.g. ``{ "dbfs" : { "destination" :
+	// "dbfs:/home/cluster_log" } }``
 	Dbfs *PipelinesDbfsStorageInfo `json:"dbfs,omitempty"`
 	// destination and either region or endpoint should also be provided. e.g.
-	// ``{ &#34;s3&#34;: { &#34;destination&#34; : &#34;s3://cluster_log_bucket/prefix&#34;, &#34;region&#34; :
-	// &#34;us-west-2&#34; } }`` Cluster iam role is used to access s3, please make sure
+	// ``{ "s3": { "destination" : "s3://cluster_log_bucket/prefix", "region" :
+	// "us-west-2" } }`` Cluster iam role is used to access s3, please make sure
 	// the cluster iam role in ``instance_profile_arn`` has permission to write
 	// data to the s3 destination.
 	S3 *PipelinesS3StorageInfo `json:"s3,omitempty"`
@@ -400,10 +400,10 @@ type PipelinesGcpAttributes struct {
 }
 
 type PipelinesMavenLibrary struct {
-	// Gradle-style maven coordinates. For example: &#34;org.jsoup:jsoup:1.7.2&#34;.
+	// Gradle-style maven coordinates. For example: "org.jsoup:jsoup:1.7.2".
 	Coordinates string `json:"coordinates"`
-	// List of dependences to exclude. For example: ``[&#34;slf4j:slf4j&#34;,
-	// &#34;*:hadoop-client&#34;]``. Maven dependency exclusions:
+	// List of dependences to exclude. For example: ``["slf4j:slf4j",
+	// "*:hadoop-client"]``. Maven dependency exclusions:
 	// https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.
 	Exclusions []string `json:"exclusions,omitempty"`
 	// Maven repo to install the Maven package from. If omitted, both Maven

--- a/service/gitcredentials/api.go
+++ b/service/gitcredentials/api.go
@@ -59,7 +59,7 @@ func (a *GitCredentialsAPI) GetCredentialByCredentialId(ctx context.Context, cre
 	})
 }
 
-// Returns the calling user&#39;s Git credentials. One credential per user is
+// Returns the calling user's Git credentials. One credential per user is
 // supported.
 func (a *GitCredentialsAPI) GetCredentials(ctx context.Context) (*GetCredentialsResponse, error) {
 	var getCredentialsResponse GetCredentialsResponse

--- a/service/gitcredentials/interface.go
+++ b/service/gitcredentials/interface.go
@@ -24,7 +24,7 @@ type GitCredentialsService interface {
 	GetCredential(ctx context.Context, getCredentialRequest GetCredentialRequest) (*GetCredentialResponse, error)
 
 	GetCredentialByCredentialId(ctx context.Context, credentialId string) (*GetCredentialResponse, error)
-	// Returns the calling user&#39;s Git credentials. One credential per user is
+	// Returns the calling user's Git credentials. One credential per user is
 	// supported.
 	GetCredentials(ctx context.Context) (*GetCredentialsResponse, error)
 

--- a/service/instancepools/model.go
+++ b/service/instancepools/model.go
@@ -33,7 +33,7 @@ type CreateInstancePoolRequest struct {
 	// value to 0 to instantly remove idle instances from the cache if min cache
 	// size could still hold.
 	IdleInstanceAutoterminationMinutes int `json:"idle_instance_autotermination_minutes,omitempty"`
-	// The fleet related setting to power the intance pool. Note that we don&#39;t
+	// The fleet related setting to power the intance pool. Note that we don't
 	// want to inline this message as it can be hard to interpret/manage
 	InstancePoolFleetAttributes *InstancePoolFleetAttributes `json:"instance_pool_fleet_attributes,omitempty"`
 	// Pool name requested by the user. This has to be unique. Length must be
@@ -54,7 +54,7 @@ type CreateInstancePoolRequest struct {
 	// Custom Docker Image BYOC
 	PreloadedDockerImages []DockerImage `json:"preloaded_docker_images,omitempty"`
 	// A list of preloaded Spark image versions for the pool, e.g.
-	// [&#34;5.2.x-scala2.11&#34;]. Pool-backed clusters started with the preloaded
+	// ["5.2.x-scala2.11"]. Pool-backed clusters started with the preloaded
 	// Spark version will start faster. A list of available Spark versions can
 	// be retrieved by using the :ref:`clusterClusterServicelistSparkVersions`
 	// API call.
@@ -177,7 +177,7 @@ type EditInstancePoolRequest struct {
 	// Custom Docker Image BYOC
 	PreloadedDockerImages []DockerImage `json:"preloaded_docker_images,omitempty"`
 	// A list of preloaded Spark image versions for the pool, e.g.
-	// [&#34;5.2.x-scala2.11&#34;]. Pool-backed clusters started with the preloaded
+	// ["5.2.x-scala2.11"]. Pool-backed clusters started with the preloaded
 	// Spark version will start faster. A list of available Spark versions can
 	// be retrieved by using the :ref:`clusterClusterServicelistSparkVersions`
 	// API call.
@@ -206,7 +206,7 @@ type FleetLaunchTemplateOverride struct {
 type FleetOnDemandOption struct {
 	// Only lowest-price and prioritized are allowed
 	AllocationStrategy FleetOnDemandOptionAllocationStrategy `json:"allocation_strategy,omitempty"`
-	// The maximum amount per hour for On-Demand Instances that you&#39;re willing
+	// The maximum amount per hour for On-Demand Instances that you're willing
 	// to pay.
 	MaxTotalPrice float64 `json:"max_total_price,omitempty"`
 	// If you specify use-capacity-reservations-first, the fleet uses unused
@@ -239,7 +239,7 @@ type FleetSpotOption struct {
 	// EC2 Fleet selects the cheapest Spot pools and evenly allocates your
 	// target Spot capacity across the number of Spot pools that you specify.
 	InstancePoolsToUseCount int `json:"instance_pools_to_use_count,omitempty"`
-	// The maximum amount per hour for Spot Instances that you&#39;re willing to
+	// The maximum amount per hour for Spot Instances that you're willing to
 	// pay.
 	MaxTotalPrice float64 `json:"max_total_price,omitempty"`
 }
@@ -274,8 +274,8 @@ type GetInstancePoolResponse struct {
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// Tags that are added by Databricks regardless of any ``custom_tags``,
 	// including: - Vendor: Databricks - InstancePoolCreator:
-	// &lt;user_id_of_creator&gt; - InstancePoolName: &lt;name_of_pool&gt; - InstancePoolId:
-	// &lt;id_of_pool&gt;
+	// <user_id_of_creator> - InstancePoolName: <name_of_pool> - InstancePoolId:
+	// <id_of_pool>
 	DefaultTags map[string]string `json:"default_tags,omitempty"`
 	// Defines the specification of the disks that will be attached to all spark
 	// containers.
@@ -314,7 +314,7 @@ type GetInstancePoolResponse struct {
 	// Custom Docker Image BYOC
 	PreloadedDockerImages []DockerImage `json:"preloaded_docker_images,omitempty"`
 	// A list of preloaded Spark image versions for the pool, e.g.
-	// [&#34;5.2.x-scala2.11&#34;]. Pool-backed clusters started with the preloaded
+	// ["5.2.x-scala2.11"]. Pool-backed clusters started with the preloaded
 	// Spark version will start faster. A list of available Spark versions can
 	// be retrieved by using the :ref:`clusterClusterServicelistSparkVersions`
 	// API call.
@@ -350,8 +350,8 @@ type InstancePoolAndStats struct {
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
 	// Tags that are added by Databricks regardless of any ``custom_tags``,
 	// including: - Vendor: Databricks - InstancePoolCreator:
-	// &lt;user_id_of_creator&gt; - InstancePoolName: &lt;name_of_pool&gt; - InstancePoolId:
-	// &lt;id_of_pool&gt;
+	// <user_id_of_creator> - InstancePoolName: <name_of_pool> - InstancePoolId:
+	// <id_of_pool>
 	DefaultTags map[string]string `json:"default_tags,omitempty"`
 	// Defines the specification of the disks that will be attached to all spark
 	// containers.
@@ -390,7 +390,7 @@ type InstancePoolAndStats struct {
 	// Custom Docker Image BYOC
 	PreloadedDockerImages []DockerImage `json:"preloaded_docker_images,omitempty"`
 	// A list of preloaded Spark image versions for the pool, e.g.
-	// [&#34;5.2.x-scala2.11&#34;]. Pool-backed clusters started with the preloaded
+	// ["5.2.x-scala2.11"]. Pool-backed clusters started with the preloaded
 	// Spark version will start faster. A list of available Spark versions can
 	// be retrieved by using the :ref:`clusterClusterServicelistSparkVersions`
 	// API call.
@@ -417,7 +417,7 @@ type InstancePoolAwsAttributes struct {
 	// by InstancePoolConf.instancePoolDefaultAwsAvailability
 	Availability InstancePoolAwsAttributesAvailability `json:"availability,omitempty"`
 	// The bid price for AWS spot instances, as a percentage of the
-	// corresponding instance type&#39;s on-demand price. For example, if this field
+	// corresponding instance type's on-demand price. For example, if this field
 	// is set to 50, and the cluster needs a new ``r3.xlarge`` spot instance,
 	// then the bid price is half of the price of on-demand ``r3.xlarge``
 	// instances. Similarly, if this field is set to 200, the bid price is twice
@@ -430,10 +430,10 @@ type InstancePoolAwsAttributes struct {
 	// CommonConf.maxSpotBidPricePercent.
 	SpotBidPricePercent int `json:"spot_bid_price_percent,omitempty"`
 	// Identifier for the availability zone/datacenter in which the cluster
-	// resides. This string will be of a form like &#34;us-west-2a&#34;. The provided
+	// resides. This string will be of a form like "us-west-2a". The provided
 	// availability zone must be in the same region as the Databricks
-	// deployment. For example, &#34;us-west-2a&#34; is not a valid zone id if the
-	// Databricks deployment resides in the &#34;us-east-1&#34; region. This is an
+	// deployment. For example, "us-west-2a" is not a valid zone id if the
+	// Databricks deployment resides in the "us-east-1" region. This is an
 	// optional field at cluster creation, and if not specified, a default zone
 	// will be used. The list of available zones as well as the default value
 	// can be found by using the `List Zones`_ method.

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -22,7 +22,7 @@ type JobsAPI struct {
 }
 
 // Cancels all active runs of a job. The runs are canceled asynchronously, so it
-// doesn&#39;t prevent new runs from being started.
+// doesn't prevent new runs from being started.
 func (a *JobsAPI) CancelAllRuns(ctx context.Context, request CancelAllRuns) error {
 	path := "/api/2.1/jobs/runs/cancel-all"
 	err := a.client.Post(ctx, path, request, nil)
@@ -30,7 +30,7 @@ func (a *JobsAPI) CancelAllRuns(ctx context.Context, request CancelAllRuns) erro
 }
 
 // Cancels all active runs of a job. The runs are canceled asynchronously, so it
-// doesn&#39;t prevent new runs from being started.
+// doesn't prevent new runs from being started.
 func (a *JobsAPI) CancelAllRunsByJobId(ctx context.Context, jobId int64) error {
 	return a.CancelAllRuns(ctx, CancelAllRuns{
 		JobId: jobId,

--- a/service/jobs/interface.go
+++ b/service/jobs/interface.go
@@ -14,7 +14,7 @@ import (
 // Evolving: this interface is under development. Method signatures may change.
 type JobsService interface {
 	// Cancels all active runs of a job. The runs are canceled asynchronously,
-	// so it doesn&#39;t prevent new runs from being started.
+	// so it doesn't prevent new runs from being started.
 	CancelAllRuns(ctx context.Context, cancelAllRuns CancelAllRuns) error
 
 	CancelAllRunsByJobId(ctx context.Context, jobId int64) error

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -44,11 +44,11 @@ type ClusterInstance struct {
 
 type ClusterLogConf struct {
 	// DBFS location of cluster log. Destination must be provided. For example,
-	// `{ &#34;dbfs&#34; : { &#34;destination&#34; : &#34;dbfs:/home/cluster_log&#34; } }`
+	// `{ "dbfs" : { "destination" : "dbfs:/home/cluster_log" } }`
 	Dbfs *DbfsStorageInfo `json:"dbfs,omitempty"`
 	// S3 location of cluster log. `destination` and either `region` or
-	// `endpoint` must be provided. For example, `{ &#34;s3&#34;: { &#34;destination&#34; :
-	// &#34;s3://cluster_log_bucket/prefix&#34;, &#34;region&#34; : &#34;us-west-2&#34; } }`
+	// `endpoint` must be provided. For example, `{ "s3": { "destination" :
+	// "s3://cluster_log_bucket/prefix", "region" : "us-west-2" } }`
 	S3 any/* ERROR */ `json:"s3,omitempty"`
 }
 
@@ -79,10 +79,10 @@ type CreateJob struct {
 	EmailNotifications *JobEmailNotifications `json:"email_notifications,omitempty"`
 	// Used to tell what is the format of the job. This field is ignored in
 	// Create/Update/Reset calls. When using the Jobs API 2.1 this value is
-	// always set to `&#34;MULTI_TASK&#34;`.
+	// always set to `"MULTI_TASK"`.
 	Format CreateJobFormat `json:"format,omitempty"`
 	// An optional specification for a remote repository containing the
-	// notebooks used by this job&#39;s notebook tasks.
+	// notebooks used by this job's notebook tasks.
 	GitSource *GitSource `json:"git_source,omitempty"`
 	// A list of job cluster specifications that can be shared and reused by
 	// tasks of this job. Libraries cannot be declared in a shared job cluster.
@@ -121,7 +121,7 @@ type CreateJob struct {
 
 // Used to tell what is the format of the job. This field is ignored in
 // Create/Update/Reset calls. When using the Jobs API 2.1 this value is always
-// set to `&#34;MULTI_TASK&#34;`.
+// set to `"MULTI_TASK"`.
 type CreateJobFormat string
 
 const CreateJobFormatMultiTask CreateJobFormat = `MULTI_TASK`
@@ -185,7 +185,7 @@ type GitSnapshot struct {
 }
 
 // An optional specification for a remote repository containing the notebooks
-// used by this job&#39;s notebook tasks.
+// used by this job's notebook tasks.
 type GitSource struct {
 	// Name of the branch to be checked out and used by this job. This field
 	// cannot be specified in conjunction with git_tag or git_commit. The
@@ -231,14 +231,14 @@ const GitSourceGitProviderGitlabenterpriseedition GitSourceGitProvider = `gitLab
 
 type InitScriptInfo struct {
 	// S3 location of init script. Destination and either region or endpoint
-	// must be provided. For example, `{ &#34;s3&#34;: { &#34;destination&#34; :
-	// &#34;s3://init_script_bucket/prefix&#34;, &#34;region&#34; : &#34;us-west-2&#34; } }`
+	// must be provided. For example, `{ "s3": { "destination" :
+	// "s3://init_script_bucket/prefix", "region" : "us-west-2" } }`
 	S3 any/* ERROR */ `json:"S3,omitempty"`
 	// DBFS location of init script. Destination must be provided. For example,
-	// `{ &#34;dbfs&#34; : { &#34;destination&#34; : &#34;dbfs:/home/init_script&#34; } }`
+	// `{ "dbfs" : { "destination" : "dbfs:/home/init_script" } }`
 	Dbfs *DbfsStorageInfo `json:"dbfs,omitempty"`
 	// File location of init script. Destination must be provided. For example,
-	// `{ &#34;file&#34; : { &#34;destination&#34; : &#34;file:/my/local/file.sh&#34; } }`
+	// `{ "file" : { "destination" : "file:/my/local/file.sh" } }`
 	File *FileStorageInfo `json:"file,omitempty"`
 }
 
@@ -295,10 +295,10 @@ type JobSettings struct {
 	EmailNotifications *JobEmailNotifications `json:"email_notifications,omitempty"`
 	// Used to tell what is the format of the job. This field is ignored in
 	// Create/Update/Reset calls. When using the Jobs API 2.1 this value is
-	// always set to `&#34;MULTI_TASK&#34;`.
+	// always set to `"MULTI_TASK"`.
 	Format JobSettingsFormat `json:"format,omitempty"`
 	// An optional specification for a remote repository containing the
-	// notebooks used by this job&#39;s notebook tasks.
+	// notebooks used by this job's notebook tasks.
 	GitSource *GitSource `json:"git_source,omitempty"`
 	// A list of job cluster specifications that can be shared and reused by
 	// tasks of this job. Libraries cannot be declared in a shared job cluster.
@@ -337,7 +337,7 @@ type JobSettings struct {
 
 // Used to tell what is the format of the job. This field is ignored in
 // Create/Update/Reset calls. When using the Jobs API 2.1 this value is always
-// set to `&#34;MULTI_TASK&#34;`.
+// set to `"MULTI_TASK"`.
 type JobSettingsFormat string
 
 const JobSettingsFormatMultiTask JobSettingsFormat = `MULTI_TASK`
@@ -407,12 +407,12 @@ type Library struct {
 
 	Jar string `json:"jar,omitempty"`
 	// If maven, specification of a Maven library to be installed. For example:
-	// `{ &#34;coordinates&#34;: &#34;org.jsoup:jsoup:1.7.2&#34; }`
+	// `{ "coordinates": "org.jsoup:jsoup:1.7.2" }`
 	Maven *MavenLibrary `json:"maven,omitempty"`
 	// If pypi, specification of a PyPI library to be installed. Specifying the
 	// `repo` field is optional and if not specified, the default pip index is
-	// used. For example: `{ &#34;package&#34;: &#34;simplejson&#34;, &#34;repo&#34;:
-	// &#34;https://my-repo.com&#34; }`
+	// used. For example: `{ "package": "simplejson", "repo":
+	// "https://my-repo.com" }`
 	Pypi *PythonPyPiLibrary `json:"pypi,omitempty"`
 
 	Whl string `json:"whl,omitempty"`
@@ -430,9 +430,9 @@ type MavenLibrary struct {
 	// Gradle-style Maven coordinates. For example: `org.jsoup:jsoup:1.7.2`.
 	// This field is required.
 	Coordinates string `json:"coordinates"`
-	// List of dependences to exclude. For example: `[&#34;slf4j:slf4j&#34;,
-	// &#34;*:hadoop-client&#34;]`. Maven dependency exclusions:
-	// &lt;https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html&gt;.
+	// List of dependences to exclude. For example: `["slf4j:slf4j",
+	// "*:hadoop-client"]`. Maven dependency exclusions:
+	// <https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html>.
 	Exclusions []string `json:"exclusions,omitempty"`
 	// Maven repo to install the Maven package from. If omitted, both Maven
 	// Central Repository and Spark Packages are searched.
@@ -454,8 +454,8 @@ type NewCluster struct {
 	// destination. Only one destination can be specified for one cluster. If
 	// the conf is given, the logs are delivered to the destination every `5
 	// mins`. The destination of driver logs is
-	// `&lt;destination&gt;/&lt;cluster-id&gt;/driver`, while the destination of executor
-	// logs is `&lt;destination&gt;/&lt;cluster-id&gt;/executor`.
+	// `<destination>/<cluster-id>/driver`, while the destination of executor
+	// logs is `<destination>/<cluster-id>/executor`.
 	ClusterLogConf *ClusterLogConf `json:"cluster_log_conf,omitempty"`
 
 	CustomTags map[string]string `json:"custom_tags,omitempty"`
@@ -475,7 +475,7 @@ type NewCluster struct {
 	// The configuration for storing init scripts. Any number of scripts can be
 	// specified. The scripts are executed sequentially in the order provided.
 	// If `cluster_log_conf` is specified, init script logs are sent to
-	// `&lt;destination&gt;/&lt;cluster-id&gt;/init_scripts`.
+	// `<destination>/<cluster-id>/init_scripts`.
 	InitScripts []InitScriptInfo `json:"init_scripts,omitempty"`
 	// The optional ID of the instance pool to use for cluster nodes. If
 	// `driver_instance_pool_id` is present, `instance_pool_id` is used for
@@ -492,7 +492,7 @@ type NewCluster struct {
 	NodeTypeId string `json:"node_type_id"`
 	// If num_workers, number of worker nodes that this cluster must have. A
 	// cluster has one Spark driver and num_workers executors for a total of
-	// num_workers &#43; 1 Spark nodes. When reading the properties of a cluster,
+	// num_workers + 1 Spark nodes. When reading the properties of a cluster,
 	// this field reflects the desired number of workers rather than the actual
 	// current number of workers. For example, if a cluster is resized from 5 to
 	// 10 workers, this field immediately updates to reflect the target size of
@@ -505,20 +505,20 @@ type NewCluster struct {
 	// configuration key-value pairs. You can also pass in a string of extra JVM
 	// options to the driver and the executors via
 	// `spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions`
-	// respectively. Example Spark confs: `{&#34;spark.speculation&#34;: true,
-	// &#34;spark.streaming.ui.retainedBatches&#34;: 5}` or
-	// `{&#34;spark.driver.extraJavaOptions&#34;: &#34;-verbose:gc -XX:&#43;PrintGCDetails&#34;}`
+	// respectively. Example Spark confs: `{"spark.speculation": true,
+	// "spark.streaming.ui.retainedBatches": 5}` or
+	// `{"spark.driver.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails"}`
 	SparkConf map[string]any/* MISSING TYPE */ `json:"spark_conf,omitempty"`
 	// An object containing a set of optional, user-specified environment
 	// variable key-value pairs. Key-value pair of the form (X,Y) are exported
-	// as is (for example, `export X=&#39;Y&#39;`) while launching the driver and
+	// as is (for example, `export X='Y'`) while launching the driver and
 	// workers. To specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we
 	// recommend appending them to `$SPARK_DAEMON_JAVA_OPTS` as shown in the
 	// following example. This ensures that all default databricks managed
 	// environmental variables are included as well. Example Spark environment
-	// variables: `{&#34;SPARK_WORKER_MEMORY&#34;: &#34;28000m&#34;, &#34;SPARK_LOCAL_DIRS&#34;:
-	// &#34;/local_disk0&#34;}` or `{&#34;SPARK_DAEMON_JAVA_OPTS&#34;: &#34;$SPARK_DAEMON_JAVA_OPTS
-	// -Dspark.shuffle.service.enabled=true&#34;}`
+	// variables: `{"SPARK_WORKER_MEMORY": "28000m", "SPARK_LOCAL_DIRS":
+	// "/local_disk0"}` or `{"SPARK_DAEMON_JAVA_OPTS": "$SPARK_DAEMON_JAVA_OPTS
+	// -Dspark.shuffle.service.enabled=true"}`
 	SparkEnvVars map[string]any/* MISSING TYPE */ `json:"spark_env_vars,omitempty"`
 	// The Spark version of the cluster. A list of available Spark versions can
 	// be retrieved by using the [Runtime
@@ -584,7 +584,7 @@ type PythonWheelTask struct {
 	// `$packageName.$entryPoint()`
 	EntryPoint string `json:"entry_point,omitempty"`
 	// Command-line parameters passed to Python wheel task in the form of
-	// `[&#34;--name=task&#34;, &#34;--data=dbfs:/path/to/data.json&#34;]`. Leave it empty if
+	// `["--name=task", "--data=dbfs:/path/to/data.json"]`. Leave it empty if
 	// `parameters` is not null.
 	NamedParameters any/* MISSING TYPE */ `json:"named_parameters,omitempty"`
 	// Name of the package to execute
@@ -630,11 +630,11 @@ const RepairHistoryItemTypeRepair RepairHistoryItemType = `REPAIR`
 
 type RepairRun struct {
 	// A list of parameters for jobs with Spark JAR tasks, for example
-	// `&#34;jar_params&#34;: [&#34;john doe&#34;, &#34;35&#34;]`. The parameters are used to invoke the
+	// `"jar_params": ["john doe", "35"]`. The parameters are used to invoke the
 	// main function of the main class specified in the Spark JAR task. If not
 	// specified upon `run-now`, it defaults to an empty list. jar_params cannot
 	// be specified in conjunction with notebook_params. The JSON representation
-	// of this field (for example `{&#34;jar_params&#34;:[&#34;john doe&#34;,&#34;35&#34;]}`) cannot
+	// of this field (for example `{"jar_params":["john doe","35"]}`) cannot
 	// exceed 10,000 bytes. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs.
@@ -644,7 +644,7 @@ type RepairRun struct {
 	// requests to repair the same run.
 	LatestRepairId int64 `json:"latest_repair_id,omitempty"`
 	// A map from keys to values for jobs with notebook task, for example
-	// `&#34;notebook_params&#34;: {&#34;name&#34;: &#34;john doe&#34;, &#34;age&#34;: &#34;35&#34;}`. The map is passed
+	// `"notebook_params": {"name": "john doe", "age": "35"}`. The map is passed
 	// to the notebook and is accessible through the
 	// [dbutils.widgets.get](..dev-tools/databricks-utilshtml#dbutils-widgets)
 	// function. If not specified upon `run-now`, the triggered run uses the
@@ -652,21 +652,21 @@ type RepairRun struct {
 	// with jar_params. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs. The JSON representation of this field (for
-	// example `{&#34;notebook_params&#34;:{&#34;name&#34;:&#34;john doe&#34;,&#34;age&#34;:&#34;35&#34;}}`) cannot
+	// example `{"notebook_params":{"name":"john doe","age":"35"}}`) cannot
 	// exceed 10,000 bytes.
 	NotebookParams map[string]string `json:"notebook_params,omitempty"`
 
 	PipelineParams *RepairRunPipelineParams `json:"pipeline_params,omitempty"`
 	// A map from keys to values for jobs with Python wheel task, for example
-	// `&#34;python_named_params&#34;: {&#34;name&#34;: &#34;task&#34;, &#34;data&#34;:
-	// &#34;dbfs:/path/to/data.json&#34;}`.
+	// `"python_named_params": {"name": "task", "data":
+	// "dbfs:/path/to/data.json"}`.
 	PythonNamedParams map[string]string `json:"python_named_params,omitempty"`
 	// A list of parameters for jobs with Python tasks, for example
-	// `&#34;python_params&#34;: [&#34;john doe&#34;, &#34;35&#34;]`. The parameters are passed to
+	// `"python_params": ["john doe", "35"]`. The parameters are passed to
 	// Python file as command-line parameters. If specified upon `run-now`, it
 	// would overwrite the parameters specified in job setting. The JSON
-	// representation of this field (for example `{&#34;python_params&#34;:[&#34;john
-	// doe&#34;,&#34;35&#34;]}`) cannot exceed 10,000 bytes. Use [Task parameter
+	// representation of this field (for example `{"python_params":["john
+	// doe","35"]}`) cannot exceed 10,000 bytes. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs. Important These parameters accept only Latin
 	// characters (ASCII character set). Using non-ASCII characters returns an
@@ -678,12 +678,12 @@ type RepairRun struct {
 	// The job run ID of the run to repair. The run must not be in progress.
 	RunId int64 `json:"run_id,omitempty"`
 	// A list of parameters for jobs with spark submit task, for example
-	// `&#34;spark_submit_params&#34;: [&#34;--class&#34;,
-	// &#34;org.apache.spark.examples.SparkPi&#34;]`. The parameters are passed to
+	// `"spark_submit_params": ["--class",
+	// "org.apache.spark.examples.SparkPi"]`. The parameters are passed to
 	// spark-submit script as command-line parameters. If specified upon
 	// `run-now`, it would overwrite the parameters specified in job setting.
 	// The JSON representation of this field (for example
-	// `{&#34;python_params&#34;:[&#34;john doe&#34;,&#34;35&#34;]}`) cannot exceed 10,000 bytes. Use
+	// `{"python_params":["john doe","35"]}`) cannot exceed 10,000 bytes. Use
 	// [Task parameter variables](..jobshtml#parameter-variables) to set
 	// parameters containing information about job runs. Important These
 	// parameters accept only Latin characters (ASCII character set). Using
@@ -709,7 +709,7 @@ type ResetJob struct {
 type Run struct {
 	// The sequence number of this run attempt for a triggered job run. The
 	// initial attempt of a run has an attempt_number of 0\. If the initial run
-	// attempt fails, and the job has a retry policy (`max_retries` \&gt; 0),
+	// attempt fails, and the job has a retry policy (`max_retries` \> 0),
 	// subsequent runs are created with an `original_attempt_run_id` of the
 	// original attempt?s ID and an incrementing `attempt_number`. Runs are
 	// retried only until they succeed, and the maximum `attempt_number` is the
@@ -736,7 +736,7 @@ type Run struct {
 	// encountered an unexpected error.
 	ExecutionDuration int64 `json:"execution_duration,omitempty"`
 	// An optional specification for a remote repository containing the
-	// notebooks used by this job&#39;s notebook tasks.
+	// notebooks used by this job's notebook tasks.
 	GitSource *GitSource `json:"git_source,omitempty"`
 	// A list of job cluster specifications that can be shared and reused by
 	// tasks of this job. Libraries cannot be declared in a shared job cluster.
@@ -909,11 +909,11 @@ type RunNow struct {
 	// jobs](https://kb.databricks.com/jobs/jobs-idempotency.html).
 	IdempotencyToken string `json:"idempotency_token,omitempty"`
 	// A list of parameters for jobs with Spark JAR tasks, for example
-	// `&#34;jar_params&#34;: [&#34;john doe&#34;, &#34;35&#34;]`. The parameters are used to invoke the
+	// `"jar_params": ["john doe", "35"]`. The parameters are used to invoke the
 	// main function of the main class specified in the Spark JAR task. If not
 	// specified upon `run-now`, it defaults to an empty list. jar_params cannot
 	// be specified in conjunction with notebook_params. The JSON representation
-	// of this field (for example `{&#34;jar_params&#34;:[&#34;john doe&#34;,&#34;35&#34;]}`) cannot
+	// of this field (for example `{"jar_params":["john doe","35"]}`) cannot
 	// exceed 10,000 bytes. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs.
@@ -921,7 +921,7 @@ type RunNow struct {
 	// The ID of the job to be executed
 	JobId int64 `json:"job_id,omitempty"`
 	// A map from keys to values for jobs with notebook task, for example
-	// `&#34;notebook_params&#34;: {&#34;name&#34;: &#34;john doe&#34;, &#34;age&#34;: &#34;35&#34;}`. The map is passed
+	// `"notebook_params": {"name": "john doe", "age": "35"}`. The map is passed
 	// to the notebook and is accessible through the
 	// [dbutils.widgets.get](..dev-tools/databricks-utilshtml#dbutils-widgets)
 	// function. If not specified upon `run-now`, the triggered run uses the
@@ -929,21 +929,21 @@ type RunNow struct {
 	// with jar_params. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs. The JSON representation of this field (for
-	// example `{&#34;notebook_params&#34;:{&#34;name&#34;:&#34;john doe&#34;,&#34;age&#34;:&#34;35&#34;}}`) cannot
+	// example `{"notebook_params":{"name":"john doe","age":"35"}}`) cannot
 	// exceed 10,000 bytes.
 	NotebookParams map[string]string `json:"notebook_params,omitempty"`
 
 	PipelineParams *RunNowPipelineParams `json:"pipeline_params,omitempty"`
 	// A map from keys to values for jobs with Python wheel task, for example
-	// `&#34;python_named_params&#34;: {&#34;name&#34;: &#34;task&#34;, &#34;data&#34;:
-	// &#34;dbfs:/path/to/data.json&#34;}`.
+	// `"python_named_params": {"name": "task", "data":
+	// "dbfs:/path/to/data.json"}`.
 	PythonNamedParams map[string]string `json:"python_named_params,omitempty"`
 	// A list of parameters for jobs with Python tasks, for example
-	// `&#34;python_params&#34;: [&#34;john doe&#34;, &#34;35&#34;]`. The parameters are passed to
+	// `"python_params": ["john doe", "35"]`. The parameters are passed to
 	// Python file as command-line parameters. If specified upon `run-now`, it
 	// would overwrite the parameters specified in job setting. The JSON
-	// representation of this field (for example `{&#34;python_params&#34;:[&#34;john
-	// doe&#34;,&#34;35&#34;]}`) cannot exceed 10,000 bytes. Use [Task parameter
+	// representation of this field (for example `{"python_params":["john
+	// doe","35"]}`) cannot exceed 10,000 bytes. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs. Important These parameters accept only Latin
 	// characters (ASCII character set). Using non-ASCII characters returns an
@@ -951,12 +951,12 @@ type RunNow struct {
 	// kanjis, and emojis.
 	PythonParams []string `json:"python_params,omitempty"`
 	// A list of parameters for jobs with spark submit task, for example
-	// `&#34;spark_submit_params&#34;: [&#34;--class&#34;,
-	// &#34;org.apache.spark.examples.SparkPi&#34;]`. The parameters are passed to
+	// `"spark_submit_params": ["--class",
+	// "org.apache.spark.examples.SparkPi"]`. The parameters are passed to
 	// spark-submit script as command-line parameters. If specified upon
 	// `run-now`, it would overwrite the parameters specified in job setting.
 	// The JSON representation of this field (for example
-	// `{&#34;python_params&#34;:[&#34;john doe&#34;,&#34;35&#34;]}`) cannot exceed 10,000 bytes. Use
+	// `{"python_params":["john doe","35"]}`) cannot exceed 10,000 bytes. Use
 	// [Task parameter variables](..jobshtml#parameter-variables) to set
 	// parameters containing information about job runs. Important These
 	// parameters accept only Latin characters (ASCII character set). Using
@@ -991,7 +991,7 @@ type RunOutput struct {
 	// [SparkJarTask](..dev-tools/api/latest/jobshtml#/components/schemas/SparkJarTask),
 	// [SparkPythonTask](..dev-tools/api/latest/jobshtml#/components/schemas/SparkPythonTask,
 	// [PythonWheelTask](..dev-tools/api/latest/jobshtml#/components/schemas/PythonWheelTask.
-	// It&#39;s not supported for the
+	// It's not supported for the
 	// [NotebookTask](..dev-tools/api/latest/jobshtml#/components/schemas/NotebookTask,
 	// [PipelineTask](..dev-tools/api/latest/jobshtml#/components/schemas/PipelineTask,
 	// or
@@ -1014,17 +1014,17 @@ type RunOutput struct {
 
 type RunParameters struct {
 	// A list of parameters for jobs with Spark JAR tasks, for example
-	// `&#34;jar_params&#34;: [&#34;john doe&#34;, &#34;35&#34;]`. The parameters are used to invoke the
+	// `"jar_params": ["john doe", "35"]`. The parameters are used to invoke the
 	// main function of the main class specified in the Spark JAR task. If not
 	// specified upon `run-now`, it defaults to an empty list. jar_params cannot
 	// be specified in conjunction with notebook_params. The JSON representation
-	// of this field (for example `{&#34;jar_params&#34;:[&#34;john doe&#34;,&#34;35&#34;]}`) cannot
+	// of this field (for example `{"jar_params":["john doe","35"]}`) cannot
 	// exceed 10,000 bytes. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs.
 	JarParams []string `json:"jar_params,omitempty"`
 	// A map from keys to values for jobs with notebook task, for example
-	// `&#34;notebook_params&#34;: {&#34;name&#34;: &#34;john doe&#34;, &#34;age&#34;: &#34;35&#34;}`. The map is passed
+	// `"notebook_params": {"name": "john doe", "age": "35"}`. The map is passed
 	// to the notebook and is accessible through the
 	// [dbutils.widgets.get](..dev-tools/databricks-utilshtml#dbutils-widgets)
 	// function. If not specified upon `run-now`, the triggered run uses the
@@ -1032,21 +1032,21 @@ type RunParameters struct {
 	// with jar_params. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs. The JSON representation of this field (for
-	// example `{&#34;notebook_params&#34;:{&#34;name&#34;:&#34;john doe&#34;,&#34;age&#34;:&#34;35&#34;}}`) cannot
+	// example `{"notebook_params":{"name":"john doe","age":"35"}}`) cannot
 	// exceed 10,000 bytes.
 	NotebookParams map[string]string `json:"notebook_params,omitempty"`
 
 	PipelineParams *RunParametersPipelineParams `json:"pipeline_params,omitempty"`
 	// A map from keys to values for jobs with Python wheel task, for example
-	// `&#34;python_named_params&#34;: {&#34;name&#34;: &#34;task&#34;, &#34;data&#34;:
-	// &#34;dbfs:/path/to/data.json&#34;}`.
+	// `"python_named_params": {"name": "task", "data":
+	// "dbfs:/path/to/data.json"}`.
 	PythonNamedParams map[string]string `json:"python_named_params,omitempty"`
 	// A list of parameters for jobs with Python tasks, for example
-	// `&#34;python_params&#34;: [&#34;john doe&#34;, &#34;35&#34;]`. The parameters are passed to
+	// `"python_params": ["john doe", "35"]`. The parameters are passed to
 	// Python file as command-line parameters. If specified upon `run-now`, it
 	// would overwrite the parameters specified in job setting. The JSON
-	// representation of this field (for example `{&#34;python_params&#34;:[&#34;john
-	// doe&#34;,&#34;35&#34;]}`) cannot exceed 10,000 bytes. Use [Task parameter
+	// representation of this field (for example `{"python_params":["john
+	// doe","35"]}`) cannot exceed 10,000 bytes. Use [Task parameter
 	// variables](..jobshtml#parameter-variables) to set parameters containing
 	// information about job runs. Important These parameters accept only Latin
 	// characters (ASCII character set). Using non-ASCII characters returns an
@@ -1054,12 +1054,12 @@ type RunParameters struct {
 	// kanjis, and emojis.
 	PythonParams []string `json:"python_params,omitempty"`
 	// A list of parameters for jobs with spark submit task, for example
-	// `&#34;spark_submit_params&#34;: [&#34;--class&#34;,
-	// &#34;org.apache.spark.examples.SparkPi&#34;]`. The parameters are passed to
+	// `"spark_submit_params": ["--class",
+	// "org.apache.spark.examples.SparkPi"]`. The parameters are passed to
 	// spark-submit script as command-line parameters. If specified upon
 	// `run-now`, it would overwrite the parameters specified in job setting.
 	// The JSON representation of this field (for example
-	// `{&#34;python_params&#34;:[&#34;john doe&#34;,&#34;35&#34;]}`) cannot exceed 10,000 bytes. Use
+	// `{"python_params":["john doe","35"]}`) cannot exceed 10,000 bytes. Use
 	// [Task parameter variables](..jobshtml#parameter-variables) to set
 	// parameters containing information about job runs. Important These
 	// parameters accept only Latin characters (ASCII character set). Using
@@ -1149,7 +1149,7 @@ type RunSubmitTaskSettings struct {
 type RunTask struct {
 	// The sequence number of this run attempt for a triggered job run. The
 	// initial attempt of a run has an attempt_number of 0\. If the initial run
-	// attempt fails, and the job has a retry policy (`max_retries` \&gt; 0),
+	// attempt fails, and the job has a retry policy (`max_retries` \> 0),
 	// subsequent runs are created with an `original_attempt_run_id` of the
 	// original attempt?s ID and an incrementing `attempt_number`. Runs are
 	// retried only until they succeed, and the maximum `attempt_number` is the
@@ -1180,7 +1180,7 @@ type RunTask struct {
 	// running jobs on new clusters for greater reliability.
 	ExistingClusterId string `json:"existing_cluster_id,omitempty"`
 	// An optional specification for a remote repository containing the
-	// notebooks used by this job&#39;s notebook tasks.
+	// notebooks used by this job's notebook tasks.
 	GitSource *GitSource `json:"git_source,omitempty"`
 	// An optional list of libraries to be installed on the cluster that
 	// executes the job. The default value is an empty list.
@@ -1294,7 +1294,7 @@ type SubmitRun struct {
 	// List of permissions to set on the job.
 	AccessControlList any/* MISSING TYPE */ `json:"access_control_list,omitempty"`
 	// An optional specification for a remote repository containing the
-	// notebooks used by this job&#39;s notebook tasks.
+	// notebooks used by this job's notebook tasks.
 	GitSource *GitSource `json:"git_source,omitempty"`
 	// An optional token that can be used to guarantee the idempotency of job
 	// run requests. If a run with the provided token already exists, the

--- a/service/libraries/api.go
+++ b/service/libraries/api.go
@@ -24,12 +24,12 @@ type LibrariesAPI struct {
 // UI. If a library has been set to be installed on all clusters,
 // “is_library_for_all_clusters“ will be “true“, even if the library was
 // also installed on this specific cluster.. An example response: .. code:: {
-// &#34;statuses&#34;: [ { &#34;cluster_id&#34;: &#34;11203-my-cluster&#34;, &#34;library_statuses&#34;: [ {
-// &#34;library&#34;: { &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, &#34;status&#34;:
-// &#34;INSTALLING&#34;, &#34;messages&#34;: [], &#34;is_library_for_all_clusters&#34;: false } ] }, {
-// &#34;cluster_id&#34;: &#34;20131-my-other-cluster&#34;, &#34;library_statuses&#34;: [ { &#34;library&#34;: {
-// &#34;egg&#34;: &#34;dbfs:/mnt/libraries/library.egg&#34; }, &#34;status&#34;: &#34;ERROR&#34;, &#34;messages&#34;:
-// [&#34;Could not download library&#34;], &#34;is_library_for_all_clusters&#34;: false } ] } ]
+// "statuses": [ { "cluster_id": "11203-my-cluster", "library_statuses": [ {
+// "library": { "jar": "dbfs:/mnt/libraries/library.jar" }, "status":
+// "INSTALLING", "messages": [], "is_library_for_all_clusters": false } ] }, {
+// "cluster_id": "20131-my-other-cluster", "library_statuses": [ { "library": {
+// "egg": "dbfs:/mnt/libraries/library.egg" }, "status": "ERROR", "messages":
+// ["Could not download library"], "is_library_for_all_clusters": false } ] } ]
 // }
 func (a *LibrariesAPI) AllClusterStatuses(ctx context.Context) (*ListAllClusterLibraryStatusesResponse, error) {
 	var listAllClusterLibraryStatusesResponse ListAllClusterLibraryStatusesResponse
@@ -52,16 +52,16 @@ func (a *LibrariesAPI) AllClusterStatuses(ctx context.Context) (*ListAllClusterL
 // but now marked for removal. Within this group there is no order guarantee. An
 // example request: .. code::
 // /libraries/cluster-status?cluster_id=11203-my-cluster And response: .. code::
-// { &#34;cluster_id&#34;: &#34;11203-my-cluster&#34;, &#34;library_statuses&#34;: [ { &#34;library&#34;: {
-// &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, &#34;status&#34;: &#34;INSTALLED&#34;,
-// &#34;messages&#34;: [], &#34;is_library_for_all_clusters&#34;: false }, { &#34;library&#34;: {
-// &#34;pypi&#34;: { &#34;package&#34;: &#34;beautifulsoup4&#34; }, }, &#34;status&#34;: &#34;INSTALLING&#34;,
-// &#34;messages&#34;: [&#34;Successfully resolved package from PyPI&#34;],
-// &#34;is_library_for_all_clusters&#34;: false }, { &#34;library&#34;: { &#34;cran&#34;: { &#34;package&#34;:
-// &#34;ada&#34;, &#34;repo&#34;: &#34;http://cran.us.r-project.org&#34; }, }, &#34;status&#34;: &#34;FAILED&#34;,
-// &#34;messages&#34;: [&#34;R package installation is not supported on this spark
-// version.\nPlease upgrade to Runtime 3.2 or higher&#34;],
-// &#34;is_library_for_all_clusters&#34;: false } ] }
+// { "cluster_id": "11203-my-cluster", "library_statuses": [ { "library": {
+// "jar": "dbfs:/mnt/libraries/library.jar" }, "status": "INSTALLED",
+// "messages": [], "is_library_for_all_clusters": false }, { "library": {
+// "pypi": { "package": "beautifulsoup4" }, }, "status": "INSTALLING",
+// "messages": ["Successfully resolved package from PyPI"],
+// "is_library_for_all_clusters": false }, { "library": { "cran": { "package":
+// "ada", "repo": "http://cran.us.r-project.org" }, }, "status": "FAILED",
+// "messages": ["R package installation is not supported on this spark
+// version.\nPlease upgrade to Runtime 3.2 or higher"],
+// "is_library_for_all_clusters": false } ] }
 func (a *LibrariesAPI) ClusterStatus(ctx context.Context, request ClusterStatusRequest) (*ClusterStatusResponse, error) {
 	var clusterStatusResponse ClusterStatusResponse
 	path := "/api/2.0/libraries/cluster-status"
@@ -83,16 +83,16 @@ func (a *LibrariesAPI) ClusterStatus(ctx context.Context, request ClusterStatusR
 // but now marked for removal. Within this group there is no order guarantee. An
 // example request: .. code::
 // /libraries/cluster-status?cluster_id=11203-my-cluster And response: .. code::
-// { &#34;cluster_id&#34;: &#34;11203-my-cluster&#34;, &#34;library_statuses&#34;: [ { &#34;library&#34;: {
-// &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, &#34;status&#34;: &#34;INSTALLED&#34;,
-// &#34;messages&#34;: [], &#34;is_library_for_all_clusters&#34;: false }, { &#34;library&#34;: {
-// &#34;pypi&#34;: { &#34;package&#34;: &#34;beautifulsoup4&#34; }, }, &#34;status&#34;: &#34;INSTALLING&#34;,
-// &#34;messages&#34;: [&#34;Successfully resolved package from PyPI&#34;],
-// &#34;is_library_for_all_clusters&#34;: false }, { &#34;library&#34;: { &#34;cran&#34;: { &#34;package&#34;:
-// &#34;ada&#34;, &#34;repo&#34;: &#34;http://cran.us.r-project.org&#34; }, }, &#34;status&#34;: &#34;FAILED&#34;,
-// &#34;messages&#34;: [&#34;R package installation is not supported on this spark
-// version.\nPlease upgrade to Runtime 3.2 or higher&#34;],
-// &#34;is_library_for_all_clusters&#34;: false } ] }
+// { "cluster_id": "11203-my-cluster", "library_statuses": [ { "library": {
+// "jar": "dbfs:/mnt/libraries/library.jar" }, "status": "INSTALLED",
+// "messages": [], "is_library_for_all_clusters": false }, { "library": {
+// "pypi": { "package": "beautifulsoup4" }, }, "status": "INSTALLING",
+// "messages": ["Successfully resolved package from PyPI"],
+// "is_library_for_all_clusters": false }, { "library": { "cran": { "package":
+// "ada", "repo": "http://cran.us.r-project.org" }, }, "status": "FAILED",
+// "messages": ["R package installation is not supported on this spark
+// version.\nPlease upgrade to Runtime 3.2 or higher"],
+// "is_library_for_all_clusters": false } ] }
 func (a *LibrariesAPI) ClusterStatusByClusterId(ctx context.Context, clusterId string) (*ClusterStatusResponse, error) {
 	return a.ClusterStatus(ctx, ClusterStatusRequest{
 		ClusterId: clusterId,
@@ -105,24 +105,24 @@ func (a *LibrariesAPI) ClusterStatusByClusterId(ctx context.Context, clusterId s
 // the libraries specified via this method and the libraries set to be installed
 // on all clusters via the libraries UI. Note that CRAN libraries can only be
 // installed on clusters running Databricks Runtime 3.2 or higher. An example
-// request: .. code:: { &#34;cluster_id&#34;: &#34;10201-my-cluster&#34;, &#34;libraries&#34;: [ {
-// &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, { &#34;egg&#34;:
-// &#34;dbfs:/mnt/libraries/library.egg&#34; }, { &#34;whl&#34;:
-// &#34;dbfs:/mnt/libraries/library.whl&#34; }, { &#34;maven&#34;: { &#34;coordinates&#34;:
-// &#34;org.jsoup:jsoup:1.7.2&#34;, &#34;exclusions&#34;: [&#34;slf4j:slf4j&#34;] } }, { &#34;pypi&#34;: {
-// &#34;package&#34;: &#34;simplejson&#34;, &#34;repo&#34;: &#34;http://my-pypi-mirror.com&#34; } }, { &#34;cran&#34;: {
-// &#34;package: &#34;ada&#34;, &#34;repo&#34;: &#34;http://cran.us.r-project.org&#34; } } ] }
+// request: .. code:: { "cluster_id": "10201-my-cluster", "libraries": [ {
+// "jar": "dbfs:/mnt/libraries/library.jar" }, { "egg":
+// "dbfs:/mnt/libraries/library.egg" }, { "whl":
+// "dbfs:/mnt/libraries/library.whl" }, { "maven": { "coordinates":
+// "org.jsoup:jsoup:1.7.2", "exclusions": ["slf4j:slf4j"] } }, { "pypi": {
+// "package": "simplejson", "repo": "http://my-pypi-mirror.com" } }, { "cran": {
+// "package: "ada", "repo": "http://cran.us.r-project.org" } } ] }
 func (a *LibrariesAPI) Install(ctx context.Context, request InstallLibrariesRequest) error {
 	path := "/api/2.0/libraries/install"
 	err := a.client.Post(ctx, path, request, nil)
 	return err
 }
 
-// Set libraries to be uninstalled on a cluster. The libraries won&#39;t be
+// Set libraries to be uninstalled on a cluster. The libraries won't be
 // uninstalled until the cluster is restarted. Uninstalling libraries that are
 // not installed on the cluster will have no impact but is not an error. An
-// example request: .. code:: { &#34;cluster_id&#34;: &#34;10201-my-cluster&#34;, &#34;libraries&#34;: [
-// { &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, { &#34;cran&#34;: &#34;ada&#34; } ] }
+// example request: .. code:: { "cluster_id": "10201-my-cluster", "libraries": [
+// { "jar": "dbfs:/mnt/libraries/library.jar" }, { "cran": "ada" } ] }
 func (a *LibrariesAPI) Uninstall(ctx context.Context, request UninstallLibrariesRequest) error {
 	path := "/api/2.0/libraries/uninstall"
 	err := a.client.Post(ctx, path, request, nil)

--- a/service/libraries/interface.go
+++ b/service/libraries/interface.go
@@ -16,13 +16,13 @@ type LibrariesService interface {
 	// the libraries UI. If a library has been set to be installed on all
 	// clusters, ``is_library_for_all_clusters`` will be ``true``, even if the
 	// library was also installed on this specific cluster.. An example
-	// response: .. code:: { &#34;statuses&#34;: [ { &#34;cluster_id&#34;: &#34;11203-my-cluster&#34;,
-	// &#34;library_statuses&#34;: [ { &#34;library&#34;: { &#34;jar&#34;:
-	// &#34;dbfs:/mnt/libraries/library.jar&#34; }, &#34;status&#34;: &#34;INSTALLING&#34;, &#34;messages&#34;:
-	// [], &#34;is_library_for_all_clusters&#34;: false } ] }, { &#34;cluster_id&#34;:
-	// &#34;20131-my-other-cluster&#34;, &#34;library_statuses&#34;: [ { &#34;library&#34;: { &#34;egg&#34;:
-	// &#34;dbfs:/mnt/libraries/library.egg&#34; }, &#34;status&#34;: &#34;ERROR&#34;, &#34;messages&#34;:
-	// [&#34;Could not download library&#34;], &#34;is_library_for_all_clusters&#34;: false } ]
+	// response: .. code:: { "statuses": [ { "cluster_id": "11203-my-cluster",
+	// "library_statuses": [ { "library": { "jar":
+	// "dbfs:/mnt/libraries/library.jar" }, "status": "INSTALLING", "messages":
+	// [], "is_library_for_all_clusters": false } ] }, { "cluster_id":
+	// "20131-my-other-cluster", "library_statuses": [ { "library": { "egg":
+	// "dbfs:/mnt/libraries/library.egg" }, "status": "ERROR", "messages":
+	// ["Could not download library"], "is_library_for_all_clusters": false } ]
 	// } ] }
 	AllClusterStatuses(ctx context.Context) (*ListAllClusterLibraryStatusesResponse, error)
 
@@ -40,16 +40,16 @@ type LibrariesService interface {
 	// on this cluster or on all clusters, but now marked for removal. Within
 	// this group there is no order guarantee. An example request: .. code::
 	// /libraries/cluster-status?cluster_id=11203-my-cluster And response: ..
-	// code:: { &#34;cluster_id&#34;: &#34;11203-my-cluster&#34;, &#34;library_statuses&#34;: [ {
-	// &#34;library&#34;: { &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, &#34;status&#34;:
-	// &#34;INSTALLED&#34;, &#34;messages&#34;: [], &#34;is_library_for_all_clusters&#34;: false }, {
-	// &#34;library&#34;: { &#34;pypi&#34;: { &#34;package&#34;: &#34;beautifulsoup4&#34; }, }, &#34;status&#34;:
-	// &#34;INSTALLING&#34;, &#34;messages&#34;: [&#34;Successfully resolved package from PyPI&#34;],
-	// &#34;is_library_for_all_clusters&#34;: false }, { &#34;library&#34;: { &#34;cran&#34;: {
-	// &#34;package&#34;: &#34;ada&#34;, &#34;repo&#34;: &#34;http://cran.us.r-project.org&#34; }, }, &#34;status&#34;:
-	// &#34;FAILED&#34;, &#34;messages&#34;: [&#34;R package installation is not supported on this
-	// spark version.\nPlease upgrade to Runtime 3.2 or higher&#34;],
-	// &#34;is_library_for_all_clusters&#34;: false } ] }
+	// code:: { "cluster_id": "11203-my-cluster", "library_statuses": [ {
+	// "library": { "jar": "dbfs:/mnt/libraries/library.jar" }, "status":
+	// "INSTALLED", "messages": [], "is_library_for_all_clusters": false }, {
+	// "library": { "pypi": { "package": "beautifulsoup4" }, }, "status":
+	// "INSTALLING", "messages": ["Successfully resolved package from PyPI"],
+	// "is_library_for_all_clusters": false }, { "library": { "cran": {
+	// "package": "ada", "repo": "http://cran.us.r-project.org" }, }, "status":
+	// "FAILED", "messages": ["R package installation is not supported on this
+	// spark version.\nPlease upgrade to Runtime 3.2 or higher"],
+	// "is_library_for_all_clusters": false } ] }
 	ClusterStatus(ctx context.Context, clusterStatusRequest ClusterStatusRequest) (*ClusterStatusResponse, error)
 
 	ClusterStatusByClusterId(ctx context.Context, clusterId string) (*ClusterStatusResponse, error)
@@ -59,21 +59,21 @@ type LibrariesService interface {
 	// cluster is the union of the libraries specified via this method and the
 	// libraries set to be installed on all clusters via the libraries UI. Note
 	// that CRAN libraries can only be installed on clusters running Databricks
-	// Runtime 3.2 or higher. An example request: .. code:: { &#34;cluster_id&#34;:
-	// &#34;10201-my-cluster&#34;, &#34;libraries&#34;: [ { &#34;jar&#34;:
-	// &#34;dbfs:/mnt/libraries/library.jar&#34; }, { &#34;egg&#34;:
-	// &#34;dbfs:/mnt/libraries/library.egg&#34; }, { &#34;whl&#34;:
-	// &#34;dbfs:/mnt/libraries/library.whl&#34; }, { &#34;maven&#34;: { &#34;coordinates&#34;:
-	// &#34;org.jsoup:jsoup:1.7.2&#34;, &#34;exclusions&#34;: [&#34;slf4j:slf4j&#34;] } }, { &#34;pypi&#34;: {
-	// &#34;package&#34;: &#34;simplejson&#34;, &#34;repo&#34;: &#34;http://my-pypi-mirror.com&#34; } }, {
-	// &#34;cran&#34;: { &#34;package: &#34;ada&#34;, &#34;repo&#34;: &#34;http://cran.us.r-project.org&#34; } } ] }
+	// Runtime 3.2 or higher. An example request: .. code:: { "cluster_id":
+	// "10201-my-cluster", "libraries": [ { "jar":
+	// "dbfs:/mnt/libraries/library.jar" }, { "egg":
+	// "dbfs:/mnt/libraries/library.egg" }, { "whl":
+	// "dbfs:/mnt/libraries/library.whl" }, { "maven": { "coordinates":
+	// "org.jsoup:jsoup:1.7.2", "exclusions": ["slf4j:slf4j"] } }, { "pypi": {
+	// "package": "simplejson", "repo": "http://my-pypi-mirror.com" } }, {
+	// "cran": { "package: "ada", "repo": "http://cran.us.r-project.org" } } ] }
 	Install(ctx context.Context, installLibrariesRequest InstallLibrariesRequest) error
 
-	// Set libraries to be uninstalled on a cluster. The libraries won&#39;t be
+	// Set libraries to be uninstalled on a cluster. The libraries won't be
 	// uninstalled until the cluster is restarted. Uninstalling libraries that
 	// are not installed on the cluster will have no impact but is not an error.
-	// An example request: .. code:: { &#34;cluster_id&#34;: &#34;10201-my-cluster&#34;,
-	// &#34;libraries&#34;: [ { &#34;jar&#34;: &#34;dbfs:/mnt/libraries/library.jar&#34; }, { &#34;cran&#34;:
-	// &#34;ada&#34; } ] }
+	// An example request: .. code:: { "cluster_id": "10201-my-cluster",
+	// "libraries": [ { "jar": "dbfs:/mnt/libraries/library.jar" }, { "cran":
+	// "ada" } ] }
 	Uninstall(ctx context.Context, uninstallLibrariesRequest UninstallLibrariesRequest) error
 }

--- a/service/libraries/model.go
+++ b/service/libraries/model.go
@@ -34,25 +34,25 @@ type Library struct {
 	// Specification of a CRAN library to be installed as part of the library
 	Cran *RCranLibrary `json:"cran,omitempty"`
 	// URI of the egg to be installed. Currently only DBFS and S3 URIs are
-	// supported. For example: ``{ &#34;egg&#34;: &#34;dbfs:/my/egg&#34; }`` or ``{ &#34;egg&#34;:
-	// &#34;s3://my-bucket/egg&#34; }``. If S3 is used, please make sure the cluster has
+	// supported. For example: ``{ "egg": "dbfs:/my/egg" }`` or ``{ "egg":
+	// "s3://my-bucket/egg" }``. If S3 is used, please make sure the cluster has
 	// read access on the library. You may need to launch the cluster with an
 	// IAM role to access the S3 URI.
 	Egg string `json:"egg,omitempty"`
 	// URI of the jar to be installed. Currently only DBFS and S3 URIs are
-	// supported. For example: ``{ &#34;jar&#34;: &#34;dbfs:/mnt/databricks/library.jar&#34; }``
-	// or ``{ &#34;jar&#34;: &#34;s3://my-bucket/library.jar&#34; }``. If S3 is used, please
+	// supported. For example: ``{ "jar": "dbfs:/mnt/databricks/library.jar" }``
+	// or ``{ "jar": "s3://my-bucket/library.jar" }``. If S3 is used, please
 	// make sure the cluster has read access on the library. You may need to
 	// launch the cluster with an IAM role to access the S3 URI.
 	Jar string `json:"jar,omitempty"`
 	// Specification of a maven library to be installed. For example: ``{
-	// &#34;coordinates&#34;: &#34;org.jsoup:jsoup:1.7.2&#34; }``
+	// "coordinates": "org.jsoup:jsoup:1.7.2" }``
 	Maven *MavenLibrary `json:"maven,omitempty"`
 	// Specification of a PyPi library to be installed. For example: ``{
-	// &#34;package&#34;: &#34;simplejson&#34; }``
+	// "package": "simplejson" }``
 	Pypi *PythonPyPiLibrary `json:"pypi,omitempty"`
-	// URI of the wheel to be installed. For example: ``{ &#34;whl&#34;: &#34;dbfs:/my/whl&#34;
-	// }`` or ``{ &#34;whl&#34;: &#34;s3://my-bucket/whl&#34; }``. If S3 is used, please make
+	// URI of the wheel to be installed. For example: ``{ "whl": "dbfs:/my/whl"
+	// }`` or ``{ "whl": "s3://my-bucket/whl" }``. If S3 is used, please make
 	// sure the cluster has read access on the library. You may need to launch
 	// the cluster with an IAM role to access the S3 URI.
 	Whl string `json:"whl,omitempty"`
@@ -94,10 +94,10 @@ type ListAllClusterLibraryStatusesResponse struct {
 }
 
 type MavenLibrary struct {
-	// Gradle-style maven coordinates. For example: &#34;org.jsoup:jsoup:1.7.2&#34;.
+	// Gradle-style maven coordinates. For example: "org.jsoup:jsoup:1.7.2".
 	Coordinates string `json:"coordinates"`
-	// List of dependences to exclude. For example: ``[&#34;slf4j:slf4j&#34;,
-	// &#34;*:hadoop-client&#34;]``. Maven dependency exclusions:
+	// List of dependences to exclude. For example: ``["slf4j:slf4j",
+	// "*:hadoop-client"]``. Maven dependency exclusions:
 	// https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.
 	Exclusions []string `json:"exclusions,omitempty"`
 	// Maven repo to install the Maven package from. If omitted, both Maven
@@ -107,8 +107,8 @@ type MavenLibrary struct {
 
 type PythonPyPiLibrary struct {
 	// The name of the pypi package to install. An optional exact version
-	// specification is also supported. Examples: &#34;simplejson&#34; and
-	// &#34;simplejson==3.8.0&#34;.
+	// specification is also supported. Examples: "simplejson" and
+	// "simplejson==3.8.0".
 	Package string `json:"package"`
 	// The repository where the package can be found. If not specified, the
 	// default pip index is used.

--- a/service/mlflow/api.go
+++ b/service/mlflow/api.go
@@ -180,7 +180,7 @@ func (a *MLflowDatabricksAPI) GetByName(ctx context.Context, name string) (*GetR
 	})
 }
 
-// Transition a model version&#39;s stage. This is a &lt;Workspace&gt; version of the
+// Transition a model version's stage. This is a <Workspace> version of the
 // [MLflow
 // endpoint](https://www.mlflow.org/docs/latest/rest-api.html#transition-modelversion-stage)
 // that also accepts a comment associated with the transition to be recorded.
@@ -269,12 +269,12 @@ func (a *MLflowRunsAPI) Get(ctx context.Context, request GetRunRequest) (*GetRun
 // data may be written. You can write metrics, params, and tags in interleaving
 // fashion, but within a given entity type are guaranteed to follow the order
 // specified in the request body. That is, for an API request like ..
-// code-block:: json { &#34;run_id&#34;: &#34;2a14ed5c6a87499199e0106c3501eab8&#34;, &#34;metrics&#34;:
-// [ {&#34;key&#34;: &#34;mae&#34;, &#34;value&#34;: 2.5, &#34;timestamp&#34;: 1552550804}, {&#34;key&#34;: &#34;rmse&#34;,
-// &#34;value&#34;: 2.7, &#34;timestamp&#34;: 1552550804}, ], &#34;params&#34;: [ {&#34;key&#34;: &#34;model_class&#34;,
-// &#34;value&#34;: &#34;LogisticRegression&#34;}, ] } the server is guaranteed to write metric
-// &#34;rmse&#34; after &#34;mae&#34;, though it may write param &#34;model_class&#34; before both
-// metrics, after &#34;mae&#34;, or after both metrics. The overwrite behavior for
+// code-block:: json { "run_id": "2a14ed5c6a87499199e0106c3501eab8", "metrics":
+// [ {"key": "mae", "value": 2.5, "timestamp": 1552550804}, {"key": "rmse",
+// "value": 2.7, "timestamp": 1552550804}, ], "params": [ {"key": "model_class",
+// "value": "LogisticRegression"}, ] } the server is guaranteed to write metric
+// "rmse" after "mae", though it may write param "model_class" before both
+// metrics, after "mae", or after both metrics. The overwrite behavior for
 // metrics, params, and tags is as follows: - Metrics: metric values are never
 // overwritten. Logging a metric (key, value, timestamp) appends to the set of
 // values for the metric with the provided key. - Tags: tag values can be

--- a/service/mlflow/interface.go
+++ b/service/mlflow/interface.go
@@ -78,7 +78,7 @@ type MLflowDatabricksService interface {
 	Get(ctx context.Context, getRegisteredModelRequest GetRegisteredModelRequest) (*GetRegisteredModelResponse, error)
 
 	GetByName(ctx context.Context, name string) (*GetRegisteredModelResponse, error)
-	// Transition a model version&#39;s stage. This is a &lt;Workspace&gt; version of the
+	// Transition a model version's stage. This is a <Workspace> version of the
 	// [MLflow
 	// endpoint](https://www.mlflow.org/docs/latest/rest-api.html#transition-modelversion-stage)
 	// that also accepts a comment associated with the transition to be
@@ -124,13 +124,13 @@ type MLflowRunsService interface {
 	// request), partial data may be written. You can write metrics, params, and
 	// tags in interleaving fashion, but within a given entity type are
 	// guaranteed to follow the order specified in the request body. That is,
-	// for an API request like .. code-block:: json { &#34;run_id&#34;:
-	// &#34;2a14ed5c6a87499199e0106c3501eab8&#34;, &#34;metrics&#34;: [ {&#34;key&#34;: &#34;mae&#34;, &#34;value&#34;:
-	// 2.5, &#34;timestamp&#34;: 1552550804}, {&#34;key&#34;: &#34;rmse&#34;, &#34;value&#34;: 2.7, &#34;timestamp&#34;:
-	// 1552550804}, ], &#34;params&#34;: [ {&#34;key&#34;: &#34;model_class&#34;, &#34;value&#34;:
-	// &#34;LogisticRegression&#34;}, ] } the server is guaranteed to write metric
-	// &#34;rmse&#34; after &#34;mae&#34;, though it may write param &#34;model_class&#34; before both
-	// metrics, after &#34;mae&#34;, or after both metrics. The overwrite behavior for
+	// for an API request like .. code-block:: json { "run_id":
+	// "2a14ed5c6a87499199e0106c3501eab8", "metrics": [ {"key": "mae", "value":
+	// 2.5, "timestamp": 1552550804}, {"key": "rmse", "value": 2.7, "timestamp":
+	// 1552550804}, ], "params": [ {"key": "model_class", "value":
+	// "LogisticRegression"}, ] } the server is guaranteed to write metric
+	// "rmse" after "mae", though it may write param "model_class" before both
+	// metrics, after "mae", or after both metrics. The overwrite behavior for
 	// metrics, params, and tags is as follows: - Metrics: metric values are
 	// never overwritten. Logging a metric (key, value, timestamp) appends to
 	// the set of values for the metric with the provided key. - Tags: tag

--- a/service/mlflow/model.go
+++ b/service/mlflow/model.go
@@ -21,7 +21,7 @@ type Activity struct {
 	LastUpdatedTimestamp int64 `json:"last_updated_timestamp,omitempty"`
 	// Comment made by system, for example explaining an activity of type
 	// `SYSTEM_TRANSITION`. It usually describes a side effect, such as a
-	// version being archived as part of another version&#39;s stage transition, and
+	// version being archived as part of another version's stage transition, and
 	// may not be returned for some activity types.
 	SystemComment string `json:"system_comment,omitempty"`
 	// Target stage of the transition (if the activity is stage transition
@@ -269,7 +269,7 @@ type CreateRunRequest struct {
 	// Additional metadata for run.
 	Tags []RunTag `json:"tags,omitempty"`
 	// ID of the user executing the run. This field is deprecated as of MLflow
-	// 1.0, and will be removed in a future MLflow release. Use &#39;mlflow.user&#39;
+	// 1.0, and will be removed in a future MLflow release. Use 'mlflow.user'
 	// tag instead.
 	UserId string `json:"user_id,omitempty"`
 }
@@ -374,7 +374,7 @@ type Experiment struct {
 	ExperimentId string `json:"experiment_id,omitempty"`
 	// Last update time
 	LastUpdateTime int64 `json:"last_update_time,omitempty"`
-	// Current life cycle stage of the experiment: &#34;active&#34; or &#34;deleted&#34;.
+	// Current life cycle stage of the experiment: "active" or "deleted".
 	// Deleted experiments are not returned by APIs.
 	LifecycleStage string `json:"lifecycle_stage,omitempty"`
 	// Human readable name that identifies the experiment.
@@ -418,8 +418,8 @@ type GetExperimentResponse struct {
 	// Experiment details.
 	Experiment *Experiment `json:"experiment,omitempty"`
 	// A collection of active runs in the experiment. Note: this may not contain
-	// all of the experiment&#39;s active runs. This field is deprecated. Please use
-	// the &#34;Search Runs&#34; API to fetch runs within an experiment.
+	// all of the experiment's active runs. This field is deprecated. Please use
+	// the "Search Runs" API to fetch runs within an experiment.
 	Runs []RunInfo `json:"runs,omitempty"`
 }
 
@@ -433,7 +433,7 @@ type GetLatestVersionsRequest struct {
 type GetLatestVersionsResponse struct {
 	// Latest version models for each requests stage. Only return models with
 	// current ``READY`` status. If no ``stages`` provided, returns the latest
-	// version for each stage, including ``&#34;None&#34;``.
+	// version for each stage, including ``"None"``.
 	ModelVersions []ModelVersion `json:"model_versions,omitempty"`
 }
 
@@ -512,7 +512,7 @@ type GetTransitionRequestsResponse struct {
 
 type HttpUrlSpec struct {
 	// Value of the authorization header that should be sent in the request sent
-	// by the wehbook. It should be of the form `&#34;&lt;auth type&gt; &lt;credentials&gt;&#34;`.
+	// by the wehbook. It should be of the form `"<auth type> <credentials>"`.
 	// If set to an empty string, no authorization header will be included in
 	// the request.
 	Authorization string `json:"authorization,omitempty"`
@@ -525,7 +525,7 @@ type HttpUrlSpec struct {
 	// requests can be maliciously routed to an unintended host.
 	EnableSslVerification bool `json:"enable_ssl_verification,omitempty"`
 	// Shared secret required for HMAC encoding payload. The HMAC-encoded
-	// payload will be sent in the header as: { &#34;X-Databricks-Signature&#34;:
+	// payload will be sent in the header as: { "X-Databricks-Signature":
 	// $encoded_payload }.
 	Secret string `json:"secret,omitempty"`
 	// External HTTPS URL called on event trigger (by using a POST request).
@@ -533,7 +533,7 @@ type HttpUrlSpec struct {
 }
 
 type JobSpec struct {
-	// The personal access token used to authorize webhook&#39;s job runs.
+	// The personal access token used to authorize webhook's job runs.
 	AccessToken string `json:"access_token"`
 	// ID of the job that the webhook runs.
 	JobId string `json:"job_id"`
@@ -567,7 +567,7 @@ type ListArtifactsResponse struct {
 
 type ListExperimentsRequest struct {
 	// Maximum number of experiments desired. If `max_results` is unspecified,
-	// return all experiments. If `max_results` is too large, it&#39;ll be
+	// return all experiments. If `max_results` is too large, it'll be
 	// automatically capped at 1000. Callers of this endpoint are encouraged to
 	// pass max_results explicitly and leverage page_token to iterate through
 	// experiments.
@@ -943,7 +943,7 @@ type RunData struct {
 
 type RunInfo struct {
 	// URI of the directory where artifacts should be uploaded. This can be a
-	// local path (starting with &#34;/&#34;), or a distributed file system (DFS) path,
+	// local path (starting with "/"), or a distributed file system (DFS) path,
 	// like ``s3://bucket/directory`` or ``dbfs:/my/directory``. If not set, the
 	// local ``./mlruns`` directory is chosen.
 	ArtifactUri string `json:"artifact_uri,omitempty"`
@@ -951,7 +951,7 @@ type RunInfo struct {
 	EndTime int64 `json:"end_time,omitempty"`
 	// The experiment ID.
 	ExperimentId string `json:"experiment_id,omitempty"`
-	// Current life cycle stage of the experiment : OneOf(&#34;active&#34;, &#34;deleted&#34;)
+	// Current life cycle stage of the experiment : OneOf("active", "deleted")
 	LifecycleStage string `json:"lifecycle_stage,omitempty"`
 	// Unique identifier for the run.
 	RunId string `json:"run_id,omitempty"`
@@ -963,7 +963,7 @@ type RunInfo struct {
 	// Current status of the run.
 	Status RunInfoStatus `json:"status,omitempty"`
 	// User who initiated the run. This field is deprecated as of MLflow 1.0,
-	// and will be removed in a future MLflow release. Use &#39;mlflow.user&#39; tag
+	// and will be removed in a future MLflow release. Use 'mlflow.user' tag
 	// instead.
 	UserId string `json:"user_id,omitempty"`
 }
@@ -989,14 +989,14 @@ type RunTag struct {
 }
 
 type SearchExperimentsRequest struct {
-	// String representing a SQL filter condition (e.g. &#34;name ILIKE
-	// &#39;my-experiment%&#39;&#34;)
+	// String representing a SQL filter condition (e.g. "name ILIKE
+	// 'my-experiment%'")
 	Filter string `json:"filter,omitempty"`
 	// Maximum number of experiments desired. Max threshold is 3000.
 	MaxResults int64 `json:"max_results,omitempty"`
 	// List of columns for ordering search results, which can include experiment
-	// name and last updated timestamp with an optional &#34;DESC&#34; or &#34;ASC&#34;
-	// annotation, where &#34;ASC&#34; is the default. Tiebreaks are done by experiment
+	// name and last updated timestamp with an optional "DESC" or "ASC"
+	// annotation, where "ASC" is the default. Tiebreaks are done by experiment
 	// id DESC.
 	OrderBy []string `json:"order_by,omitempty"`
 	// Token indicating the page of experiments to fetch
@@ -1025,13 +1025,13 @@ type SearchExperimentsResponse struct {
 }
 
 type SearchModelVersionsRequest struct {
-	// String filter condition, like &#34;name=&#39;my-model-name&#39;&#34;. Must be a single
+	// String filter condition, like "name='my-model-name'". Must be a single
 	// boolean condition, with string values wrapped in single quotes.
 	Filter string ` url:"filter,omitempty"`
 	// Maximum number of models desired. Max threshold is 10K.
 	MaxResults int ` url:"max_results,omitempty"`
 	// List of columns to be ordered by including model name, version, stage
-	// with an optional &#34;DESC&#34; or &#34;ASC&#34; annotation, where &#34;ASC&#34; is the default.
+	// with an optional "DESC" or "ASC" annotation, where "ASC" is the default.
 	// Tiebreaks are done by latest stage transition timestamp, followed by name
 	// ASC, followed by version DESC.
 	OrderBy any/* MISSING TYPE */ ` url:"order_by,omitempty"`
@@ -1048,15 +1048,15 @@ type SearchModelVersionsResponse struct {
 }
 
 type SearchRegisteredModelsRequest struct {
-	// String filter condition, like &#34;name LIKE &#39;my-model-name&#39;&#34;. Interpreted in
-	// the backend automatically as &#34;name LIKE &#39;%my-model-name%&#39;&#34;. Single
+	// String filter condition, like "name LIKE 'my-model-name'". Interpreted in
+	// the backend automatically as "name LIKE '%my-model-name%'". Single
 	// boolean condition, with string values wrapped in single quotes.
 	Filter string ` url:"filter,omitempty"`
 	// Maximum number of models desired. Default is 100. Max threshold is 1000.
 	MaxResults int ` url:"max_results,omitempty"`
 	// List of columns for ordering search results, which can include model name
-	// and last updated timestamp with an optional &#34;DESC&#34; or &#34;ASC&#34; annotation,
-	// where &#34;ASC&#34; is the default. Tiebreaks are done by model name ASC.
+	// and last updated timestamp with an optional "DESC" or "ASC" annotation,
+	// where "ASC" is the default. Tiebreaks are done by model name ASC.
 	OrderBy any/* MISSING TYPE */ ` url:"order_by,omitempty"`
 	// Pagination token to go to the next page based on a previous search query.
 	PageToken string ` url:"page_token,omitempty"`
@@ -1075,18 +1075,18 @@ type SearchRunsRequest struct {
 	// A filter expression over params, metrics, and tags, that allows returning
 	// a subset of runs. The syntax is a subset of SQL that supports ANDing
 	// together binary operations between a param, metric, or tag and a
-	// constant. Example: ``metrics.rmse &lt; 1 and params.model_class =
-	// &#39;LogisticRegression&#39;`` You can select columns with special characters
-	// (hyphen, space, period, etc.) by using double quotes: ``metrics.&#34;model
-	// class&#34; = &#39;LinearRegression&#39; and tags.&#34;user-name&#34; = &#39;Tomas&#39;`` Supported
-	// operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+	// constant. Example: ``metrics.rmse < 1 and params.model_class =
+	// 'LogisticRegression'`` You can select columns with special characters
+	// (hyphen, space, period, etc.) by using double quotes: ``metrics."model
+	// class" = 'LinearRegression' and tags."user-name" = 'Tomas'`` Supported
+	// operators are ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.
 	Filter string `json:"filter,omitempty"`
 	// Maximum number of runs desired. Max threshold is 50000
 	MaxResults int `json:"max_results,omitempty"`
 	// List of columns to be ordered by, including attributes, params, metrics,
-	// and tags with an optional &#34;DESC&#34; or &#34;ASC&#34; annotation, where &#34;ASC&#34; is the
-	// default. Example: [&#34;params.input DESC&#34;, &#34;metrics.alpha ASC&#34;,
-	// &#34;metrics.rmse&#34;] Tiebreaks are done by start_time DESC followed by run_id
+	// and tags with an optional "DESC" or "ASC" annotation, where "ASC" is the
+	// default. Example: ["params.input DESC", "metrics.alpha ASC",
+	// "metrics.rmse"] Tiebreaks are done by start_time DESC followed by run_id
 	// for runs with the same start time (and this is the default ordering
 	// criterion if order_by is not provided).
 	OrderBy []string `json:"order_by,omitempty"`
@@ -1237,7 +1237,7 @@ type UpdateCommentResponse struct {
 type UpdateExperimentRequest struct {
 	// ID of the associated experiment.
 	ExperimentId string `json:"experiment_id"`
-	// If provided, the experiment&#39;s name is changed to the new name. The new
+	// If provided, the experiment's name is changed to the new name. The new
 	// name must be unique.
 	NewName string `json:"new_name,omitempty"`
 }

--- a/service/permissions/model.go
+++ b/service/permissions/model.go
@@ -6,7 +6,7 @@ package permissions
 
 type AccessControlRequest struct {
 	GroupName string `json:"group_name,omitempty"`
-	// getPermissionLevel defaults to CAN_ATTACH_TO when it&#39;s not defined (for
+	// getPermissionLevel defaults to CAN_ATTACH_TO when it's not defined (for
 	// PUT/PATCH) so you should use .permissionLevel.isDefined to verify that it
 	// actually exists
 	PermissionLevel AccessControlRequestPermissionLevel `json:"permission_level,omitempty"`
@@ -16,7 +16,7 @@ type AccessControlRequest struct {
 	UserName string `json:"user_name,omitempty"`
 }
 
-// getPermissionLevel defaults to CAN_ATTACH_TO when it&#39;s not defined (for
+// getPermissionLevel defaults to CAN_ATTACH_TO when it's not defined (for
 // PUT/PATCH) so you should use .permissionLevel.isDefined to verify that it
 // actually exists
 type AccessControlRequestPermissionLevel string

--- a/service/scim/api.go
+++ b/service/scim/api.go
@@ -65,7 +65,7 @@ func (a *GroupsAPI) FetchGroupById(ctx context.Context, id string) (*Group, erro
 	})
 }
 
-// Get multiple groups associated with the &lt;Workspace&gt;.
+// Get multiple groups associated with the <Workspace>.
 func (a *GroupsAPI) ListGroups(ctx context.Context, request ListGroupsRequest) (*ListGroupsResponse, error) {
 	var listGroupsResponse ListGroupsResponse
 	path := "/api/2.0/preview/scim/v2/Groups"
@@ -73,7 +73,7 @@ func (a *GroupsAPI) ListGroups(ctx context.Context, request ListGroupsRequest) (
 	return &listGroupsResponse, err
 }
 
-// Create one group in the &lt;Workspace&gt;.
+// Create one group in the <Workspace>.
 func (a *GroupsAPI) NewGroup(ctx context.Context, request Group) (*Group, error) {
 	var group Group
 	path := "/api/2.0/preview/scim/v2/Groups"
@@ -134,7 +134,7 @@ func (a *ServicePrincipalsAPI) FetchServicePrincipalById(ctx context.Context, id
 	})
 }
 
-// Get multiple service principals associated with a &lt;Workspace&gt;.
+// Get multiple service principals associated with a <Workspace>.
 func (a *ServicePrincipalsAPI) ListServicePrincipals(ctx context.Context, request ListServicePrincipalsRequest) (*ListServicePrincipalResponse, error) {
 	var listServicePrincipalResponse ListServicePrincipalResponse
 	path := "/api/2.0/preview/scim/v2/ServicePrincipals"
@@ -142,7 +142,7 @@ func (a *ServicePrincipalsAPI) ListServicePrincipals(ctx context.Context, reques
 	return &listServicePrincipalResponse, err
 }
 
-// Create one service principal in the &lt;Workspace&gt;.
+// Create one service principal in the <Workspace>.
 func (a *ServicePrincipalsAPI) NewServicePrincipal(ctx context.Context, request ServicePrincipal) (*ServicePrincipal, error) {
 	var servicePrincipal ServicePrincipal
 	path := "/api/2.0/preview/scim/v2/ServicePrincipals"
@@ -203,7 +203,7 @@ func (a *UsersAPI) FetchUserById(ctx context.Context, id string) (*User, error) 
 	})
 }
 
-// Get multiple users associated with a &lt;Workspace&gt;.
+// Get multiple users associated with a <Workspace>.
 func (a *UsersAPI) ListUsers(ctx context.Context, request ListUsersRequest) (*ListUsersResponse, error) {
 	var listUsersResponse ListUsersResponse
 	path := "/api/2.0/preview/scim/v2/Users"
@@ -211,7 +211,7 @@ func (a *UsersAPI) ListUsers(ctx context.Context, request ListUsersRequest) (*Li
 	return &listUsersResponse, err
 }
 
-// Create one user in the &lt;Workspace&gt;.
+// Create one user in the <Workspace>.
 func (a *UsersAPI) NewUser(ctx context.Context, request User) (*User, error) {
 	var user User
 	path := "/api/2.0/preview/scim/v2/Users"

--- a/service/scim/interface.go
+++ b/service/scim/interface.go
@@ -25,10 +25,10 @@ type GroupsService interface {
 	FetchGroup(ctx context.Context, fetchGroupRequest FetchGroupRequest) (*Group, error)
 
 	FetchGroupById(ctx context.Context, id string) (*Group, error)
-	// Get multiple groups associated with the &lt;Workspace&gt;.
+	// Get multiple groups associated with the <Workspace>.
 	ListGroups(ctx context.Context, listGroupsRequest ListGroupsRequest) (*ListGroupsResponse, error)
 
-	// Create one group in the &lt;Workspace&gt;.
+	// Create one group in the <Workspace>.
 	NewGroup(ctx context.Context, group Group) (*Group, error)
 
 	// Partially update details of a group
@@ -50,10 +50,10 @@ type ServicePrincipalsService interface {
 	FetchServicePrincipal(ctx context.Context, fetchServicePrincipalRequest FetchServicePrincipalRequest) (*ServicePrincipal, error)
 
 	FetchServicePrincipalById(ctx context.Context, id string) (*ServicePrincipal, error)
-	// Get multiple service principals associated with a &lt;Workspace&gt;.
+	// Get multiple service principals associated with a <Workspace>.
 	ListServicePrincipals(ctx context.Context, listServicePrincipalsRequest ListServicePrincipalsRequest) (*ListServicePrincipalResponse, error)
 
-	// Create one service principal in the &lt;Workspace&gt;.
+	// Create one service principal in the <Workspace>.
 	NewServicePrincipal(ctx context.Context, servicePrincipal ServicePrincipal) (*ServicePrincipal, error)
 
 	// Partially update details of one service principal.
@@ -75,10 +75,10 @@ type UsersService interface {
 	FetchUser(ctx context.Context, fetchUserRequest FetchUserRequest) (*User, error)
 
 	FetchUserById(ctx context.Context, id string) (*User, error)
-	// Get multiple users associated with a &lt;Workspace&gt;.
+	// Get multiple users associated with a <Workspace>.
 	ListUsers(ctx context.Context, listUsersRequest ListUsersRequest) (*ListUsersResponse, error)
 
-	// Create one user in the &lt;Workspace&gt;.
+	// Create one user in the <Workspace>.
 	NewUser(ctx context.Context, user User) (*User, error)
 
 	// Partially update details of one user.

--- a/service/scim/model.go
+++ b/service/scim/model.go
@@ -17,32 +17,32 @@ type ComplexValue struct {
 }
 
 type DeleteGroupRequest struct {
-	// Unique ID for a group in the &lt;Workspace&gt;.
+	// Unique ID for a group in the <Workspace>.
 	Id string ` path:"id"`
 }
 
 type DeleteServicePrincipalRequest struct {
-	// Unique ID for a service principal in the &lt;Workspace&gt;.
+	// Unique ID for a service principal in the <Workspace>.
 	Id string ` path:"id"`
 }
 
 type DeleteUserRequest struct {
-	// Unique ID for a user in the &lt;Workspace&gt;.
+	// Unique ID for a user in the <Workspace>.
 	Id string ` path:"id"`
 }
 
 type FetchGroupRequest struct {
-	// Unique ID for a group in the &lt;Workspace&gt;.
+	// Unique ID for a group in the <Workspace>.
 	Id string ` path:"id"`
 }
 
 type FetchServicePrincipalRequest struct {
-	// Unique ID for a service principal in the &lt;Workspace&gt;.
+	// Unique ID for a service principal in the <Workspace>.
 	Id string ` path:"id"`
 }
 
 type FetchUserRequest struct {
-	// Unique ID for a user in the &lt;Workspace&gt;.
+	// Unique ID for a user in the <Workspace>.
 	Id string ` path:"id"`
 }
 
@@ -61,8 +61,6 @@ type Group struct {
 	Members []ComplexValue `json:"members,omitempty"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
-	// SCIM schema used for the group object.
-	Schemas []Urn `json:"schemas,omitempty"`
 }
 
 type ListGroupsRequest struct {
@@ -187,12 +185,10 @@ const ListUsersSortOrderAscending ListUsersSortOrder = `ascending`
 const ListUsersSortOrderDescending ListUsersSortOrder = `descending`
 
 type PartialUpdate struct {
-	// Unique ID for a group in the &lt;Workspace&gt;.
+	// Unique ID for a group in the <Workspace>.
 	Id string ` path:"id"`
 
 	Operations []Patch `json:"operations,omitempty"`
-	// SCIM schema used for the user object.
-	Schemas []Urn `json:"schemas,omitempty"`
 }
 
 type Patch struct {
@@ -231,27 +227,7 @@ type ServicePrincipal struct {
 	Id string `json:"id,omitempty" path:"id"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
-	// SCIM schema used for the user object.
-	Schemas []Urn `json:"schemas,omitempty"`
 }
-
-// Defines type of SCIM protocol entity
-type Urn string
-
-// Defines type of SCIM protocol entity
-const UrnGroup Urn = `urn:ietf:params:scim:schemas:core:2.0:Group`
-
-// Defines type of SCIM protocol entity
-const UrnPatchOp Urn = `urn:ietf:params:scim:api:messages:2.0:PatchOp`
-
-// Defines type of SCIM protocol entity
-const UrnServicePrincipal Urn = `urn:ietf:params:scim:schemas:core:2.0:ServicePrincipal`
-
-// Defines type of SCIM protocol entity
-const UrnUser Urn = `urn:ietf:params:scim:schemas:core:2.0:User`
-
-// Defines type of SCIM protocol entity
-const UrnWorkspaceUser Urn = `urn:ietf:params:scim:schemas:extension:workspace:2.0:User`
 
 type User struct {
 	// If this user is active
@@ -273,8 +249,6 @@ type User struct {
 	Name *UserName `json:"name,omitempty"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
-	// SCIM schema used for the user object.
-	Schemas []Urn `json:"schemas,omitempty"`
 	// Email address of the Databricks user.
 	UserName string `json:"userName,omitempty"`
 }

--- a/service/secrets/api.go
+++ b/service/secrets/api.go
@@ -21,23 +21,23 @@ type SecretsAPI struct {
 // Creates a new secret scope. The scope name must consist of alphanumeric
 // characters, dashes, underscores, and periods, and may not exceed 128
 // characters. The maximum number of scopes in a workspace is 100. Example
-// request: .. code:: { &#34;scope&#34;: &#34;my-simple-databricks-scope&#34;,
-// &#34;initial_manage_principal&#34;: &#34;users&#34; &#34;scope_backend_type&#34;:
-// &#34;databricks|azure_keyvault&#34;, # below is only required if scope type is
-// azure_keyvault &#34;backend_azure_keyvault&#34;: { &#34;resource_id&#34;:
-// &#34;/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.KeyVault/vaults/xxxx&#34;,
-// &#34;tenant_id&#34;: &#34;xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&#34;, &#34;dns_name&#34;:
-// &#34;https://xxxx.vault.azure.net/&#34;, } } If “initial_manage_principal“ is
+// request: .. code:: { "scope": "my-simple-databricks-scope",
+// "initial_manage_principal": "users" "scope_backend_type":
+// "databricks|azure_keyvault", # below is only required if scope type is
+// azure_keyvault "backend_azure_keyvault": { "resource_id":
+// "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.KeyVault/vaults/xxxx",
+// "tenant_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "dns_name":
+// "https://xxxx.vault.azure.net/", } } If “initial_manage_principal“ is
 // specified, the initial ACL applied to the scope is applied to the supplied
 // principal (user or group) with “MANAGE“ permissions. The only supported
 // principal for this option is the group “users“, which contains all users in
 // the workspace. If “initial_manage_principal“ is not specified, the initial
 // ACL with “MANAGE“ permission applied to the scope is assigned to the API
-// request issuer&#39;s user identity. If “scope_backend_type“ is
+// request issuer's user identity. If “scope_backend_type“ is
 // “azure_keyvault“, a secret scope is created with secrets from a given Azure
 // KeyVault. The caller must provide the keyvault_resource_id and the tenant_id
 // for the key vault. If “scope_backend_type“ is “databricks“ or is
-// unspecified, an empty secret scope is created and stored in Databricks&#39;s own
+// unspecified, an empty secret scope is created and stored in Databricks's own
 // storage. Throws “RESOURCE_ALREADY_EXISTS“ if a scope with the given name
 // already exists. Throws “RESOURCE_LIMIT_EXCEEDED“ if maximum number of
 // scopes in the workspace is exceeded. Throws “INVALID_PARAMETER_VALUE“ if
@@ -49,8 +49,8 @@ func (a *SecretsAPI) CreateScope(ctx context.Context, request CreateScopeRequest
 }
 
 // Deletes the given ACL on the given scope. Users must have the “MANAGE“
-// permission to invoke this API. Example request: .. code:: { &#34;scope&#34;:
-// &#34;my-secret-scope&#34;, &#34;principal&#34;: &#34;data-scientists&#34; } Throws
+// permission to invoke this API. Example request: .. code:: { "scope":
+// "my-secret-scope", "principal": "data-scientists" } Throws
 // “RESOURCE_DOES_NOT_EXIST“ if no such secret scope, principal, or ACL
 // exists. Throws “PERMISSION_DENIED“ if the user does not have permission to
 // make this API call.
@@ -60,8 +60,8 @@ func (a *SecretsAPI) DeleteAcl(ctx context.Context, request DeleteAclRequest) er
 	return err
 }
 
-// Deletes a secret scope. Example request: .. code:: { &#34;scope&#34;:
-// &#34;my-secret-scope&#34; } Throws “RESOURCE_DOES_NOT_EXIST“ if the scope does not
+// Deletes a secret scope. Example request: .. code:: { "scope":
+// "my-secret-scope" } Throws “RESOURCE_DOES_NOT_EXIST“ if the scope does not
 // exist. Throws “PERMISSION_DENIED“ if the user does not have permission to
 // make this API call.
 func (a *SecretsAPI) DeleteScope(ctx context.Context, request DeleteScopeRequest) error {
@@ -72,7 +72,7 @@ func (a *SecretsAPI) DeleteScope(ctx context.Context, request DeleteScopeRequest
 
 // Deletes the secret stored in this secret scope. You must have “WRITE“ or
 // “MANAGE“ permission on the Secret Scope. Example request: .. code:: {
-// &#34;scope&#34;: &#34;my-secret-scope&#34;, &#34;key&#34;: &#34;my-secret-key&#34; } Throws
+// "scope": "my-secret-scope", "key": "my-secret-key" } Throws
 // “RESOURCE_DOES_NOT_EXIST“ if no such secret scope or secret exists. Throws
 // “PERMISSION_DENIED“ if the user does not have permission to make this API
 // call.
@@ -84,7 +84,7 @@ func (a *SecretsAPI) DeleteSecret(ctx context.Context, request DeleteSecretReque
 
 // Describes the details about the given ACL, such as the group and permission.
 // Users must have the “MANAGE“ permission to invoke this API. Example
-// response: .. code:: { &#34;principal&#34;: &#34;data-scientists&#34;, &#34;permission&#34;: &#34;READ&#34; }
+// response: .. code:: { "principal": "data-scientists", "permission": "READ" }
 // Throws “RESOURCE_DOES_NOT_EXIST“ if no such secret scope exists. Throws
 // “PERMISSION_DENIED“ if the user does not have permission to make this API
 // call.
@@ -96,9 +96,9 @@ func (a *SecretsAPI) GetAcl(ctx context.Context, request GetAclRequest) (*GetAcl
 }
 
 // Lists the ACLs set on the given scope. Users must have the “MANAGE“
-// permission to invoke this API. Example response: .. code:: { &#34;acls&#34;: [{
-// &#34;principal&#34;: &#34;admins&#34;, &#34;permission&#34;: &#34;MANAGE&#34; },{ &#34;principal&#34;:
-// &#34;data-scientists&#34;, &#34;permission&#34;: &#34;READ&#34; }] } Throws
+// permission to invoke this API. Example response: .. code:: { "acls": [{
+// "principal": "admins", "permission": "MANAGE" },{ "principal":
+// "data-scientists", "permission": "READ" }] } Throws
 // “RESOURCE_DOES_NOT_EXIST“ if no such secret scope exists. Throws
 // “PERMISSION_DENIED“ if the user does not have permission to make this API
 // call.
@@ -110,8 +110,8 @@ func (a *SecretsAPI) ListAcls(ctx context.Context, request ListAclsRequest) (*Li
 }
 
 // Lists all secret scopes available in the workspace. Example response: ..
-// code:: { &#34;scopes&#34;: [{ &#34;name&#34;: &#34;my-databricks-scope&#34;, &#34;backend_type&#34;:
-// &#34;DATABRICKS&#34; },{ &#34;name&#34;: &#34;mount-points&#34;, &#34;backend_type&#34;: &#34;DATABRICKS&#34; }] }
+// code:: { "scopes": [{ "name": "my-databricks-scope", "backend_type":
+// "DATABRICKS" },{ "name": "mount-points", "backend_type": "DATABRICKS" }] }
 // Throws “PERMISSION_DENIED“ if the user does not have permission to make
 // this API call.
 func (a *SecretsAPI) ListScopes(ctx context.Context) (*ListScopesResponse, error) {
@@ -123,9 +123,9 @@ func (a *SecretsAPI) ListScopes(ctx context.Context) (*ListScopesResponse, error
 
 // Lists the secret keys that are stored at this scope. This is a metadata-only
 // operation; secret data cannot be retrieved using this API. Users need the
-// READ permission to make this call. Example response: .. code:: { &#34;secrets&#34;: [
-// { &#34;key&#34;: &#34;my-string-key&#34;&#34;, &#34;last_updated_timestamp&#34;: &#34;1520467595000&#34; }, {
-// &#34;key&#34;: &#34;my-byte-key&#34;, &#34;last_updated_timestamp&#34;: &#34;1520467595000&#34; }, ] } The
+// READ permission to make this call. Example response: .. code:: { "secrets": [
+// { "key": "my-string-key"", "last_updated_timestamp": "1520467595000" }, {
+// "key": "my-byte-key", "last_updated_timestamp": "1520467595000" }, ] } The
 // lastUpdatedTimestamp returned is in milliseconds since epoch. Throws
 // “RESOURCE_DOES_NOT_EXIST“ if no such secret scope exists. Throws
 // “PERMISSION_DENIED“ if the user does not have permission to make this API
@@ -146,10 +146,10 @@ func (a *SecretsAPI) ListSecrets(ctx context.Context, request ListSecretsRequest
 // available. Note that in general, secret values can only be read from within a
 // command on a cluster (for example, through a notebook). There is no API to
 // read the actual secret value material outside of a cluster. However, the
-// user&#39;s permission will be applied based on who is executing the command, and
+// user's permission will be applied based on who is executing the command, and
 // they must have at least READ permission. Users must have the “MANAGE“
-// permission to invoke this API. Example request: .. code:: { &#34;scope&#34;:
-// &#34;my-secret-scope&#34;, &#34;principal&#34;: &#34;data-scientists&#34;, &#34;permission&#34;: &#34;READ&#34; } The
+// permission to invoke this API. Example request: .. code:: { "scope":
+// "my-secret-scope", "principal": "data-scientists", "permission": "READ" } The
 // principal is a user or group name corresponding to an existing Databricks
 // principal to be granted or revoked access. Throws “RESOURCE_DOES_NOT_EXIST“
 // if no such secret scope exists. Throws “RESOURCE_ALREADY_EXISTS“ if a
@@ -165,14 +165,14 @@ func (a *SecretsAPI) PutAcl(ctx context.Context, request PutAclRequest) error {
 
 // Inserts a secret under the provided scope with the given name. If a secret
 // already exists with the same name, this command overwrites the existing
-// secret&#39;s value. The server encrypts the secret using the secret scope&#39;s
+// secret's value. The server encrypts the secret using the secret scope's
 // encryption settings before storing it. You must have “WRITE“ or “MANAGE“
 // permission on the secret scope. The secret key must consist of alphanumeric
 // characters, dashes, underscores, and periods, and cannot exceed 128
 // characters. The maximum allowed secret value size is 128 KB. The maximum
 // number of secrets in a given scope is 1000. Example request: .. code:: {
-// &#34;scope&#34;: &#34;my-databricks-scope&#34;, &#34;key&#34;: &#34;my-string-key&#34;, &#34;string_value&#34;:
-// &#34;foobar&#34; } The input fields &#34;string_value&#34; or &#34;bytes_value&#34; specify the type
+// "scope": "my-databricks-scope", "key": "my-string-key", "string_value":
+// "foobar" } The input fields "string_value" or "bytes_value" specify the type
 // of the secret, which will determine the value returned when the secret value
 // is requested. Exactly one must be specified. Throws
 // “RESOURCE_DOES_NOT_EXIST“ if no such secret scope exists. Throws

--- a/service/secrets/interface.go
+++ b/service/secrets/interface.go
@@ -13,24 +13,24 @@ type SecretsService interface {
 	// Creates a new secret scope. The scope name must consist of alphanumeric
 	// characters, dashes, underscores, and periods, and may not exceed 128
 	// characters. The maximum number of scopes in a workspace is 100. Example
-	// request: .. code:: { &#34;scope&#34;: &#34;my-simple-databricks-scope&#34;,
-	// &#34;initial_manage_principal&#34;: &#34;users&#34; &#34;scope_backend_type&#34;:
-	// &#34;databricks|azure_keyvault&#34;, # below is only required if scope type is
-	// azure_keyvault &#34;backend_azure_keyvault&#34;: { &#34;resource_id&#34;:
-	// &#34;/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.KeyVault/vaults/xxxx&#34;,
-	// &#34;tenant_id&#34;: &#34;xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx&#34;, &#34;dns_name&#34;:
-	// &#34;https://xxxx.vault.azure.net/&#34;, } } If ``initial_manage_principal`` is
+	// request: .. code:: { "scope": "my-simple-databricks-scope",
+	// "initial_manage_principal": "users" "scope_backend_type":
+	// "databricks|azure_keyvault", # below is only required if scope type is
+	// azure_keyvault "backend_azure_keyvault": { "resource_id":
+	// "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/xxxx/providers/Microsoft.KeyVault/vaults/xxxx",
+	// "tenant_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "dns_name":
+	// "https://xxxx.vault.azure.net/", } } If ``initial_manage_principal`` is
 	// specified, the initial ACL applied to the scope is applied to the
 	// supplied principal (user or group) with ``MANAGE`` permissions. The only
 	// supported principal for this option is the group ``users``, which
 	// contains all users in the workspace. If ``initial_manage_principal`` is
 	// not specified, the initial ACL with ``MANAGE`` permission applied to the
-	// scope is assigned to the API request issuer&#39;s user identity. If
+	// scope is assigned to the API request issuer's user identity. If
 	// ``scope_backend_type`` is ``azure_keyvault``, a secret scope is created
 	// with secrets from a given Azure KeyVault. The caller must provide the
 	// keyvault_resource_id and the tenant_id for the key vault. If
 	// ``scope_backend_type`` is ``databricks`` or is unspecified, an empty
-	// secret scope is created and stored in Databricks&#39;s own storage. Throws
+	// secret scope is created and stored in Databricks's own storage. Throws
 	// ``RESOURCE_ALREADY_EXISTS`` if a scope with the given name already
 	// exists. Throws ``RESOURCE_LIMIT_EXCEEDED`` if maximum number of scopes in
 	// the workspace is exceeded. Throws ``INVALID_PARAMETER_VALUE`` if the
@@ -38,22 +38,22 @@ type SecretsService interface {
 	CreateScope(ctx context.Context, createScopeRequest CreateScopeRequest) error
 
 	// Deletes the given ACL on the given scope. Users must have the ``MANAGE``
-	// permission to invoke this API. Example request: .. code:: { &#34;scope&#34;:
-	// &#34;my-secret-scope&#34;, &#34;principal&#34;: &#34;data-scientists&#34; } Throws
+	// permission to invoke this API. Example request: .. code:: { "scope":
+	// "my-secret-scope", "principal": "data-scientists" } Throws
 	// ``RESOURCE_DOES_NOT_EXIST`` if no such secret scope, principal, or ACL
 	// exists. Throws ``PERMISSION_DENIED`` if the user does not have permission
 	// to make this API call.
 	DeleteAcl(ctx context.Context, deleteAclRequest DeleteAclRequest) error
 
-	// Deletes a secret scope. Example request: .. code:: { &#34;scope&#34;:
-	// &#34;my-secret-scope&#34; } Throws ``RESOURCE_DOES_NOT_EXIST`` if the scope does
+	// Deletes a secret scope. Example request: .. code:: { "scope":
+	// "my-secret-scope" } Throws ``RESOURCE_DOES_NOT_EXIST`` if the scope does
 	// not exist. Throws ``PERMISSION_DENIED`` if the user does not have
 	// permission to make this API call.
 	DeleteScope(ctx context.Context, deleteScopeRequest DeleteScopeRequest) error
 
 	// Deletes the secret stored in this secret scope. You must have ``WRITE``
 	// or ``MANAGE`` permission on the Secret Scope. Example request: .. code::
-	// { &#34;scope&#34;: &#34;my-secret-scope&#34;, &#34;key&#34;: &#34;my-secret-key&#34; } Throws
+	// { "scope": "my-secret-scope", "key": "my-secret-key" } Throws
 	// ``RESOURCE_DOES_NOT_EXIST`` if no such secret scope or secret exists.
 	// Throws ``PERMISSION_DENIED`` if the user does not have permission to make
 	// this API call.
@@ -61,24 +61,24 @@ type SecretsService interface {
 
 	// Describes the details about the given ACL, such as the group and
 	// permission. Users must have the ``MANAGE`` permission to invoke this API.
-	// Example response: .. code:: { &#34;principal&#34;: &#34;data-scientists&#34;,
-	// &#34;permission&#34;: &#34;READ&#34; } Throws ``RESOURCE_DOES_NOT_EXIST`` if no such
+	// Example response: .. code:: { "principal": "data-scientists",
+	// "permission": "READ" } Throws ``RESOURCE_DOES_NOT_EXIST`` if no such
 	// secret scope exists. Throws ``PERMISSION_DENIED`` if the user does not
 	// have permission to make this API call.
 	GetAcl(ctx context.Context, getAclRequest GetAclRequest) (*GetAclResponse, error)
 
 	// Lists the ACLs set on the given scope. Users must have the ``MANAGE``
-	// permission to invoke this API. Example response: .. code:: { &#34;acls&#34;: [{
-	// &#34;principal&#34;: &#34;admins&#34;, &#34;permission&#34;: &#34;MANAGE&#34; },{ &#34;principal&#34;:
-	// &#34;data-scientists&#34;, &#34;permission&#34;: &#34;READ&#34; }] } Throws
+	// permission to invoke this API. Example response: .. code:: { "acls": [{
+	// "principal": "admins", "permission": "MANAGE" },{ "principal":
+	// "data-scientists", "permission": "READ" }] } Throws
 	// ``RESOURCE_DOES_NOT_EXIST`` if no such secret scope exists. Throws
 	// ``PERMISSION_DENIED`` if the user does not have permission to make this
 	// API call.
 	ListAcls(ctx context.Context, listAclsRequest ListAclsRequest) (*ListAclsResponse, error)
 
 	// Lists all secret scopes available in the workspace. Example response: ..
-	// code:: { &#34;scopes&#34;: [{ &#34;name&#34;: &#34;my-databricks-scope&#34;, &#34;backend_type&#34;:
-	// &#34;DATABRICKS&#34; },{ &#34;name&#34;: &#34;mount-points&#34;, &#34;backend_type&#34;: &#34;DATABRICKS&#34; }]
+	// code:: { "scopes": [{ "name": "my-databricks-scope", "backend_type":
+	// "DATABRICKS" },{ "name": "mount-points", "backend_type": "DATABRICKS" }]
 	// } Throws ``PERMISSION_DENIED`` if the user does not have permission to
 	// make this API call.
 	ListScopes(ctx context.Context) (*ListScopesResponse, error)
@@ -86,9 +86,9 @@ type SecretsService interface {
 	// Lists the secret keys that are stored at this scope. This is a
 	// metadata-only operation; secret data cannot be retrieved using this API.
 	// Users need the READ permission to make this call. Example response: ..
-	// code:: { &#34;secrets&#34;: [ { &#34;key&#34;: &#34;my-string-key&#34;&#34;,
-	// &#34;last_updated_timestamp&#34;: &#34;1520467595000&#34; }, { &#34;key&#34;: &#34;my-byte-key&#34;,
-	// &#34;last_updated_timestamp&#34;: &#34;1520467595000&#34; }, ] } The lastUpdatedTimestamp
+	// code:: { "secrets": [ { "key": "my-string-key"",
+	// "last_updated_timestamp": "1520467595000" }, { "key": "my-byte-key",
+	// "last_updated_timestamp": "1520467595000" }, ] } The lastUpdatedTimestamp
 	// returned is in milliseconds since epoch. Throws
 	// ``RESOURCE_DOES_NOT_EXIST`` if no such secret scope exists. Throws
 	// ``PERMISSION_DENIED`` if the user does not have permission to make this
@@ -104,11 +104,11 @@ type SecretsService interface {
 	// list what secrets are available. Note that in general, secret values can
 	// only be read from within a command on a cluster (for example, through a
 	// notebook). There is no API to read the actual secret value material
-	// outside of a cluster. However, the user&#39;s permission will be applied
+	// outside of a cluster. However, the user's permission will be applied
 	// based on who is executing the command, and they must have at least READ
 	// permission. Users must have the ``MANAGE`` permission to invoke this API.
-	// Example request: .. code:: { &#34;scope&#34;: &#34;my-secret-scope&#34;, &#34;principal&#34;:
-	// &#34;data-scientists&#34;, &#34;permission&#34;: &#34;READ&#34; } The principal is a user or
+	// Example request: .. code:: { "scope": "my-secret-scope", "principal":
+	// "data-scientists", "permission": "READ" } The principal is a user or
 	// group name corresponding to an existing Databricks principal to be
 	// granted or revoked access. Throws ``RESOURCE_DOES_NOT_EXIST`` if no such
 	// secret scope exists. Throws ``RESOURCE_ALREADY_EXISTS`` if a permission
@@ -119,15 +119,15 @@ type SecretsService interface {
 
 	// Inserts a secret under the provided scope with the given name. If a
 	// secret already exists with the same name, this command overwrites the
-	// existing secret&#39;s value. The server encrypts the secret using the secret
-	// scope&#39;s encryption settings before storing it. You must have ``WRITE`` or
+	// existing secret's value. The server encrypts the secret using the secret
+	// scope's encryption settings before storing it. You must have ``WRITE`` or
 	// ``MANAGE`` permission on the secret scope. The secret key must consist of
 	// alphanumeric characters, dashes, underscores, and periods, and cannot
 	// exceed 128 characters. The maximum allowed secret value size is 128 KB.
 	// The maximum number of secrets in a given scope is 1000. Example request:
-	// .. code:: { &#34;scope&#34;: &#34;my-databricks-scope&#34;, &#34;key&#34;: &#34;my-string-key&#34;,
-	// &#34;string_value&#34;: &#34;foobar&#34; } The input fields &#34;string_value&#34; or
-	// &#34;bytes_value&#34; specify the type of the secret, which will determine the
+	// .. code:: { "scope": "my-databricks-scope", "key": "my-string-key",
+	// "string_value": "foobar" } The input fields "string_value" or
+	// "bytes_value" specify the type of the secret, which will determine the
 	// value returned when the secret value is requested. Exactly one must be
 	// specified. Throws ``RESOURCE_DOES_NOT_EXIST`` if no such secret scope
 	// exists. Throws ``RESOURCE_LIMIT_EXCEEDED`` if maximum number of secrets

--- a/service/unitycatalog/model.go
+++ b/service/unitycatalog/model.go
@@ -22,8 +22,8 @@ type CatalogInfo struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Catalog.
 	Privileges []CatalogInfoPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// Delta Sharing Catalog specific fields. A Delta Sharing Catalog is a
@@ -157,8 +157,8 @@ type CreateCatalogRequest struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Catalog.
 	Privileges []CreateCatalogRequestPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// Delta Sharing Catalog specific fields. A Delta Sharing Catalog is a
@@ -223,8 +223,8 @@ type CreateCatalogResponse struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Catalog.
 	Privileges []CreateCatalogResponsePrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// Delta Sharing Catalog specific fields. A Delta Sharing Catalog is a
@@ -279,7 +279,7 @@ type CreateExternalLocationRequest struct {
 	CreatedAt int64 `json:"created_at,omitempty"`
 	// [Create,Update:IGN] Username of External Location creator.
 	CreatedBy string `json:"created_by,omitempty"`
-	// [Create,Update:IGN] Unique ID of the location&#39;s Storage Credential.
+	// [Create,Update:IGN] Unique ID of the location's Storage Credential.
 	CredentialId string `json:"credential_id,omitempty"`
 	// [Create:REQ Update:OPT] Current name of the Storage Credential this
 	// location uses.
@@ -309,7 +309,7 @@ type CreateExternalLocationResponse struct {
 	CreatedAt int64 `json:"created_at,omitempty"`
 	// [Create,Update:IGN] Username of External Location creator.
 	CreatedBy string `json:"created_by,omitempty"`
-	// [Create,Update:IGN] Unique ID of the location&#39;s Storage Credential.
+	// [Create,Update:IGN] Unique ID of the location's Storage Credential.
 	CredentialId string `json:"credential_id,omitempty"`
 	// [Create:REQ Update:OPT] Current name of the Storage Credential this
 	// location uses.
@@ -537,7 +537,7 @@ const CreateProviderResponseAuthenticationTypeUnknown CreateProviderResponseAuth
 
 type CreateRecipientRequest struct {
 	// [Create:IGN,Update:IGN] A boolean status field showing whether the
-	// Recipient&#39;s activation URL has been exercised or not.
+	// Recipient's activation URL has been exercised or not.
 	Activated bool `json:"activated,omitempty"`
 	// [Create:IGN,Update:IGN] Full activation url to retrieve the access token.
 	// It will be empty if the token is already retrieved.
@@ -580,7 +580,7 @@ const CreateRecipientRequestAuthenticationTypeUnknown CreateRecipientRequestAuth
 
 type CreateRecipientResponse struct {
 	// [Create:IGN,Update:IGN] A boolean status field showing whether the
-	// Recipient&#39;s activation URL has been exercised or not.
+	// Recipient's activation URL has been exercised or not.
 	Activated bool `json:"activated,omitempty"`
 	// [Create:IGN,Update:IGN] Full activation url to retrieve the access token.
 	// It will be empty if the token is already retrieved.
@@ -632,7 +632,7 @@ type CreateSchemaRequest struct {
 	// [Create,Update:IGN] Username of Schema creator.
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Full name of Schema, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.
+	// <catalog_name>.<schema_name>.
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -642,8 +642,8 @@ type CreateSchemaRequest struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Schema.
 	Privileges []CreateSchemaRequestPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create,Update:IGN] Time at which this Schema was created, in epoch
@@ -684,7 +684,7 @@ type CreateSchemaResponse struct {
 	// [Create,Update:IGN] Username of Schema creator.
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Full name of Schema, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.
+	// <catalog_name>.<schema_name>.
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -694,8 +694,8 @@ type CreateSchemaResponse struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Schema.
 	Privileges []CreateSchemaResponsePrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create,Update:IGN] Time at which this Schema was created, in epoch
@@ -841,8 +841,8 @@ type CreateStorageCredentialResponse struct {
 type CreateTableRequest struct {
 	// [Create:REQ Update:IGN] Name of parent Catalog.
 	CatalogName string `json:"catalog_name,omitempty"`
-	// This name (&#39;columns&#39;) is what the client actually sees as the field name
-	// in messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('columns') is what the client actually sees as the field name
+	// in messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Columns []ColumnInfo `json:"columns,omitempty"`
 	// [Create,Update:OPT] User-provided free-form text description.
@@ -854,10 +854,10 @@ type CreateTableRequest struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Unique ID of the data_access_configuration to use.
 	DataAccessConfigurationId string `json:"data_access_configuration_id,omitempty"`
-	// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+	// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 	DataSourceFormat CreateTableRequestDataSourceFormat `json:"data_source_format,omitempty"`
 	// [Create,Update:IGN] Full name of Table, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.&lt;table_name&gt;
+	// <catalog_name>.<schema_name>.<table_name>
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -867,8 +867,8 @@ type CreateTableRequest struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Table.
 	Privileges []CreateTableRequestPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create:REQ Update:IGN] Name of parent Schema relative to its parent
@@ -884,18 +884,18 @@ type CreateTableRequest struct {
 	StorageLocation string `json:"storage_location,omitempty"`
 	// [Create:IGN Update:IGN] Name of Table, relative to parent Schema.
 	TableId string `json:"table_id,omitempty"`
-	// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+	// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 	TableType CreateTableRequestTableType `json:"table_type,omitempty"`
 	// [Create,Update:IGN] Time at which this Table was last modified, in epoch
 	// milliseconds.
 	UpdatedAt int64 `json:"updated_at,omitempty"`
 	// [Create,Update:IGN] Username of user who last modified the Table.
 	UpdatedBy string `json:"updated_by,omitempty"`
-	// [Create,Update:OPT] View definition SQL (when table_type == &#34;VIEW&#34;)
+	// [Create,Update:OPT] View definition SQL (when table_type == "VIEW")
 	ViewDefinition string `json:"view_definition,omitempty"`
 }
 
-// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 type CreateTableRequestDataSourceFormat string
 
 const CreateTableRequestDataSourceFormatAvro CreateTableRequestDataSourceFormat = `AVRO`
@@ -938,7 +938,7 @@ const CreateTableRequestPrivilegesItemUsage CreateTableRequestPrivilegesItem = `
 
 const CreateTableRequestPrivilegesItemWriteFiles CreateTableRequestPrivilegesItem = `WRITE_FILES`
 
-// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 type CreateTableRequestTableType string
 
 const CreateTableRequestTableTypeExternal CreateTableRequestTableType = `EXTERNAL`
@@ -952,8 +952,8 @@ const CreateTableRequestTableTypeView CreateTableRequestTableType = `VIEW`
 type CreateTableResponse struct {
 	// [Create:REQ Update:IGN] Name of parent Catalog.
 	CatalogName string `json:"catalog_name,omitempty"`
-	// This name (&#39;columns&#39;) is what the client actually sees as the field name
-	// in messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('columns') is what the client actually sees as the field name
+	// in messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Columns []ColumnInfo `json:"columns,omitempty"`
 	// [Create,Update:OPT] User-provided free-form text description.
@@ -965,10 +965,10 @@ type CreateTableResponse struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Unique ID of the data_access_configuration to use.
 	DataAccessConfigurationId string `json:"data_access_configuration_id,omitempty"`
-	// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+	// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 	DataSourceFormat CreateTableResponseDataSourceFormat `json:"data_source_format,omitempty"`
 	// [Create,Update:IGN] Full name of Table, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.&lt;table_name&gt;
+	// <catalog_name>.<schema_name>.<table_name>
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -978,8 +978,8 @@ type CreateTableResponse struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Table.
 	Privileges []CreateTableResponsePrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create:REQ Update:IGN] Name of parent Schema relative to its parent
@@ -995,18 +995,18 @@ type CreateTableResponse struct {
 	StorageLocation string `json:"storage_location,omitempty"`
 	// [Create:IGN Update:IGN] Name of Table, relative to parent Schema.
 	TableId string `json:"table_id,omitempty"`
-	// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+	// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 	TableType CreateTableResponseTableType `json:"table_type,omitempty"`
 	// [Create,Update:IGN] Time at which this Table was last modified, in epoch
 	// milliseconds.
 	UpdatedAt int64 `json:"updated_at,omitempty"`
 	// [Create,Update:IGN] Username of user who last modified the Table.
 	UpdatedBy string `json:"updated_by,omitempty"`
-	// [Create,Update:OPT] View definition SQL (when table_type == &#34;VIEW&#34;)
+	// [Create,Update:OPT] View definition SQL (when table_type == "VIEW")
 	ViewDefinition string `json:"view_definition,omitempty"`
 }
 
-// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 type CreateTableResponseDataSourceFormat string
 
 const CreateTableResponseDataSourceFormatAvro CreateTableResponseDataSourceFormat = `AVRO`
@@ -1049,7 +1049,7 @@ const CreateTableResponsePrivilegesItemUsage CreateTableResponsePrivilegesItem =
 
 const CreateTableResponsePrivilegesItemWriteFiles CreateTableResponsePrivilegesItem = `WRITE_FILES`
 
-// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 type CreateTableResponseTableType string
 
 const CreateTableResponseTableTypeExternal CreateTableResponseTableType = `EXTERNAL`
@@ -1127,7 +1127,7 @@ type ExternalLocationInfo struct {
 	CreatedAt int64 `json:"created_at,omitempty"`
 	// [Create,Update:IGN] Username of External Location creator.
 	CreatedBy string `json:"created_by,omitempty"`
-	// [Create,Update:IGN] Unique ID of the location&#39;s Storage Credential.
+	// [Create,Update:IGN] Unique ID of the location's Storage Credential.
 	CredentialId string `json:"credential_id,omitempty"`
 	// [Create:REQ Update:OPT] Current name of the Storage Credential this
 	// location uses.
@@ -1190,8 +1190,8 @@ type GetCatalogResponse struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Catalog.
 	Privileges []GetCatalogResponsePrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// Delta Sharing Catalog specific fields. A Delta Sharing Catalog is a
@@ -1251,7 +1251,7 @@ type GetExternalLocationResponse struct {
 	CreatedAt int64 `json:"created_at,omitempty"`
 	// [Create,Update:IGN] Username of External Location creator.
 	CreatedBy string `json:"created_by,omitempty"`
-	// [Create,Update:IGN] Unique ID of the location&#39;s Storage Credential.
+	// [Create,Update:IGN] Unique ID of the location's Storage Credential.
 	CredentialId string `json:"credential_id,omitempty"`
 	// [Create:REQ Update:OPT] Current name of the Storage Credential this
 	// location uses.
@@ -1336,7 +1336,7 @@ const GetMetastoreResponsePrivilegesItemUsage GetMetastoreResponsePrivilegesItem
 const GetMetastoreResponsePrivilegesItemWriteFiles GetMetastoreResponsePrivilegesItem = `WRITE_FILES`
 
 type GetMetastoreSummaryResponse struct {
-	// Unique identifier of the Metastore&#39;s (Default) Data Access Configuration
+	// Unique identifier of the Metastore's (Default) Data Access Configuration
 	DefaultDataAccessConfigId string `json:"default_data_access_config_id,omitempty"`
 	// The unique ID (UUID) of the Metastore
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -1414,7 +1414,7 @@ type GetRecipientRequest struct {
 
 type GetRecipientResponse struct {
 	// [Create:IGN,Update:IGN] A boolean status field showing whether the
-	// Recipient&#39;s activation URL has been exercised or not.
+	// Recipient's activation URL has been exercised or not.
 	Activated bool `json:"activated,omitempty"`
 	// [Create:IGN,Update:IGN] Full activation url to retrieve the access token.
 	// It will be empty if the token is already retrieved.
@@ -1480,7 +1480,7 @@ type GetSchemaResponse struct {
 	// [Create,Update:IGN] Username of Schema creator.
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Full name of Schema, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.
+	// <catalog_name>.<schema_name>.
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -1490,8 +1490,8 @@ type GetSchemaResponse struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Schema.
 	Privileges []GetSchemaResponsePrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create,Update:IGN] Time at which this Schema was created, in epoch
@@ -1593,8 +1593,8 @@ type GetTableRequest struct {
 type GetTableResponse struct {
 	// [Create:REQ Update:IGN] Name of parent Catalog.
 	CatalogName string `json:"catalog_name,omitempty"`
-	// This name (&#39;columns&#39;) is what the client actually sees as the field name
-	// in messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('columns') is what the client actually sees as the field name
+	// in messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Columns []ColumnInfo `json:"columns,omitempty"`
 	// [Create,Update:OPT] User-provided free-form text description.
@@ -1606,10 +1606,10 @@ type GetTableResponse struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Unique ID of the data_access_configuration to use.
 	DataAccessConfigurationId string `json:"data_access_configuration_id,omitempty"`
-	// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+	// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 	DataSourceFormat GetTableResponseDataSourceFormat `json:"data_source_format,omitempty"`
 	// [Create,Update:IGN] Full name of Table, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.&lt;table_name&gt;
+	// <catalog_name>.<schema_name>.<table_name>
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -1619,8 +1619,8 @@ type GetTableResponse struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Table.
 	Privileges []GetTableResponsePrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create:REQ Update:IGN] Name of parent Schema relative to its parent
@@ -1636,18 +1636,18 @@ type GetTableResponse struct {
 	StorageLocation string `json:"storage_location,omitempty"`
 	// [Create:IGN Update:IGN] Name of Table, relative to parent Schema.
 	TableId string `json:"table_id,omitempty"`
-	// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+	// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 	TableType GetTableResponseTableType `json:"table_type,omitempty"`
 	// [Create,Update:IGN] Time at which this Table was last modified, in epoch
 	// milliseconds.
 	UpdatedAt int64 `json:"updated_at,omitempty"`
 	// [Create,Update:IGN] Username of user who last modified the Table.
 	UpdatedBy string `json:"updated_by,omitempty"`
-	// [Create,Update:OPT] View definition SQL (when table_type == &#34;VIEW&#34;)
+	// [Create,Update:OPT] View definition SQL (when table_type == "VIEW")
 	ViewDefinition string `json:"view_definition,omitempty"`
 }
 
-// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 type GetTableResponseDataSourceFormat string
 
 const GetTableResponseDataSourceFormatAvro GetTableResponseDataSourceFormat = `AVRO`
@@ -1690,7 +1690,7 @@ const GetTableResponsePrivilegesItemUsage GetTableResponsePrivilegesItem = `USAG
 
 const GetTableResponsePrivilegesItemWriteFiles GetTableResponsePrivilegesItem = `WRITE_FILES`
 
-// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 type GetTableResponseTableType string
 
 const GetTableResponseTableTypeExternal GetTableResponseTableType = `EXTERNAL`
@@ -1783,7 +1783,7 @@ type ListTableSummariesRequest struct {
 }
 
 type ListTableSummariesResponse struct {
-	// Optional. Opaque token for pagination. Empty if there&#39;s no more page.
+	// Optional. Opaque token for pagination. Empty if there's no more page.
 	NextPageToken string `json:"next_page_token,omitempty"`
 	// Only name, catalog_name, schema_name, full_name and table_type will be
 	// set.
@@ -2004,7 +2004,7 @@ type ProviderShare struct {
 
 type RecipientInfo struct {
 	// [Create:IGN,Update:IGN] A boolean status field showing whether the
-	// Recipient&#39;s activation URL has been exercised or not.
+	// Recipient's activation URL has been exercised or not.
 	Activated bool `json:"activated,omitempty"`
 	// [Create:IGN,Update:IGN] Full activation url to retrieve the access token.
 	// It will be empty if the token is already retrieved.
@@ -2097,7 +2097,7 @@ type RotateRecipientTokenRequest struct {
 
 type RotateRecipientTokenResponse struct {
 	// [Create:IGN,Update:IGN] A boolean status field showing whether the
-	// Recipient&#39;s activation URL has been exercised or not.
+	// Recipient's activation URL has been exercised or not.
 	Activated bool `json:"activated,omitempty"`
 	// [Create:IGN,Update:IGN] Full activation url to retrieve the access token.
 	// It will be empty if the token is already retrieved.
@@ -2149,7 +2149,7 @@ type SchemaInfo struct {
 	// [Create,Update:IGN] Username of Schema creator.
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Full name of Schema, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.
+	// <catalog_name>.<schema_name>.
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -2159,8 +2159,8 @@ type SchemaInfo struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Schema.
 	Privileges []SchemaInfoPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create,Update:IGN] Time at which this Schema was created, in epoch
@@ -2222,15 +2222,15 @@ type SharedDataObject struct {
 	// The type of the data object. Output only field. [Update:IGN]
 	DataObjectType string `json:"data_object_type,omitempty"`
 	// A fully qualified name that uniquely identifies a data object. For
-	// example, a table&#39;s fully qualified name is in the format of
-	// `&lt;catalog&gt;.&lt;schema&gt;.&lt;table&gt;`. [Update:REQ]
+	// example, a table's fully qualified name is in the format of
+	// `<catalog>.<schema>.<table>`. [Update:REQ]
 	Name string `json:"name,omitempty"`
 
 	Partitions []Partition `json:"partitions,omitempty"`
 	// A user-provided new name for the data object within the share. If this
-	// new name is not not provided, the object&#39;s original name will be used as
+	// new name is not not provided, the object's original name will be used as
 	// the `shared_as` name. The `shared_as` name must be unique within a Share.
-	// For tables, the new name must follow the format of `&lt;schema&gt;.&lt;table&gt;`.
+	// For tables, the new name must follow the format of `<schema>.<table>`.
 	// [Update:OPT]
 	SharedAs string `json:"shared_as,omitempty"`
 }
@@ -2285,8 +2285,8 @@ type StringKeyValuePair struct {
 type TableInfo struct {
 	// [Create:REQ Update:IGN] Name of parent Catalog.
 	CatalogName string `json:"catalog_name,omitempty"`
-	// This name (&#39;columns&#39;) is what the client actually sees as the field name
-	// in messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('columns') is what the client actually sees as the field name
+	// in messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Columns []ColumnInfo `json:"columns,omitempty"`
 	// [Create,Update:OPT] User-provided free-form text description.
@@ -2298,10 +2298,10 @@ type TableInfo struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Unique ID of the data_access_configuration to use.
 	DataAccessConfigurationId string `json:"data_access_configuration_id,omitempty"`
-	// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+	// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 	DataSourceFormat TableInfoDataSourceFormat `json:"data_source_format,omitempty"`
 	// [Create,Update:IGN] Full name of Table, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.&lt;table_name&gt;
+	// <catalog_name>.<schema_name>.<table_name>
 	FullName string `json:"full_name,omitempty"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
@@ -2311,8 +2311,8 @@ type TableInfo struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Table.
 	Privileges []TableInfoPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create:REQ Update:IGN] Name of parent Schema relative to its parent
@@ -2328,18 +2328,18 @@ type TableInfo struct {
 	StorageLocation string `json:"storage_location,omitempty"`
 	// [Create:IGN Update:IGN] Name of Table, relative to parent Schema.
 	TableId string `json:"table_id,omitempty"`
-	// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+	// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 	TableType TableInfoTableType `json:"table_type,omitempty"`
 	// [Create,Update:IGN] Time at which this Table was last modified, in epoch
 	// milliseconds.
 	UpdatedAt int64 `json:"updated_at,omitempty"`
 	// [Create,Update:IGN] Username of user who last modified the Table.
 	UpdatedBy string `json:"updated_by,omitempty"`
-	// [Create,Update:OPT] View definition SQL (when table_type == &#34;VIEW&#34;)
+	// [Create,Update:OPT] View definition SQL (when table_type == "VIEW")
 	ViewDefinition string `json:"view_definition,omitempty"`
 }
 
-// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 type TableInfoDataSourceFormat string
 
 const TableInfoDataSourceFormatAvro TableInfoDataSourceFormat = `AVRO`
@@ -2382,7 +2382,7 @@ const TableInfoPrivilegesItemUsage TableInfoPrivilegesItem = `USAGE`
 
 const TableInfoPrivilegesItemWriteFiles TableInfoPrivilegesItem = `WRITE_FILES`
 
-// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 type TableInfoTableType string
 
 const TableInfoTableTypeExternal TableInfoTableType = `EXTERNAL`
@@ -2429,8 +2429,8 @@ type UpdateCatalogRequest struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Catalog.
 	Privileges []UpdateCatalogRequestPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// Delta Sharing Catalog specific fields. A Delta Sharing Catalog is a
@@ -2485,12 +2485,12 @@ type UpdateExternalLocationRequest struct {
 	CreatedAt int64 `json:"created_at,omitempty"`
 	// [Create,Update:IGN] Username of External Location creator.
 	CreatedBy string `json:"created_by,omitempty"`
-	// [Create,Update:IGN] Unique ID of the location&#39;s Storage Credential.
+	// [Create,Update:IGN] Unique ID of the location's Storage Credential.
 	CredentialId string `json:"credential_id,omitempty"`
 	// [Create:REQ Update:OPT] Current name of the Storage Credential this
 	// location uses.
 	CredentialName string `json:"credential_name,omitempty"`
-	// TODO: SC-90063 re-add &#39;force&#39; parameter in backward-compatible way for
+	// TODO: SC-90063 re-add 'force' parameter in backward-compatible way for
 	// DBR (not removed below as it still works with CLI) Optional. Force update
 	// even if changing url invalidates dependent external tables or mounts.
 	Force bool `json:"force,omitempty"`
@@ -2635,7 +2635,7 @@ const UpdateProviderRequestAuthenticationTypeUnknown UpdateProviderRequestAuthen
 
 type UpdateRecipientRequest struct {
 	// [Create:IGN,Update:IGN] A boolean status field showing whether the
-	// Recipient&#39;s activation URL has been exercised or not.
+	// Recipient's activation URL has been exercised or not.
 	Activated bool `json:"activated,omitempty"`
 	// [Create:IGN,Update:IGN] Full activation url to retrieve the access token.
 	// It will be empty if the token is already retrieved.
@@ -2689,7 +2689,7 @@ type UpdateSchemaRequest struct {
 	// [Create,Update:IGN] Username of Schema creator.
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Full name of Schema, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.
+	// <catalog_name>.<schema_name>.
 	FullName string `json:"full_name,omitempty"`
 	// Required. Full name of the Schema (from URL).
 	FullNameArg string ` path:"full_name_arg"`
@@ -2701,8 +2701,8 @@ type UpdateSchemaRequest struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Schema.
 	Privileges []UpdateSchemaRequestPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create,Update:IGN] Time at which this Schema was created, in epoch
@@ -2781,8 +2781,8 @@ type UpdateStorageCredentialRequest struct {
 type UpdateTableRequest struct {
 	// [Create:REQ Update:IGN] Name of parent Catalog.
 	CatalogName string `json:"catalog_name,omitempty"`
-	// This name (&#39;columns&#39;) is what the client actually sees as the field name
-	// in messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('columns') is what the client actually sees as the field name
+	// in messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Columns []ColumnInfo `json:"columns,omitempty"`
 	// [Create,Update:OPT] User-provided free-form text description.
@@ -2794,10 +2794,10 @@ type UpdateTableRequest struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Unique ID of the data_access_configuration to use.
 	DataAccessConfigurationId string `json:"data_access_configuration_id,omitempty"`
-	// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+	// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 	DataSourceFormat UpdateTableRequestDataSourceFormat `json:"data_source_format,omitempty"`
 	// [Create,Update:IGN] Full name of Table, in form of
-	// &lt;catalog_name&gt;.&lt;schema_name&gt;.&lt;table_name&gt;
+	// <catalog_name>.<schema_name>.<table_name>
 	FullName string `json:"full_name,omitempty"`
 	// Required. Full name of the Table (from URL).
 	FullNameArg string ` path:"full_name_arg"`
@@ -2809,8 +2809,8 @@ type UpdateTableRequest struct {
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Table.
 	Privileges []UpdateTableRequestPrivilegesItem `json:"privileges,omitempty"`
-	// This name (&#39;properties&#39;) is what the client sees as the field name in
-	// messages that include PropertiesKVPairs using &#39;json_inline&#39; (e.g.,
+	// This name ('properties') is what the client sees as the field name in
+	// messages that include PropertiesKVPairs using 'json_inline' (e.g.,
 	// TableInfo).
 	Properties []StringKeyValuePair `json:"properties,omitempty"`
 	// [Create:REQ Update:IGN] Name of parent Schema relative to its parent
@@ -2826,18 +2826,18 @@ type UpdateTableRequest struct {
 	StorageLocation string `json:"storage_location,omitempty"`
 	// [Create:IGN Update:IGN] Name of Table, relative to parent Schema.
 	TableId string `json:"table_id,omitempty"`
-	// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+	// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 	TableType UpdateTableRequestTableType `json:"table_type,omitempty"`
 	// [Create,Update:IGN] Time at which this Table was last modified, in epoch
 	// milliseconds.
 	UpdatedAt int64 `json:"updated_at,omitempty"`
 	// [Create,Update:IGN] Username of user who last modified the Table.
 	UpdatedBy string `json:"updated_by,omitempty"`
-	// [Create,Update:OPT] View definition SQL (when table_type == &#34;VIEW&#34;)
+	// [Create,Update:OPT] View definition SQL (when table_type == "VIEW")
 	ViewDefinition string `json:"view_definition,omitempty"`
 }
 
-// [Create:REQ Update:OPT] Data source format (&#34;DELTA&#34;, &#34;CSV&#34;, etc.).
+// [Create:REQ Update:OPT] Data source format ("DELTA", "CSV", etc.).
 type UpdateTableRequestDataSourceFormat string
 
 const UpdateTableRequestDataSourceFormatAvro UpdateTableRequestDataSourceFormat = `AVRO`
@@ -2880,7 +2880,7 @@ const UpdateTableRequestPrivilegesItemUsage UpdateTableRequestPrivilegesItem = `
 
 const UpdateTableRequestPrivilegesItemWriteFiles UpdateTableRequestPrivilegesItem = `WRITE_FILES`
 
-// [Create:REQ Update:OPT] Table type (&#34;MANAGED&#34;, &#34;EXTERNAL&#34;, &#34;VIEW&#34;).
+// [Create:REQ Update:OPT] Table type ("MANAGED", "EXTERNAL", "VIEW").
 type UpdateTableRequestTableType string
 
 const UpdateTableRequestTableTypeExternal UpdateTableRequestTableType = `EXTERNAL`

--- a/service/warehouses/model.go
+++ b/service/warehouses/model.go
@@ -25,7 +25,7 @@ const ChannelNameChannelNameUnspecified ChannelName = `CHANNEL_NAME_UNSPECIFIED`
 type CreateWarehouseRequest struct {
 	// The amount of time in minutes that a SQL Endpoint must be idle (i.e., no
 	// RUNNING queries) before it is automatically stopped. Supported values: -
-	// Must be == 0 or &gt;= 10 mins - 0 indicates no autostop. Defaults to 120
+	// Must be == 0 or >= 10 mins - 0 indicates no autostop. Defaults to 120
 	// mins
 	AutoStopMins int `json:"auto_stop_mins,omitempty"`
 	// Channel Details
@@ -47,34 +47,34 @@ type CreateWarehouseRequest struct {
 	// Deprecated. Instance profile used to pass IAM role to the cluster
 	InstanceProfileArn string `json:"instance_profile_arn,omitempty"`
 	// Maximum number of clusters that the autoscaler will create to handle
-	// concurrent queries. Supported values: - Must be &gt;= min_num_clusters -
-	// Must be &lt;= 30. Defaults to min_clusters if unset.
+	// concurrent queries. Supported values: - Must be >= min_num_clusters -
+	// Must be <= 30. Defaults to min_clusters if unset.
 	MaxNumClusters int `json:"max_num_clusters,omitempty"`
 	// Minimum number of available clusters that will be maintained for this SQL
 	// Endpoint. Increasing this will ensure that a larger number of clusters
 	// are always running and therefore may reduce the cold start time for new
 	// queries. This is similar to reserved vs. revocable cores in a resource
-	// manager. Supported values: - Must be &gt; 0 - Must be &lt;=
+	// manager. Supported values: - Must be > 0 - Must be <=
 	// min(max_num_clusters, 30) Defaults to 1
 	MinNumClusters int `json:"min_num_clusters,omitempty"`
 	// Logical name for the cluster. Supported values: - Must be unique within
 	// an org. - Must be less than 100 characters.
 	Name string `json:"name,omitempty"`
 	// Configurations whether the endpoint should use spot instances. Supported
-	// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to
+	// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to
 	// COST_OPTIMIZED. Please refer to documentation for
 	// EndpointSpotInstancePolicy for more details.
 	SpotInstancePolicy CreateWarehouseRequestSpotInstancePolicy `json:"spot_instance_policy,omitempty"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL Endpoints. Supported
-	// values: - Number of tags &lt; 45.
+	// values: - Number of tags < 45.
 	Tags *EndpointTags `json:"tags,omitempty"`
 	// Warehouse type (Classic/Pro)
 	WarehouseType CreateWarehouseRequestWarehouseType `json:"warehouse_type,omitempty"`
 }
 
 // Configurations whether the endpoint should use spot instances. Supported
-// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to COST_OPTIMIZED.
+// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to COST_OPTIMIZED.
 // Please refer to documentation for EndpointSpotInstancePolicy for more
 // details.
 type CreateWarehouseRequestSpotInstancePolicy string
@@ -107,7 +107,7 @@ type DeleteWarehouseRequest struct {
 type EditWarehouseRequest struct {
 	// The amount of time in minutes that a SQL Endpoint must be idle (i.e., no
 	// RUNNING queries) before it is automatically stopped. Supported values: -
-	// Must be == 0 or &gt;= 10 mins - 0 indicates no autostop. Defaults to 120
+	// Must be == 0 or >= 10 mins - 0 indicates no autostop. Defaults to 120
 	// mins
 	AutoStopMins int `json:"auto_stop_mins,omitempty"`
 	// Channel Details
@@ -119,7 +119,7 @@ type EditWarehouseRequest struct {
 	// - 2X-Large - 3X-Large - 4X-Large
 	ClusterSize string `json:"cluster_size,omitempty"`
 	// Needed for backwards compatibility. config.conf is json_inlined. We need
-	// to keep confs here to make sure json calls with &#39;confs&#39; explicitly
+	// to keep confs here to make sure json calls with 'confs' explicitly
 	// specified continue to work as is.
 	Confs any/* ERROR */ `json:"confs,omitempty"`
 	// endpoint creator name
@@ -139,34 +139,34 @@ type EditWarehouseRequest struct {
 	// Deprecated. Instance profile used to pass IAM role to the cluster
 	InstanceProfileArn string `json:"instance_profile_arn,omitempty"`
 	// Maximum number of clusters that the autoscaler will create to handle
-	// concurrent queries. Supported values: - Must be &gt;= min_num_clusters -
-	// Must be &lt;= 30. Defaults to min_clusters if unset.
+	// concurrent queries. Supported values: - Must be >= min_num_clusters -
+	// Must be <= 30. Defaults to min_clusters if unset.
 	MaxNumClusters int `json:"max_num_clusters,omitempty"`
 	// Minimum number of available clusters that will be maintained for this SQL
 	// Endpoint. Increasing this will ensure that a larger number of clusters
 	// are always running and therefore may reduce the cold start time for new
 	// queries. This is similar to reserved vs. revocable cores in a resource
-	// manager. Supported values: - Must be &gt; 0 - Must be &lt;=
+	// manager. Supported values: - Must be > 0 - Must be <=
 	// min(max_num_clusters, 30) Defaults to 1
 	MinNumClusters int `json:"min_num_clusters,omitempty"`
 	// Logical name for the cluster. Supported values: - Must be unique within
 	// an org. - Must be less than 100 characters.
 	Name string `json:"name,omitempty"`
 	// Configurations whether the endpoint should use spot instances. Supported
-	// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to
+	// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to
 	// COST_OPTIMIZED. Please refer to documentation for
 	// EndpointSpotInstancePolicy for more details.
 	SpotInstancePolicy EditWarehouseRequestSpotInstancePolicy `json:"spot_instance_policy,omitempty"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL Endpoints. Supported
-	// values: - Number of tags &lt; 45.
+	// values: - Number of tags < 45.
 	Tags *EndpointTags `json:"tags,omitempty"`
 	// Warehouse type (Classic/Pro)
 	WarehouseType EditWarehouseRequestWarehouseType `json:"warehouse_type,omitempty"`
 }
 
 // Configurations whether the endpoint should use spot instances. Supported
-// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to COST_OPTIMIZED.
+// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to COST_OPTIMIZED.
 // Please refer to documentation for EndpointSpotInstancePolicy for more
 // details.
 type EditWarehouseRequestSpotInstancePolicy string
@@ -196,7 +196,7 @@ type EndpointHealth struct {
 	// Details about errors that are causing current degraded/failed status.
 	Details string `json:"details,omitempty"`
 	// The reason for failure to bring up clusters for this endpoint. This is
-	// available when status is &#39;FAILED&#39; and sometimes when it is DEGRADED.
+	// available when status is 'FAILED' and sometimes when it is DEGRADED.
 	FailureReason *TerminationReason `json:"failure_reason,omitempty"`
 	// Deprecated. split into summary and details for security
 	Message string `json:"message,omitempty"`
@@ -221,7 +221,7 @@ const EndpointHealthStatusStatusUnspecified EndpointHealthStatus = `STATUS_UNSPE
 type EndpointInfo struct {
 	// The amount of time in minutes that a SQL Endpoint must be idle (i.e., no
 	// RUNNING queries) before it is automatically stopped. Supported values: -
-	// Must be == 0 or &gt;= 10 mins - 0 indicates no autostop. Defaults to 120
+	// Must be == 0 or >= 10 mins - 0 indicates no autostop. Defaults to 120
 	// mins
 	AutoStopMins int `json:"auto_stop_mins,omitempty"`
 	// Channel Details
@@ -254,14 +254,14 @@ type EndpointInfo struct {
 	// the jdbc connection string for this endpoint
 	JdbcUrl string `json:"jdbc_url,omitempty"`
 	// Maximum number of clusters that the autoscaler will create to handle
-	// concurrent queries. Supported values: - Must be &gt;= min_num_clusters -
-	// Must be &lt;= 30. Defaults to min_clusters if unset.
+	// concurrent queries. Supported values: - Must be >= min_num_clusters -
+	// Must be <= 30. Defaults to min_clusters if unset.
 	MaxNumClusters int `json:"max_num_clusters,omitempty"`
 	// Minimum number of available clusters that will be maintained for this SQL
 	// Endpoint. Increasing this will ensure that a larger number of clusters
 	// are always running and therefore may reduce the cold start time for new
 	// queries. This is similar to reserved vs. revocable cores in a resource
-	// manager. Supported values: - Must be &gt; 0 - Must be &lt;=
+	// manager. Supported values: - Must be > 0 - Must be <=
 	// min(max_num_clusters, 30) Defaults to 1
 	MinNumClusters int `json:"min_num_clusters,omitempty"`
 	// Logical name for the cluster. Supported values: - Must be unique within
@@ -274,7 +274,7 @@ type EndpointInfo struct {
 	// ODBC parameters for the sql endpoint
 	OdbcParams *OdbcParams `json:"odbc_params,omitempty"`
 	// Configurations whether the endpoint should use spot instances. Supported
-	// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to
+	// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to
 	// COST_OPTIMIZED. Please refer to documentation for
 	// EndpointSpotInstancePolicy for more details.
 	SpotInstancePolicy EndpointInfoSpotInstancePolicy `json:"spot_instance_policy,omitempty"`
@@ -282,14 +282,14 @@ type EndpointInfo struct {
 	State EndpointInfoState `json:"state,omitempty"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL Endpoints. Supported
-	// values: - Number of tags &lt; 45.
+	// values: - Number of tags < 45.
 	Tags *EndpointTags `json:"tags,omitempty"`
 	// Warehouse type (Classic/Pro)
 	WarehouseType EndpointInfoWarehouseType `json:"warehouse_type,omitempty"`
 }
 
 // Configurations whether the endpoint should use spot instances. Supported
-// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to COST_OPTIMIZED.
+// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to COST_OPTIMIZED.
 // Please refer to documentation for EndpointSpotInstancePolicy for more
 // details.
 type EndpointInfoSpotInstancePolicy string
@@ -342,7 +342,7 @@ type GetWarehouseRequest struct {
 type GetWarehouseResponse struct {
 	// The amount of time in minutes that a SQL Endpoint must be idle (i.e., no
 	// RUNNING queries) before it is automatically stopped. Supported values: -
-	// Must be == 0 or &gt;= 10 mins - 0 indicates no autostop. Defaults to 120
+	// Must be == 0 or >= 10 mins - 0 indicates no autostop. Defaults to 120
 	// mins
 	AutoStopMins int `json:"auto_stop_mins,omitempty"`
 	// Channel Details
@@ -375,14 +375,14 @@ type GetWarehouseResponse struct {
 	// the jdbc connection string for this endpoint
 	JdbcUrl string `json:"jdbc_url,omitempty"`
 	// Maximum number of clusters that the autoscaler will create to handle
-	// concurrent queries. Supported values: - Must be &gt;= min_num_clusters -
-	// Must be &lt;= 30. Defaults to min_clusters if unset.
+	// concurrent queries. Supported values: - Must be >= min_num_clusters -
+	// Must be <= 30. Defaults to min_clusters if unset.
 	MaxNumClusters int `json:"max_num_clusters,omitempty"`
 	// Minimum number of available clusters that will be maintained for this SQL
 	// Endpoint. Increasing this will ensure that a larger number of clusters
 	// are always running and therefore may reduce the cold start time for new
 	// queries. This is similar to reserved vs. revocable cores in a resource
-	// manager. Supported values: - Must be &gt; 0 - Must be &lt;=
+	// manager. Supported values: - Must be > 0 - Must be <=
 	// min(max_num_clusters, 30) Defaults to 1
 	MinNumClusters int `json:"min_num_clusters,omitempty"`
 	// Logical name for the cluster. Supported values: - Must be unique within
@@ -395,7 +395,7 @@ type GetWarehouseResponse struct {
 	// ODBC parameters for the sql endpoint
 	OdbcParams *OdbcParams `json:"odbc_params,omitempty"`
 	// Configurations whether the endpoint should use spot instances. Supported
-	// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to
+	// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to
 	// COST_OPTIMIZED. Please refer to documentation for
 	// EndpointSpotInstancePolicy for more details.
 	SpotInstancePolicy GetWarehouseResponseSpotInstancePolicy `json:"spot_instance_policy,omitempty"`
@@ -403,14 +403,14 @@ type GetWarehouseResponse struct {
 	State GetWarehouseResponseState `json:"state,omitempty"`
 	// A set of key-value pairs that will be tagged on all resources (e.g., AWS
 	// instances and EBS volumes) associated with this SQL Endpoints. Supported
-	// values: - Number of tags &lt; 45.
+	// values: - Number of tags < 45.
 	Tags *EndpointTags `json:"tags,omitempty"`
 	// Warehouse type (Classic/Pro)
 	WarehouseType GetWarehouseResponseWarehouseType `json:"warehouse_type,omitempty"`
 }
 
 // Configurations whether the endpoint should use spot instances. Supported
-// values: &#34;COST_OPTIMIZED&#34;, &#34;RELIABILITY_OPTIMIZED&#34; Defaults to COST_OPTIMIZED.
+// values: "COST_OPTIMIZED", "RELIABILITY_OPTIMIZED" Defaults to COST_OPTIMIZED.
 // Please refer to documentation for EndpointSpotInstancePolicy for more
 // details.
 type GetWarehouseResponseSpotInstancePolicy string
@@ -451,7 +451,7 @@ type GetWorkspaceWarehouseConfigResponse struct {
 	// Deprecated: Use sql_configuration_parameters
 	ConfigParam *RepeatedEndpointConfPairs `json:"config_param,omitempty"`
 	// Spark confs for external hive metastore configuration JSON serialized
-	// size must be less than &lt;= 512K
+	// size must be less than <= 512K
 	DataAccessConfig []EndpointConfPair `json:"data_access_config,omitempty"`
 	// Enable Serverless compute for SQL Endpoints Deprecated: Use
 	// enable_serverless_compute TODO(SC-79930): Remove the field once clients
@@ -461,7 +461,7 @@ type GetWorkspaceWarehouseConfigResponse struct {
 	EnableServerlessCompute bool `json:"enable_serverless_compute,omitempty"`
 	// List of Warehouse Types allowed in this workspace (limits allowed value
 	// of the type field in CreateWarehouse and EditWarehouse). Note: Some types
-	// cannot be disabled, they don&#39;t need to be specified in
+	// cannot be disabled, they don't need to be specified in
 	// SetWorkspaceWarehouseConfig. Note: Disabling a type may cause existing
 	// warehouses to be converted to another type. Used by frontend to save
 	// specific type availability in the warehouse create and edit form UI.
@@ -522,7 +522,7 @@ type SetWorkspaceWarehouseConfigRequest struct {
 	// Deprecated: Use sql_configuration_parameters
 	ConfigParam *RepeatedEndpointConfPairs `json:"config_param,omitempty"`
 	// Spark confs for external hive metastore configuration JSON serialized
-	// size must be less than &lt;= 512K
+	// size must be less than <= 512K
 	DataAccessConfig []EndpointConfPair `json:"data_access_config,omitempty"`
 	// Enable Serverless compute for SQL Endpoints Deprecated: Use
 	// enable_serverless_compute TODO(SC-79930): Remove the field once clients
@@ -532,7 +532,7 @@ type SetWorkspaceWarehouseConfigRequest struct {
 	EnableServerlessCompute bool `json:"enable_serverless_compute,omitempty"`
 	// List of Warehouse Types allowed in this workspace (limits allowed value
 	// of the type field in CreateWarehouse and EditWarehouse). Note: Some types
-	// cannot be disabled, they don&#39;t need to be specified in
+	// cannot be disabled, they don't need to be specified in
 	// SetWorkspaceWarehouseConfig. Note: Disabling a type may cause existing
 	// warehouses to be converted to another type. Used by frontend to save
 	// specific type availability in the warehouse create and edit form UI.

--- a/service/workspace/api.go
+++ b/service/workspace/api.go
@@ -24,7 +24,7 @@ type WorkspaceAPI struct {
 // “recursive“ is set to “false“, this call returns an error
 // “DIRECTORY_NOT_EMPTY“. Object deletion cannot be undone and deleting a
 // directory recursively is not atomic. Example of request: .. code :: json {
-// &#34;path&#34;: &#34;/Users/user@example.com/project&#34;, &#34;recursive&#34;: true }
+// "path": "/Users/user@example.com/project", "recursive": true }
 func (a *WorkspaceAPI) Delete(ctx context.Context, request DeleteRequest) error {
 	path := "/api/2.0/workspace/delete"
 	err := a.client.Post(ctx, path, request, nil)
@@ -36,13 +36,13 @@ func (a *WorkspaceAPI) Delete(ctx context.Context, request DeleteRequest) error 
 // export a directory in “DBC“ format. If the exported data would exceed size
 // limit, this call returns an error “MAX_NOTEBOOK_SIZE_EXCEEDED“. Currently,
 // this API does not support exporting a library. Example of request: .. code ::
-// json { &#34;path&#34;: &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;,
-// &#34;format&#34;: &#34;SOURCE&#34; } Example of response, where “content“ is
-// base64-encoded: .. code :: json { &#34;content&#34;:
-// &#34;Ly8gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKMSsx&#34;, } Alternaitvely, one can
+// json { "path": "/Users/user@example.com/project/ScalaExampleNotebook",
+// "format": "SOURCE" } Example of response, where “content“ is
+// base64-encoded: .. code :: json { "content":
+// "Ly8gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKMSsx", } Alternaitvely, one can
 // download the exported file by enabling “direct_download“: .. code :: shell
 // curl -n -o example.scala \
-// &#39;https://XX.cloud.databricks.com/api/2.0/workspace/export?path=/Users/user@example.com/ScalaExampleNotebook&amp;direct_download=true&#39;
+// 'https://XX.cloud.databricks.com/api/2.0/workspace/export?path=/Users/user@example.com/ScalaExampleNotebook&direct_download=true'
 func (a *WorkspaceAPI) Export(ctx context.Context, request ExportRequest) (*ExportResponse, error) {
 	var exportResponse ExportResponse
 	path := "/api/2.0/workspace/export"
@@ -52,10 +52,10 @@ func (a *WorkspaceAPI) Export(ctx context.Context, request ExportRequest) (*Expo
 
 // Gets the status of an object or a directory. If “path“ does not exist, this
 // call returns an error “RESOURCE_DOES_NOT_EXIST“. Example of request: ..
-// code :: json { &#34;path&#34;: &#34;/Users/user@example.com/project/ScaleExampleNotebook&#34;
-// } Example of response: .. code :: json { &#34;path&#34;:
-// &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;, &#34;language&#34;: &#34;SCALA&#34;,
-// &#34;object_type&#34;: &#34;NOTEBOOK&#34;, &#34;object_id&#34;: 789 }
+// code :: json { "path": "/Users/user@example.com/project/ScaleExampleNotebook"
+// } Example of response: .. code :: json { "path":
+// "/Users/user@example.com/project/ScalaExampleNotebook", "language": "SCALA",
+// "object_type": "NOTEBOOK", "object_id": 789 }
 func (a *WorkspaceAPI) GetStatus(ctx context.Context, request GetStatusRequest) (*GetStatusResponse, error) {
 	var getStatusResponse GetStatusResponse
 	path := "/api/2.0/workspace/get-status"
@@ -65,10 +65,10 @@ func (a *WorkspaceAPI) GetStatus(ctx context.Context, request GetStatusRequest) 
 
 // Gets the status of an object or a directory. If “path“ does not exist, this
 // call returns an error “RESOURCE_DOES_NOT_EXIST“. Example of request: ..
-// code :: json { &#34;path&#34;: &#34;/Users/user@example.com/project/ScaleExampleNotebook&#34;
-// } Example of response: .. code :: json { &#34;path&#34;:
-// &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;, &#34;language&#34;: &#34;SCALA&#34;,
-// &#34;object_type&#34;: &#34;NOTEBOOK&#34;, &#34;object_id&#34;: 789 }
+// code :: json { "path": "/Users/user@example.com/project/ScaleExampleNotebook"
+// } Example of response: .. code :: json { "path":
+// "/Users/user@example.com/project/ScalaExampleNotebook", "language": "SCALA",
+// "object_type": "NOTEBOOK", "object_id": 789 }
 func (a *WorkspaceAPI) GetStatusByPath(ctx context.Context, path string) (*GetStatusResponse, error) {
 	return a.GetStatus(ctx, GetStatusRequest{
 		Path: path,
@@ -79,9 +79,9 @@ func (a *WorkspaceAPI) GetStatusByPath(ctx context.Context, path string) (*GetSt
 // already exists and “overwrite“ is set to “false“, this call returns an
 // error “RESOURCE_ALREADY_EXISTS“. One can only use “DBC“ format to import
 // a directory. Example of request, where “content“ is the base64-encoded
-// string of “1&#43;1“: .. code :: json { &#34;content&#34;: &#34;MSsx\n&#34;, &#34;path&#34;:
-// &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;, &#34;language&#34;: &#34;SCALA&#34;,
-// &#34;overwrite&#34;: true, &#34;format&#34;: &#34;SOURCE&#34; } Alternatively, one can import a local
+// string of “1+1“: .. code :: json { "content": "MSsx\n", "path":
+// "/Users/user@example.com/project/ScalaExampleNotebook", "language": "SCALA",
+// "overwrite": true, "format": "SOURCE" } Alternatively, one can import a local
 // file directly: .. code :: shell curl -n -F
 // path=/Users/user@example.com/project/ScalaExampleNotebook -F language=SCALA \
 // -F content=@example.scala \
@@ -94,12 +94,12 @@ func (a *WorkspaceAPI) Import(ctx context.Context, request ImportRequest) error 
 
 // Lists the contents of a directory, or the object if it is not a directory. If
 // the input path does not exist, this call returns an error
-// “RESOURCE_DOES_NOT_EXIST“. Example of request: .. code :: json { &#34;path&#34;:
-// &#34;/Users/user@example.com/&#34; } Example of response: .. code :: json {
-// &#34;objects&#34;: [ { &#34;path&#34;: &#34;/Users/user@example.com/project&#34;, &#34;object_type&#34;:
-// &#34;DIRECTORY&#34;, &#34;object_id&#34;: 123 }, { &#34;path&#34;:
-// &#34;/Users/user@example.com/PythonExampleNotebook&#34;, &#34;language&#34;: &#34;PYTHON&#34;,
-// &#34;object_type&#34;: &#34;NOTEBOOK&#34;, &#34;object_id&#34;: 456 } ] }
+// “RESOURCE_DOES_NOT_EXIST“. Example of request: .. code :: json { "path":
+// "/Users/user@example.com/" } Example of response: .. code :: json {
+// "objects": [ { "path": "/Users/user@example.com/project", "object_type":
+// "DIRECTORY", "object_id": 123 }, { "path":
+// "/Users/user@example.com/PythonExampleNotebook", "language": "PYTHON",
+// "object_type": "NOTEBOOK", "object_id": 456 } ] }
 func (a *WorkspaceAPI) List(ctx context.Context, request ListRequest) (*ListResponse, error) {
 	var listResponse ListResponse
 	path := "/api/2.0/workspace/list"
@@ -111,8 +111,8 @@ func (a *WorkspaceAPI) List(ctx context.Context, request ListRequest) (*ListResp
 // exists. If there exists an object (not a directory) at any prefix of the
 // input path, this call returns an error “RESOURCE_ALREADY_EXISTS“. Note that
 // if this operation fails it may have succeeded in creating some of the
-// necessary parrent directories. Example of request: .. code:: json { &#34;path&#34;:
-// &#34;/Users/user@example.com/project&#34; }
+// necessary parrent directories. Example of request: .. code:: json { "path":
+// "/Users/user@example.com/project" }
 func (a *WorkspaceAPI) Mkdirs(ctx context.Context, request MkdirsRequest) error {
 	path := "/api/2.0/workspace/mkdirs"
 	err := a.client.Post(ctx, path, request, nil)
@@ -123,8 +123,8 @@ func (a *WorkspaceAPI) Mkdirs(ctx context.Context, request MkdirsRequest) error 
 // exists. If there exists an object (not a directory) at any prefix of the
 // input path, this call returns an error “RESOURCE_ALREADY_EXISTS“. Note that
 // if this operation fails it may have succeeded in creating some of the
-// necessary parrent directories. Example of request: .. code:: json { &#34;path&#34;:
-// &#34;/Users/user@example.com/project&#34; }
+// necessary parrent directories. Example of request: .. code:: json { "path":
+// "/Users/user@example.com/project" }
 func (a *WorkspaceAPI) MkdirsByPath(ctx context.Context, path string) error {
 	return a.Mkdirs(ctx, MkdirsRequest{
 		Path: path,

--- a/service/workspace/interface.go
+++ b/service/workspace/interface.go
@@ -16,7 +16,7 @@ type WorkspaceService interface {
 	// directory and ``recursive`` is set to ``false``, this call returns an
 	// error ``DIRECTORY_NOT_EMPTY``. Object deletion cannot be undone and
 	// deleting a directory recursively is not atomic. Example of request: ..
-	// code :: json { &#34;path&#34;: &#34;/Users/user@example.com/project&#34;, &#34;recursive&#34;:
+	// code :: json { "path": "/Users/user@example.com/project", "recursive":
 	// true }
 	Delete(ctx context.Context, deleteRequest DeleteRequest) error
 
@@ -25,22 +25,22 @@ type WorkspaceService interface {
 	// can only export a directory in ``DBC`` format. If the exported data would
 	// exceed size limit, this call returns an error
 	// ``MAX_NOTEBOOK_SIZE_EXCEEDED``. Currently, this API does not support
-	// exporting a library. Example of request: .. code :: json { &#34;path&#34;:
-	// &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;, &#34;format&#34;:
-	// &#34;SOURCE&#34; } Example of response, where ``content`` is base64-encoded: ..
-	// code :: json { &#34;content&#34;: &#34;Ly8gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKMSsx&#34;,
+	// exporting a library. Example of request: .. code :: json { "path":
+	// "/Users/user@example.com/project/ScalaExampleNotebook", "format":
+	// "SOURCE" } Example of response, where ``content`` is base64-encoded: ..
+	// code :: json { "content": "Ly8gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKMSsx",
 	// } Alternaitvely, one can download the exported file by enabling
 	// ``direct_download``: .. code :: shell curl -n -o example.scala \
-	// &#39;https://XX.cloud.databricks.com/api/2.0/workspace/export?path=/Users/user@example.com/ScalaExampleNotebook&amp;direct_download=true&#39;
+	// 'https://XX.cloud.databricks.com/api/2.0/workspace/export?path=/Users/user@example.com/ScalaExampleNotebook&direct_download=true'
 	Export(ctx context.Context, exportRequest ExportRequest) (*ExportResponse, error)
 
 	// Gets the status of an object or a directory. If ``path`` does not exist,
 	// this call returns an error ``RESOURCE_DOES_NOT_EXIST``. Example of
-	// request: .. code :: json { &#34;path&#34;:
-	// &#34;/Users/user@example.com/project/ScaleExampleNotebook&#34; } Example of
-	// response: .. code :: json { &#34;path&#34;:
-	// &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;, &#34;language&#34;:
-	// &#34;SCALA&#34;, &#34;object_type&#34;: &#34;NOTEBOOK&#34;, &#34;object_id&#34;: 789 }
+	// request: .. code :: json { "path":
+	// "/Users/user@example.com/project/ScaleExampleNotebook" } Example of
+	// response: .. code :: json { "path":
+	// "/Users/user@example.com/project/ScalaExampleNotebook", "language":
+	// "SCALA", "object_type": "NOTEBOOK", "object_id": 789 }
 	GetStatus(ctx context.Context, getStatusRequest GetStatusRequest) (*GetStatusResponse, error)
 
 	GetStatusByPath(ctx context.Context, path string) (*GetStatusResponse, error)
@@ -48,9 +48,9 @@ type WorkspaceService interface {
 	// already exists and ``overwrite`` is set to ``false``, this call returns
 	// an error ``RESOURCE_ALREADY_EXISTS``. One can only use ``DBC`` format to
 	// import a directory. Example of request, where ``content`` is the
-	// base64-encoded string of ``1&#43;1``: .. code :: json { &#34;content&#34;: &#34;MSsx\n&#34;,
-	// &#34;path&#34;: &#34;/Users/user@example.com/project/ScalaExampleNotebook&#34;,
-	// &#34;language&#34;: &#34;SCALA&#34;, &#34;overwrite&#34;: true, &#34;format&#34;: &#34;SOURCE&#34; }
+	// base64-encoded string of ``1+1``: .. code :: json { "content": "MSsx\n",
+	// "path": "/Users/user@example.com/project/ScalaExampleNotebook",
+	// "language": "SCALA", "overwrite": true, "format": "SOURCE" }
 	// Alternatively, one can import a local file directly: .. code :: shell
 	// curl -n -F path=/Users/user@example.com/project/ScalaExampleNotebook -F
 	// language=SCALA \ -F content=@example.scala \
@@ -60,11 +60,11 @@ type WorkspaceService interface {
 	// Lists the contents of a directory, or the object if it is not a
 	// directory. If the input path does not exist, this call returns an error
 	// ``RESOURCE_DOES_NOT_EXIST``. Example of request: .. code :: json {
-	// &#34;path&#34;: &#34;/Users/user@example.com/&#34; } Example of response: .. code :: json
-	// { &#34;objects&#34;: [ { &#34;path&#34;: &#34;/Users/user@example.com/project&#34;,
-	// &#34;object_type&#34;: &#34;DIRECTORY&#34;, &#34;object_id&#34;: 123 }, { &#34;path&#34;:
-	// &#34;/Users/user@example.com/PythonExampleNotebook&#34;, &#34;language&#34;: &#34;PYTHON&#34;,
-	// &#34;object_type&#34;: &#34;NOTEBOOK&#34;, &#34;object_id&#34;: 456 } ] }
+	// "path": "/Users/user@example.com/" } Example of response: .. code :: json
+	// { "objects": [ { "path": "/Users/user@example.com/project",
+	// "object_type": "DIRECTORY", "object_id": 123 }, { "path":
+	// "/Users/user@example.com/PythonExampleNotebook", "language": "PYTHON",
+	// "object_type": "NOTEBOOK", "object_id": 456 } ] }
 	List(ctx context.Context, listRequest ListRequest) (*ListResponse, error)
 
 	// Creates the given directory and necessary parent directories if they do
@@ -72,7 +72,7 @@ type WorkspaceService interface {
 	// the input path, this call returns an error ``RESOURCE_ALREADY_EXISTS``.
 	// Note that if this operation fails it may have succeeded in creating some
 	// of the necessary parrent directories. Example of request: .. code:: json
-	// { &#34;path&#34;: &#34;/Users/user@example.com/project&#34; }
+	// { "path": "/Users/user@example.com/project" }
 	Mkdirs(ctx context.Context, mkdirsRequest MkdirsRequest) error
 
 	MkdirsByPath(ctx context.Context, path string) error


### PR DESCRIPTION
regenerate comments with `text/template` (instead of `html/template`) in `databricks/openapi/gen/main.go`