### PR TITLE
Use databricks-sdk-go test cluster in databricks-sdk-go nightly tests

### DIFF
--- a/internal/commands_test.go
+++ b/internal/commands_test.go
@@ -15,7 +15,7 @@ func TestAccCommands(t *testing.T) {
 	ctx := context.Background()
 	wsc := workspaces.New()
 
-	clusterId := GetEnvOrSkipTest(t, "TEST_DEFAULT_CLUSTER_ID")
+	clusterId := GetEnvOrSkipTest(t, "TEST_DATABRICKS_SDK_GO_CLUSTER_ID")
 
 	info, err := wsc.Clusters.GetByClusterId(ctx, clusterId)
 	require.NoError(t, err)


### PR DESCRIPTION
Tested by manually running the affected test against azure-prod workspace