### PR TITLE
Allow []byte as request body parameter

### DIFF
--- a/databricks/client/client.go
+++ b/databricks/client/client.go
@@ -423,6 +423,9 @@ func makeRequestBody(method string, requestURL *string, data interface{}) ([]byt
 		*requestURL += qs
 		return requestBody, nil
 	}
+	if bytes, ok := data.([]byte); ok {
+		return bytes, nil
+	}
 	if reader, ok := data.(io.Reader); ok {
 		raw, err := io.ReadAll(reader)
 		if err != nil {


### PR DESCRIPTION
I have some code where I buffer a file and pass it as request body.

Without this change, the function serializes `[]byte` with JSON resulting in a base64 encoded string.