### PR TITLE
Do not allow config attributes to be set multiple times

### DIFF
--- a/databricks/auth_permutations_test.go
+++ b/databricks/auth_permutations_test.go
@@ -76,6 +76,18 @@ func TestConfig_NoParams(t *testing.T) {
 	}.apply(t)
 }
 
+func TestConfig_EnvIfAttrSet(t *testing.T) {
+	configFixture{
+		host:  "x",
+		token: "y",
+		env: map[string]string{
+			"DATABRICKS_HOST":  "host",
+			"DATABRICKS_TOKEN": "token",
+		},
+		assertError: "resolve: attributes already set: host, token. Config: host=x, token=***. Env: DATABRICKS_HOST, DATABRICKS_TOKEN",
+	}.apply(t)
+}
+
 func TestConfig_HostEnv(t *testing.T) {
 	configFixture{
 		env: map[string]string{

--- a/databricks/config_attributes.go
+++ b/databricks/config_attributes.go
@@ -82,13 +82,14 @@ func (a Attributes) Name() string {
 
 // Configure implements Loader interface for environment variables
 func (a Attributes) Configure(cfg *Config) error {
+	var alreadySet []ConfigAttribute
 	for _, attr := range a {
-		if !attr.IsZero(cfg) {
-			// don't overwtite a value previously set
-			continue
-		}
 		v := attr.ReadEnv()
 		if v == "" {
+			continue
+		}
+		if !attr.IsZero(cfg) {
+			alreadySet = append(alreadySet, attr)
 			continue
 		}
 		err := attr.SetS(cfg, v)
@@ -96,6 +97,15 @@ func (a Attributes) Configure(cfg *Config) error {
 			return err
 		}
 	}
+
+	if len(alreadySet) > 0 {
+		var names []string
+		for _, attr := range alreadySet {
+			names = append(names, attr.Name)
+		}
+		return fmt.Errorf("attributes already set: %s", strings.Join(names, ", "))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Doing so results in ambiguity; e.g. does it pick up the configuration from the
profile in ~/.databrickscfg, the environment, or the constructed struct.