### PR TITLE
Eliminate duplicates on iteration

### DIFF
--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -93,7 +93,10 @@ func (a *{{.Service.Name}}API) {{.PascalName}}AndWait(ctx context.Context{{if .R
 func (a *{{.Service.Name}}API) {{.PascalName}}All(ctx context.Context{{if .Request}}, request {{.Request.PascalName}}{{end}}) ([]{{.Pagination.Entity.PascalName}}, error) {
 	{{if .Pagination.MultiRequest}}var results []{{.Pagination.Entity.PascalName}}
 	ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-	{{if eq .Pagination.Increment 1 -}}
+	{{if .Pagination.NeedsOffsetDedupe -}}
+	// deduplicate items that may have been added during iteration
+	seen := map[{{template "type" .Pagination.Entity.IdentifierField.Entity}}]bool{}
+	{{end}}{{if eq .Pagination.Increment 1 -}}
 	request.{{.Pagination.Offset.PascalName}} = 1 // start iterating from the first page
 	{{end}}for {
 		response, err := a.impl.{{.PascalName}}(ctx{{if .Request}}, request{{end}})
@@ -104,6 +107,14 @@ func (a *{{.Service.Name}}API) {{.PascalName}}All(ctx context.Context{{if .Reque
 			break
 		}
 		for _, v := range response.{{.Pagination.Results.PascalName}} {
+			{{- if .Pagination.NeedsOffsetDedupe -}}
+			id := v.{{.Pagination.Entity.IdentifierField.PascalName}}
+			if seen[id] {
+				// item was added during iteration
+				continue
+			}
+			seen[id] = true
+			{{- end}}
 			results = append(results, v)
 		}
 		{{if .Pagination.Token -}}

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ doc:
 	@go run golang.org/x/tools/cmd/godoc@latest -http=localhost:6060
 
 install-codegen: vendor
-	@go build -o ~/go/bin/openapi-codegen databricks/openapi/gen/main.go
+	@go build -o ~/go/bin/openapi-codegen openapi/gen/main.go
+
+gen:
+	@go run openapi/gen/main.go
 
 .PHONY: fmt vendor fmt coverage test lint doc

--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -128,12 +128,17 @@ func (e *Entity) Fields() (fields []Field) {
 
 // Does this type have x-databricks-id field?
 func (e *Entity) HasIdentifierField() bool {
+	return e.IdentifierField() != nil
+}
+
+// Return field with x-databricks-id
+func (e *Entity) IdentifierField() *Field {
 	for _, v := range e.fields {
 		if v.Entity.IsIdentifier {
-			return true
+			return &v
 		}
 	}
-	return false
+	return nil
 }
 
 // Does this type have x-databricks-name field?

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -194,6 +194,10 @@ func (m *Method) paginationItem() *Entity {
 	return p.Entity
 }
 
+func (p *Pagination) NeedsOffsetDedupe() bool {
+	return p.Offset != nil && p.Entity.HasIdentifierField()
+}
+
 func (p *Pagination) MultiRequest() bool {
 	return p.Offset != nil || p.Token != nil
 }

--- a/service/dbsql/api.go
+++ b/service/dbsql/api.go
@@ -332,6 +332,8 @@ func (a *DashboardsAPI) GetDashboardByDashboardId(ctx context.Context, dashboard
 func (a *DashboardsAPI) ListDashboardsAll(ctx context.Context, request ListDashboardsRequest) ([]Dashboard, error) {
 	var results []Dashboard
 	ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
+	// deduplicate items that may have been added during iteration
+	seen := map[string]bool{}
 	request.Page = 1 // start iterating from the first page
 	for {
 		response, err := a.impl.ListDashboards(ctx, request)
@@ -342,6 +344,12 @@ func (a *DashboardsAPI) ListDashboardsAll(ctx context.Context, request ListDashb
 			break
 		}
 		for _, v := range response.Results {
+			id := v.Id
+			if seen[id] {
+				// item was added during iteration
+				continue
+			}
+			seen[id] = true
 			results = append(results, v)
 		}
 		request.Page++
@@ -672,6 +680,8 @@ func (a *QueriesAPI) GetQueryByQueryId(ctx context.Context, queryId string) (*Qu
 func (a *QueriesAPI) ListQueriesAll(ctx context.Context, request ListQueriesRequest) ([]Query, error) {
 	var results []Query
 	ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
+	// deduplicate items that may have been added during iteration
+	seen := map[string]bool{}
 	request.Page = 1 // start iterating from the first page
 	for {
 		response, err := a.impl.ListQueries(ctx, request)
@@ -682,6 +692,12 @@ func (a *QueriesAPI) ListQueriesAll(ctx context.Context, request ListQueriesRequ
 			break
 		}
 		for _, v := range response.Results {
+			id := v.Id
+			if seen[id] {
+				// item was added during iteration
+				continue
+			}
+			seen[id] = true
 			results = append(results, v)
 		}
 		request.Page++

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -291,6 +291,8 @@ func (a *JobsAPI) GetRunOutputByRunId(ctx context.Context, runId int64) (*RunOut
 func (a *JobsAPI) ListAll(ctx context.Context, request ListRequest) ([]Job, error) {
 	var results []Job
 	ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
+	// deduplicate items that may have been added during iteration
+	seen := map[int64]bool{}
 	for {
 		response, err := a.impl.List(ctx, request)
 		if err != nil {
@@ -300,6 +302,12 @@ func (a *JobsAPI) ListAll(ctx context.Context, request ListRequest) ([]Job, erro
 			break
 		}
 		for _, v := range response.Jobs {
+			id := v.JobId
+			if seen[id] {
+				// item was added during iteration
+				continue
+			}
+			seen[id] = true
 			results = append(results, v)
 		}
 		request.Offset += int(len(response.Jobs))
@@ -368,6 +376,8 @@ func (a *JobsAPI) GetJobBySettingsName(ctx context.Context, name string) (*Job, 
 func (a *JobsAPI) ListRunsAll(ctx context.Context, request ListRunsRequest) ([]Run, error) {
 	var results []Run
 	ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
+	// deduplicate items that may have been added during iteration
+	seen := map[int64]bool{}
 	for {
 		response, err := a.impl.ListRuns(ctx, request)
 		if err != nil {
@@ -377,6 +387,12 @@ func (a *JobsAPI) ListRunsAll(ctx context.Context, request ListRunsRequest) ([]R
 			break
 		}
 		for _, v := range response.Runs {
+			id := v.RunId
+			if seen[id] {
+				// item was added during iteration
+				continue
+			}
+			seen[id] = true
 			results = append(results, v)
 		}
 		request.Offset += int(len(response.Runs))


### PR DESCRIPTION
This PR adds an extra layer of protection from duplicates for offset-based listing APIs - jobs, job runs, dashboards, queries.

Fixes #115 