### PR TITLE
Fixed OpenAPI `path` and `url` parameter fields

### DIFF
--- a/.codegen/model.go.tmpl
+++ b/.codegen/model.go.tmpl
@@ -26,8 +26,8 @@ const {{.Entity.PascalName}}{{.PascalName}} {{.Entity.PascalName}} = `{{.Content
 
 {{- define "field-tag" -}}
 	{{if .IsJson}}json:"{{.Name}}{{if not .Required}},omitempty{{end}}"{{else}}json:"-"{{end -}}
-	{{if .IsPath}} path:"{{.Name}}"{{end -}}
-	{{if .IsQuery}} url:"{{.Name}},omitempty"{{end -}}
+	{{if .IsPath}} url:"-"{{end -}}
+	{{if .IsQuery}} url:"{{.Name}}{{if not .Required}},omitempty{{end}}"{{end -}}
 {{- end -}}
 
 {{- define "type" -}}

--- a/service/billing/model.go
+++ b/service/billing/model.go
@@ -172,7 +172,7 @@ type CreateLogDeliveryConfigurationParams struct {
 // Delete budget
 type DeleteBudgetRequest struct {
 	// Budget ID
-	BudgetId string `json:"-" path:"budget_id"`
+	BudgetId string `json:"-" url:"-"`
 }
 
 // This describes an enum
@@ -200,26 +200,26 @@ const DeliveryStatusUserFailure DeliveryStatus = `USER_FAILURE`
 type DownloadRequest struct {
 	// Format: `YYYY-MM`. Last month to return billable usage logs for. This
 	// field is required.
-	EndMonth string `json:"-" url:"end_month,omitempty"`
+	EndMonth string `json:"-" url:"end_month"`
 	// Specify whether to include personally identifiable information in the
 	// billable usage logs, for example the email addresses of cluster creators.
 	// Handle this information with care. Defaults to false.
 	PersonalData bool `json:"-" url:"personal_data,omitempty"`
 	// Format: `YYYY-MM`. First month to return billable usage logs for. This
 	// field is required.
-	StartMonth string `json:"-" url:"start_month,omitempty"`
+	StartMonth string `json:"-" url:"start_month"`
 }
 
 // Get budget and its status
 type GetBudgetRequest struct {
 	// Budget ID
-	BudgetId string `json:"-" path:"budget_id"`
+	BudgetId string `json:"-" url:"-"`
 }
 
 // Get log delivery configuration
 type GetLogDeliveryRequest struct {
 	// Databricks log delivery configuration ID
-	LogDeliveryConfigurationId string `json:"-" path:"log_delivery_configuration_id"`
+	LogDeliveryConfigurationId string `json:"-" url:"-"`
 }
 
 // Get all log delivery configurations
@@ -374,7 +374,7 @@ const OutputFormatJson OutputFormat = `JSON`
 
 type UpdateLogDeliveryConfigurationStatusRequest struct {
 	// Databricks log delivery configuration ID
-	LogDeliveryConfigurationId string `json:"-" path:"log_delivery_configuration_id"`
+	LogDeliveryConfigurationId string `json:"-" url:"-"`
 	// Status of log delivery configuration. Set to `ENABLED` (enabled) or
 	// `DISABLED` (disabled). Defaults to `ENABLED`. You can [enable or disable
 	// the configuration](#operation/patch-log-delivery-config-status) later.
@@ -387,7 +387,7 @@ type WrappedBudget struct {
 	// Budget configuration to be created.
 	Budget Budget `json:"budget"`
 	// Budget ID
-	BudgetId string `json:"-" path:"budget_id"`
+	BudgetId string `json:"-" url:"-"`
 }
 
 type WrappedBudgetWithStatus struct {

--- a/service/clusters/model.go
+++ b/service/clusters/model.go
@@ -1104,7 +1104,7 @@ const GcpAttributesAvailabilityPreemptibleWithFallbackGcp GcpAttributesAvailabil
 // Get cluster info
 type Get struct {
 	// The cluster about which to retrieve information.
-	ClusterId string `json:"-" url:"cluster_id,omitempty"`
+	ClusterId string `json:"-" url:"cluster_id"`
 }
 
 type GetEvents struct {

--- a/service/commands/model.go
+++ b/service/commands/model.go
@@ -39,11 +39,11 @@ const CommandStatusRunning CommandStatus = `Running`
 
 // Get command info
 type CommandStatusRequest struct {
-	ClusterId string `json:"-" url:"clusterId,omitempty"`
+	ClusterId string `json:"-" url:"clusterId"`
 
-	CommandId string `json:"-" url:"commandId,omitempty"`
+	CommandId string `json:"-" url:"commandId"`
 
-	ContextId string `json:"-" url:"contextId,omitempty"`
+	ContextId string `json:"-" url:"contextId"`
 }
 
 type CommandStatusResponse struct {
@@ -64,9 +64,9 @@ const ContextStatusRunning ContextStatus = `Running`
 
 // Get status
 type ContextStatusRequest struct {
-	ClusterId string `json:"-" url:"clusterId,omitempty"`
+	ClusterId string `json:"-" url:"clusterId"`
 
-	ContextId string `json:"-" url:"contextId,omitempty"`
+	ContextId string `json:"-" url:"contextId"`
 }
 
 type ContextStatusResponse struct {

--- a/service/dbfs/model.go
+++ b/service/dbfs/model.go
@@ -54,14 +54,14 @@ type FileInfo struct {
 type GetStatus struct {
 	// The path of the file or directory. The path should be the absolute DBFS
 	// path.
-	Path string `json:"-" url:"path,omitempty"`
+	Path string `json:"-" url:"path"`
 }
 
 // List directory contents or file details
 type List struct {
 	// The path of the file or directory. The path should be the absolute DBFS
 	// path.
-	Path string `json:"-" url:"path,omitempty"`
+	Path string `json:"-" url:"path"`
 }
 
 type ListStatusResponse struct {
@@ -101,7 +101,7 @@ type Read struct {
 	// The offset to read from in bytes.
 	Offset int `json:"-" url:"offset,omitempty"`
 	// The path of the file to read. The path should be the absolute DBFS path.
-	Path string `json:"-" url:"path,omitempty"`
+	Path string `json:"-" url:"path"`
 }
 
 type ReadResponse struct {

--- a/service/dbsql/model.go
+++ b/service/dbsql/model.go
@@ -99,7 +99,7 @@ type CreateDashboardRequest struct {
 }
 
 type CreateRefreshSchedule struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 	// Cron string representing the refresh schedule.
 	Cron string `json:"cron"`
 	// ID of the SQL warehouse to refresh with. If `null`, query's SQL warehouse
@@ -109,7 +109,7 @@ type CreateRefreshSchedule struct {
 
 type CreateSubscription struct {
 	// ID of the alert.
-	AlertId string `json:"alert_id" path:"alert_id"`
+	AlertId string `json:"alert_id" url:"-"`
 	// ID of the alert subscriber (if subscribing an alert destination). Alert
 	// destinations can be configured by admins through the UI. See
 	// [here](/sql/admin/alert-destinations.html).
@@ -197,24 +197,24 @@ type DataSource struct {
 
 // Delete an alert
 type DeleteAlertRequest struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 }
 
 // Remove a dashboard
 type DeleteDashboardRequest struct {
-	DashboardId string `json:"-" path:"dashboard_id"`
+	DashboardId string `json:"-" url:"-"`
 }
 
 // Delete a query
 type DeleteQueryRequest struct {
-	QueryId string `json:"-" path:"query_id"`
+	QueryId string `json:"-" url:"-"`
 }
 
 // Delete a refresh schedule
 type DeleteScheduleRequest struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 
-	ScheduleId string `json:"-" path:"schedule_id"`
+	ScheduleId string `json:"-" url:"-"`
 }
 
 // Alert destination subscribed to the alert, if it exists. Alert destinations
@@ -247,7 +247,7 @@ const DestinationTypeSlack DestinationType = `slack`
 const DestinationTypeWebhook DestinationType = `webhook`
 
 type EditAlert struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 	// Name of the alert.
 	Name string `json:"name"`
 	// Alert configuration options.
@@ -262,20 +262,20 @@ type EditAlert struct {
 
 // Get an alert
 type GetAlertRequest struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 }
 
 // Retrieve a definition
 type GetDashboardRequest struct {
-	DashboardId string `json:"-" path:"dashboard_id"`
+	DashboardId string `json:"-" url:"-"`
 }
 
 // Get object ACL
 type GetPermissionsRequest struct {
 	// Object ID. An ACL is returned for the object with this UUID.
-	ObjectId string `json:"-" path:"objectId"`
+	ObjectId string `json:"-" url:"-"`
 	// The type of object permissions to check.
-	ObjectType ObjectTypePlural `json:"-" path:"objectType"`
+	ObjectType ObjectTypePlural `json:"-" url:"-"`
 }
 
 type GetPermissionsResponse struct {
@@ -288,12 +288,12 @@ type GetPermissionsResponse struct {
 
 // Get a query definition.
 type GetQueryRequest struct {
-	QueryId string `json:"-" path:"query_id"`
+	QueryId string `json:"-" url:"-"`
 }
 
 // Get an alert's subscriptions
 type GetSubscriptionsRequest struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 }
 
 type ListDashboardsOrder string
@@ -367,7 +367,7 @@ type ListQueriesResponse struct {
 
 // Get refresh schedules
 type ListSchedulesRequest struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 }
 
 // A singular noun object type.
@@ -533,7 +533,7 @@ type QueryPostContent struct {
 	// The text of the query.
 	Query string `json:"query,omitempty"`
 
-	QueryId string `json:"-" path:"query_id"`
+	QueryId string `json:"-" url:"-"`
 	// JSON object that describes the scheduled execution frequency. A schedule
 	// object includes `interval`, `time`, `day_of_week`, and `until` fields. If
 	// a scheduled is supplied, then only `interval` is required. All other
@@ -553,12 +553,12 @@ type RefreshSchedule struct {
 
 // Restore a dashboard
 type RestoreDashboardRequest struct {
-	DashboardId string `json:"-" path:"dashboard_id"`
+	DashboardId string `json:"-" url:"-"`
 }
 
 // Restore a query
 type RestoreQueryRequest struct {
-	QueryId string `json:"-" path:"query_id"`
+	QueryId string `json:"-" url:"-"`
 }
 
 // Set object ACL
@@ -566,9 +566,9 @@ type SetPermissionsRequest struct {
 	AccessControlList []AccessControl `json:"access_control_list,omitempty"`
 	// Object ID. The ACL for the object with this UUID is overwritten by this
 	// request's POST content.
-	ObjectId string `json:"-" path:"objectId"`
+	ObjectId string `json:"-" url:"-"`
 	// The type of object permission to set.
-	ObjectType ObjectTypePlural `json:"-" path:"objectType"`
+	ObjectType ObjectTypePlural `json:"-" url:"-"`
 }
 
 type SetPermissionsResponse struct {
@@ -610,16 +610,16 @@ type TransferOwnershipRequest struct {
 	// Email address for the new owner, who must exist in the workspace.
 	NewOwner string `json:"new_owner,omitempty"`
 	// The ID of the object on which to change ownership.
-	ObjectId TransferOwnershipObjectId `json:"-" path:"objectId"`
+	ObjectId TransferOwnershipObjectId `json:"-" url:"-"`
 	// The type of object on which to change ownership.
-	ObjectType OwnableObjectType `json:"-" path:"objectType"`
+	ObjectType OwnableObjectType `json:"-" url:"-"`
 }
 
 // Unsubscribe to an alert
 type UnsubscribeRequest struct {
-	AlertId string `json:"-" path:"alert_id"`
+	AlertId string `json:"-" url:"-"`
 
-	SubscriptionId string `json:"-" path:"subscription_id"`
+	SubscriptionId string `json:"-" url:"-"`
 }
 
 type User struct {

--- a/service/deployment/model.go
+++ b/service/deployment/model.go
@@ -274,43 +274,43 @@ type CustomerManagedKey struct {
 // Delete credential configuration
 type DeleteCredentialRequest struct {
 	// Databricks Account API credential configuration ID
-	CredentialsId string `json:"-" path:"credentials_id"`
+	CredentialsId string `json:"-" url:"-"`
 }
 
 // Delete encryption key configuration
 type DeleteEncryptionKeyRequest struct {
 	// Databricks encryption key configuration ID.
-	CustomerManagedKeyId string `json:"-" path:"customer_managed_key_id"`
+	CustomerManagedKeyId string `json:"-" url:"-"`
 }
 
 // Delete network configuration
 type DeleteNetworkRequest struct {
 	// Databricks Account API network configuration ID.
-	NetworkId string `json:"-" path:"network_id"`
+	NetworkId string `json:"-" url:"-"`
 }
 
 // Delete a private access settings object
 type DeletePrivateAccesRequest struct {
 	// Databricks Account API private access settings ID.
-	PrivateAccessSettingsId string `json:"-" path:"private_access_settings_id"`
+	PrivateAccessSettingsId string `json:"-" url:"-"`
 }
 
 // Delete storage configuration
 type DeleteStorageRequest struct {
 	// Databricks Account API storage configuration ID.
-	StorageConfigurationId string `json:"-" path:"storage_configuration_id"`
+	StorageConfigurationId string `json:"-" url:"-"`
 }
 
 // Delete VPC endpoint configuration
 type DeleteVpcEndpointRequest struct {
 	// Databricks VPC endpoint ID.
-	VpcEndpointId string `json:"-" path:"vpc_endpoint_id"`
+	VpcEndpointId string `json:"-" url:"-"`
 }
 
 // Delete workspace
 type DeleteWorkspaceRequest struct {
 	// Workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 // This enumeration represents the type of Databricks VPC [endpoint
@@ -415,49 +415,49 @@ type GcpProjectContainer struct {
 // Get credential configuration
 type GetCredentialRequest struct {
 	// Databricks Account API credential configuration ID
-	CredentialsId string `json:"-" path:"credentials_id"`
+	CredentialsId string `json:"-" url:"-"`
 }
 
 // Get encryption key configuration
 type GetEncryptionKeyRequest struct {
 	// Databricks encryption key configuration ID.
-	CustomerManagedKeyId string `json:"-" path:"customer_managed_key_id"`
+	CustomerManagedKeyId string `json:"-" url:"-"`
 }
 
 // Get a network configuration
 type GetNetworkRequest struct {
 	// Databricks Account API network configuration ID.
-	NetworkId string `json:"-" path:"network_id"`
+	NetworkId string `json:"-" url:"-"`
 }
 
 // Get a private access settings object
 type GetPrivateAccesRequest struct {
 	// Databricks Account API private access settings ID.
-	PrivateAccessSettingsId string `json:"-" path:"private_access_settings_id"`
+	PrivateAccessSettingsId string `json:"-" url:"-"`
 }
 
 // Get storage configuration
 type GetStorageRequest struct {
 	// Databricks Account API storage configuration ID.
-	StorageConfigurationId string `json:"-" path:"storage_configuration_id"`
+	StorageConfigurationId string `json:"-" url:"-"`
 }
 
 // Get a VPC endpoint configuration
 type GetVpcEndpointRequest struct {
 	// Databricks VPC endpoint ID.
-	VpcEndpointId string `json:"-" path:"vpc_endpoint_id"`
+	VpcEndpointId string `json:"-" url:"-"`
 }
 
 // Get the history of a workspace's associations with keys
 type GetWorkspaceKeyHistoryRequest struct {
 	// Workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 // Get workspace
 type GetWorkspaceRequest struct {
 	// Workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 // Specifies the network connectivity types for the GKE nodes and the GKE master
@@ -695,7 +695,7 @@ type UpdateWorkspaceRequest struct {
 	// parameter is available for updating both failed and running workspaces.
 	StorageCustomerManagedKeyId string `json:"storage_customer_managed_key_id,omitempty"`
 	// Workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 type UpsertPrivateAccessSettingsRequest struct {
@@ -722,7 +722,7 @@ type UpsertPrivateAccessSettingsRequest struct {
 	// connect to your workspace. For details, see `allowed_vpc_endpoint_ids`.
 	PrivateAccessLevel PrivateAccessLevel `json:"private_access_level,omitempty"`
 	// Databricks Account API private access settings ID.
-	PrivateAccessSettingsId string `json:"-" path:"private_access_settings_id"`
+	PrivateAccessSettingsId string `json:"-" url:"-"`
 	// The human-readable name of the private access settings object.
 	PrivateAccessSettingsName string `json:"private_access_settings_name"`
 	// Determines if the workspace can be accessed over public internet. For

--- a/service/gitcredentials/model.go
+++ b/service/gitcredentials/model.go
@@ -38,13 +38,13 @@ type CredentialInfo struct {
 // Delete a credential
 type Delete struct {
 	// The ID for the corresponding credential to access.
-	CredentialId int64 `json:"-" path:"credential_id"`
+	CredentialId int64 `json:"-" url:"-"`
 }
 
 // Get a credential entry
 type Get struct {
 	// The ID for the corresponding credential to access.
-	CredentialId int64 `json:"-" path:"credential_id"`
+	CredentialId int64 `json:"-" url:"-"`
 }
 
 type GetCredentialsResponse struct {
@@ -53,7 +53,7 @@ type GetCredentialsResponse struct {
 
 type UpdateCredentials struct {
 	// The ID for the corresponding credential to access.
-	CredentialId int64 `json:"-" path:"credential_id"`
+	CredentialId int64 `json:"-" url:"-"`
 	// Git provider. This field is case-insensitive. The available Git providers
 	// are awsCodeCommit, azureDevOpsServices,
 	GitProvider string `json:"git_provider,omitempty"`

--- a/service/globalinitscripts/model.go
+++ b/service/globalinitscripts/model.go
@@ -12,13 +12,13 @@ type CreateScriptResponse struct {
 // Delete init script
 type DeleteScript struct {
 	// The ID of the global init script.
-	ScriptId string `json:"-" path:"script_id"`
+	ScriptId string `json:"-" url:"-"`
 }
 
 // Get an init script
 type GetScript struct {
 	// The ID of the global init script.
-	ScriptId string `json:"-" path:"script_id"`
+	ScriptId string `json:"-" url:"-"`
 }
 
 type GlobalInitScriptCreateRequest struct {
@@ -109,7 +109,7 @@ type GlobalInitScriptUpdateRequest struct {
 	// The Base64-encoded content of the script.
 	Script string `json:"script,omitempty"`
 	// The ID of the global init script.
-	ScriptId string `json:"-" path:"script_id"`
+	ScriptId string `json:"-" url:"-"`
 }
 
 type ListGlobalInitScriptsResponse struct {

--- a/service/ipaccesslists/model.go
+++ b/service/ipaccesslists/model.go
@@ -20,7 +20,7 @@ type CreateIpAccessListResponse struct {
 // Delete access list
 type Delete struct {
 	// The ID for the corresponding IP access list to modify.
-	IpAccessListId string `json:"-" path:"ip_access_list_id"`
+	IpAccessListId string `json:"-" url:"-"`
 }
 
 type FetchIpAccessListResponse struct {
@@ -30,7 +30,7 @@ type FetchIpAccessListResponse struct {
 // Get access list
 type Get struct {
 	// The ID for the corresponding IP access list to modify.
-	IpAccessListId string `json:"-" path:"ip_access_list_id"`
+	IpAccessListId string `json:"-" url:"-"`
 }
 
 type GetIpAccessListResponse struct {
@@ -74,7 +74,7 @@ type ReplaceIpAccessList struct {
 	// Specifies whether this IP access list is enabled.
 	Enabled bool `json:"enabled"`
 	// The ID for the corresponding IP access list to modify.
-	IpAccessListId string `json:"-" path:"ip_access_list_id"`
+	IpAccessListId string `json:"-" url:"-"`
 	// Array of IP addresses or CIDR values to be added to the IP access list.
 	IpAddresses []string `json:"ip_addresses"`
 	// Label for the IP access list. This **cannot** be empty.
@@ -89,7 +89,7 @@ type UpdateIpAccessList struct {
 	// Specifies whether this IP access list is enabled.
 	Enabled bool `json:"enabled,omitempty"`
 	// The ID for the corresponding IP access list to modify.
-	IpAccessListId string `json:"-" path:"ip_access_list_id"`
+	IpAccessListId string `json:"-" url:"-"`
 	// Array of IP addresses or CIDR values to be added to the IP access list.
 	IpAddresses []string `json:"ip_addresses,omitempty"`
 	// Label for the IP access list. This **cannot** be empty.

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -201,7 +201,7 @@ type DeleteRun struct {
 // Export and retrieve a job run
 type ExportRun struct {
 	// The canonical identifier for the run. This field is required.
-	RunId int64 `json:"-" url:"run_id,omitempty"`
+	RunId int64 `json:"-" url:"run_id"`
 	// Which views to export (CODE, DASHBOARDS, or ALL). Defaults to CODE.
 	ViewsToExport ViewsToExport `json:"-" url:"views_to_export,omitempty"`
 }
@@ -215,7 +215,7 @@ type ExportRunOutput struct {
 type Get struct {
 	// The canonical identifier of the job to retrieve information about. This
 	// field is required.
-	JobId int64 `json:"-" url:"job_id,omitempty"`
+	JobId int64 `json:"-" url:"job_id"`
 }
 
 // Get a single job run
@@ -224,13 +224,13 @@ type GetRun struct {
 	IncludeHistory bool `json:"-" url:"include_history,omitempty"`
 	// The canonical identifier of the run for which to retrieve the metadata.
 	// This field is required.
-	RunId int64 `json:"-" url:"run_id,omitempty"`
+	RunId int64 `json:"-" url:"run_id"`
 }
 
 // Get the output for a single run
 type GetRunOutput struct {
 	// The canonical identifier for the run. This field is required.
-	RunId int64 `json:"-" url:"run_id,omitempty"`
+	RunId int64 `json:"-" url:"run_id"`
 }
 
 // Read-only state of the remote repository at the time the job was run. This

--- a/service/libraries/model.go
+++ b/service/libraries/model.go
@@ -14,7 +14,7 @@ type ClusterLibraryStatuses struct {
 // Get status
 type ClusterStatus struct {
 	// Unique identifier of the cluster whose status should be retrieved.
-	ClusterId string `json:"-" url:"cluster_id,omitempty"`
+	ClusterId string `json:"-" url:"cluster_id"`
 }
 
 type InstallLibraries struct {

--- a/service/mlflow/model.go
+++ b/service/mlflow/model.go
@@ -292,41 +292,41 @@ type DeleteExperiment struct {
 
 // Delete a comment
 type DeleteModelVersionCommentRequest struct {
-	Id string `json:"-" url:"id,omitempty"`
+	Id string `json:"-" url:"id"`
 }
 
 // Delete a model version.
 type DeleteModelVersionRequest struct {
 	// Name of the registered model
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 	// Model version number
-	Version string `json:"-" url:"version,omitempty"`
+	Version string `json:"-" url:"version"`
 }
 
 // Delete a model version tag
 type DeleteModelVersionTagRequest struct {
 	// Name of the tag. The name must be an exact match; wild-card deletion is
 	// not supported. Maximum size is 250 bytes.
-	Key string `json:"-" url:"key,omitempty"`
+	Key string `json:"-" url:"key"`
 	// Name of the registered model that the tag was logged under.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 	// Model version number that the tag was logged under.
-	Version string `json:"-" url:"version,omitempty"`
+	Version string `json:"-" url:"version"`
 }
 
 // Delete a model
 type DeleteRegisteredModelRequest struct {
 	// Registered model unique name identifier.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 }
 
 // Delete a model tag
 type DeleteRegisteredModelTagRequest struct {
 	// Name of the tag. The name must be an exact match; wild-card deletion is
 	// not supported. Maximum size is 250 bytes.
-	Key string `json:"-" url:"key,omitempty"`
+	Key string `json:"-" url:"key"`
 	// Name of the registered model that the tag was logged under.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 }
 
 // Delete a webhook
@@ -354,9 +354,9 @@ type DeleteTransitionRequestRequest struct {
 	// Username of the user who created this request. Of the transition requests
 	// matching the specified details, only the one transition created by this
 	// user will be deleted.
-	Creator string `json:"-" url:"creator,omitempty"`
+	Creator string `json:"-" url:"creator"`
 	// Name of the model.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 	// Target stage of the transition request. Valid values are:
 	//
 	// * `None`: The initial stage of a model version.
@@ -366,9 +366,9 @@ type DeleteTransitionRequestRequest struct {
 	// * `Production`: Production stage.
 	//
 	// * `Archived`: Archived stage.
-	Stage string `json:"-" url:"stage,omitempty"`
+	Stage string `json:"-" url:"stage"`
 	// Version of the model.
-	Version string `json:"-" url:"version,omitempty"`
+	Version string `json:"-" url:"version"`
 }
 
 type Experiment struct {
@@ -408,7 +408,7 @@ type FileInfo struct {
 // Get metadata
 type GetByNameRequest struct {
 	// Name of the associated experiment.
-	ExperimentName string `json:"-" url:"experiment_name,omitempty"`
+	ExperimentName string `json:"-" url:"experiment_name"`
 }
 
 type GetExperimentByNameResponse struct {
@@ -419,13 +419,13 @@ type GetExperimentByNameResponse struct {
 // Get an experiment
 type GetExperimentRequest struct {
 	// ID of the associated experiment.
-	ExperimentId string `json:"-" url:"experiment_id,omitempty"`
+	ExperimentId string `json:"-" url:"experiment_id"`
 }
 
 // Get all history
 type GetHistoryRequest struct {
 	// Name of the metric.
-	MetricKey string `json:"-" url:"metric_key,omitempty"`
+	MetricKey string `json:"-" url:"metric_key"`
 	// ID of the run from which to fetch metric values. Must be provided.
 	RunId string `json:"-" url:"run_id,omitempty"`
 	// [Deprecated, use run_id instead] ID of the run from which to fetch metric
@@ -450,7 +450,7 @@ type GetLatestVersionsResponse struct {
 // Get model
 type GetMLflowDatabrickRequest struct {
 	// Name of the model.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 }
 
 type GetMetricHistoryResponse struct {
@@ -461,9 +461,9 @@ type GetMetricHistoryResponse struct {
 // Get a model version URI
 type GetModelVersionDownloadUriRequest struct {
 	// Name of the registered model
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 	// Model version number
-	Version string `json:"-" url:"version,omitempty"`
+	Version string `json:"-" url:"version"`
 }
 
 type GetModelVersionDownloadUriResponse struct {
@@ -474,9 +474,9 @@ type GetModelVersionDownloadUriResponse struct {
 // Get a model version
 type GetModelVersionRequest struct {
 	// Name of the registered model
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 	// Model version number
-	Version string `json:"-" url:"version,omitempty"`
+	Version string `json:"-" url:"version"`
 }
 
 type GetModelVersionResponse struct {
@@ -486,7 +486,7 @@ type GetModelVersionResponse struct {
 // Get a model
 type GetRegisteredModelRequest struct {
 	// Registered model unique name identifier.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 }
 
 type GetRegisteredModelResponse struct {
@@ -657,9 +657,9 @@ type ListResponse struct {
 // List transition requests
 type ListTransitionRequestsRequest struct {
 	// Name of the model.
-	Name string `json:"-" url:"name,omitempty"`
+	Name string `json:"-" url:"name"`
 	// Version of the model.
-	Version string `json:"-" url:"version,omitempty"`
+	Version string `json:"-" url:"version"`
 }
 
 type LogBatch struct {

--- a/service/permissions/model.go
+++ b/service/permissions/model.go
@@ -30,30 +30,30 @@ type CreateWorkspaceAssignments struct {
 	// Array of permissions assignments to apply to a workspace.
 	PermissionAssignments []PermissionAssignmentInput `json:"permission_assignments,omitempty"`
 	// The workspace ID for the account.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 // Delete permissions assignment
 type DeleteWorkspaceAssignmentRequest struct {
 	// The ID of the service principal.
-	PrincipalId int64 `json:"-" path:"principal_id"`
+	PrincipalId int64 `json:"-" url:"-"`
 	// The workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 // Get object permissions
 type Get struct {
-	RequestObjectId string `json:"-" path:"request_object_id"`
+	RequestObjectId string `json:"-" url:"-"`
 	// <needs content>
-	RequestObjectType string `json:"-" path:"request_object_type"`
+	RequestObjectType string `json:"-" url:"-"`
 }
 
 // Get permission levels
 type GetPermissionLevels struct {
 	// <needs content>
-	RequestObjectId string `json:"-" path:"request_object_id"`
+	RequestObjectId string `json:"-" url:"-"`
 	// <needs content>
-	RequestObjectType string `json:"-" path:"request_object_type"`
+	RequestObjectType string `json:"-" url:"-"`
 }
 
 type GetPermissionLevelsResponse struct {
@@ -64,13 +64,13 @@ type GetPermissionLevelsResponse struct {
 // List workspace permissions
 type GetWorkspaceAssignmentRequest struct {
 	// The workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 // Get permission assignments
 type ListWorkspaceAssignmentRequest struct {
 	// The workspace ID for the account.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 type ObjectPermissions struct {
@@ -163,9 +163,9 @@ type PermissionsDescription struct {
 type PermissionsRequest struct {
 	AccessControlList []AccessControlRequest `json:"access_control_list,omitempty"`
 
-	RequestObjectId string `json:"-" path:"request_object_id"`
+	RequestObjectId string `json:"-" url:"-"`
 	// <needs content>
-	RequestObjectType string `json:"-" path:"request_object_type"`
+	RequestObjectType string `json:"-" url:"-"`
 }
 
 type PrincipalOutput struct {
@@ -185,9 +185,9 @@ type UpdateWorkspaceAssignments struct {
 	// Array of permissions assignments to update on the workspace.
 	Permissions []WorkspacePermission `json:"permissions,omitempty"`
 	// The ID of the service principal.
-	PrincipalId int64 `json:"-" path:"principal_id"`
+	PrincipalId int64 `json:"-" url:"-"`
 	// The workspace ID.
-	WorkspaceId int64 `json:"-" path:"workspace_id"`
+	WorkspaceId int64 `json:"-" url:"-"`
 }
 
 type WorkspaceAssignmentsCreated struct {

--- a/service/pipelines/model.go
+++ b/service/pipelines/model.go
@@ -64,7 +64,7 @@ type CronTrigger struct {
 
 // Delete a pipeline
 type DeletePipeline struct {
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 }
 
 type EditPipeline struct {
@@ -102,7 +102,7 @@ type EditPipeline struct {
 	// Whether Photon is enabled for this pipeline.
 	Photon bool `json:"photon,omitempty"`
 	// Unique identifier for this pipeline.
-	PipelineId string `json:"pipeline_id,omitempty" path:"pipeline_id"`
+	PipelineId string `json:"pipeline_id,omitempty" url:"-"`
 	// DBFS root directory for storing checkpoints and tables.
 	Storage string `json:"storage,omitempty"`
 	// Target schema (database) to add tables in this pipeline to.
@@ -120,7 +120,7 @@ type Filters struct {
 
 // Get a pipeline
 type GetPipeline struct {
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 }
 
 type GetPipelineResponse struct {
@@ -160,9 +160,9 @@ const GetPipelineResponseHealthUnhealthy GetPipelineResponseHealth = `UNHEALTHY`
 // Get a pipeline update
 type GetUpdate struct {
 	// The ID of the pipeline.
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 	// The ID of the update.
-	UpdateId string `json:"-" path:"update_id"`
+	UpdateId string `json:"-" url:"-"`
 }
 
 type GetUpdateResponse struct {
@@ -209,7 +209,7 @@ type ListUpdates struct {
 	// Page token returned by previous call
 	PageToken string `json:"-" url:"page_token,omitempty"`
 	// The pipeline to return updates for.
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 	// If present, returns updates until and including this update_id.
 	UntilUpdateId string `json:"-" url:"until_update_id,omitempty"`
 }
@@ -423,7 +423,7 @@ type PipelineTrigger struct {
 
 // Reset a pipeline
 type ResetPipeline struct {
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 }
 
 type StartUpdate struct {
@@ -436,7 +436,7 @@ type StartUpdate struct {
 	// before the refresh.
 	FullRefreshSelection []string `json:"full_refresh_selection,omitempty"`
 
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 	// A list of tables to update without fullRefresh. If both refresh_selection
 	// and full_refresh_selection are empty, this is a full graph update. Full
 	// Refresh on a table means that the states of the table will be reset
@@ -464,7 +464,7 @@ type StartUpdateResponse struct {
 
 // Stop a pipeline
 type StopPipeline struct {
-	PipelineId string `json:"-" path:"pipeline_id"`
+	PipelineId string `json:"-" url:"-"`
 }
 
 type UpdateInfo struct {

--- a/service/repos/model.go
+++ b/service/repos/model.go
@@ -20,13 +20,13 @@ type CreateRepo struct {
 // Delete a repo
 type Delete struct {
 	// The ID for the corresponding repo to access.
-	RepoId int64 `json:"-" path:"repo_id"`
+	RepoId int64 `json:"-" url:"-"`
 }
 
 // Get a repo
 type Get struct {
 	// The ID for the corresponding repo to access.
-	RepoId int64 `json:"-" path:"repo_id"`
+	RepoId int64 `json:"-" url:"-"`
 }
 
 // Get repos
@@ -70,7 +70,7 @@ type UpdateRepo struct {
 	// Branch that the local version of the repo is checked out to.
 	Branch string `json:"branch,omitempty"`
 	// The ID for the corresponding repo to access.
-	RepoId int64 `json:"-" path:"repo_id"`
+	RepoId int64 `json:"-" url:"-"`
 	// Tag that the local version of the repo is checked out to. Updating the
 	// repo to a tag puts the repo in a detached HEAD state. Before committing
 	// new changes, you must update the repo to a branch instead of the detached

--- a/service/scim/model.go
+++ b/service/scim/model.go
@@ -19,37 +19,37 @@ type ComplexValue struct {
 // Delete a group
 type DeleteGroupRequest struct {
 	// Unique ID for a group in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Delete a service principal
 type DeleteServicePrincipalRequest struct {
 	// Unique ID for a service principal in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Delete a user
 type DeleteUserRequest struct {
 	// Unique ID for a user in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Get group details
 type GetGroupRequest struct {
 	// Unique ID for a group in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Get service principal details
 type GetServicePrincipalRequest struct {
 	// Unique ID for a service principal in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Get user details
 type GetUserRequest struct {
 	// Unique ID for a user in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 type Group struct {
@@ -62,7 +62,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty" path:"id"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 
@@ -190,7 +190,7 @@ type Name struct {
 
 type PartialUpdate struct {
 	// Unique ID for a group in the Databricks Account.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 
 	Operations []Patch `json:"operations,omitempty"`
 }
@@ -227,7 +227,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty" path:"id"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }
@@ -247,7 +247,7 @@ type User struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks user ID.
-	Id string `json:"id,omitempty" path:"id"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Name *Name `json:"name,omitempty"`
 

--- a/service/secrets/model.go
+++ b/service/secrets/model.go
@@ -62,15 +62,15 @@ type DeleteSecret struct {
 // Get secret ACL details
 type GetAcl struct {
 	// The principal to fetch ACL information for.
-	Principal string `json:"-" url:"principal,omitempty"`
+	Principal string `json:"-" url:"principal"`
 	// The name of the scope to fetch ACL information from.
-	Scope string `json:"-" url:"scope,omitempty"`
+	Scope string `json:"-" url:"scope"`
 }
 
 // Lists ACLs
 type ListAcls struct {
 	// The name of the scope to fetch ACL information from.
-	Scope string `json:"-" url:"scope,omitempty"`
+	Scope string `json:"-" url:"scope"`
 }
 
 type ListAclsResponse struct {
@@ -86,7 +86,7 @@ type ListScopesResponse struct {
 // List secret keys
 type ListSecrets struct {
 	// The name of the scope to list secrets within.
-	Scope string `json:"-" url:"scope,omitempty"`
+	Scope string `json:"-" url:"scope"`
 }
 
 type ListSecretsResponse struct {

--- a/service/tokenmanagement/model.go
+++ b/service/tokenmanagement/model.go
@@ -22,13 +22,13 @@ type CreateOboTokenResponse struct {
 // Delete a token
 type DeleteToken struct {
 	// The ID of the token to get.
-	TokenId string `json:"-" path:"token_id"`
+	TokenId string `json:"-" url:"-"`
 }
 
 // Get token info
 type GetTokenInfo struct {
 	// The ID of the token to get.
-	TokenId string `json:"-" path:"token_id"`
+	TokenId string `json:"-" url:"-"`
 }
 
 // List all tokens

--- a/service/unitycatalog/model.go
+++ b/service/unitycatalog/model.go
@@ -352,7 +352,7 @@ type CreateMetastoreAssignment struct {
 	// The ID of the Metastore.
 	MetastoreId string `json:"metastore_id"`
 	// A workspace ID.
-	WorkspaceId int `json:"-" path:"workspace_id"`
+	WorkspaceId int `json:"-" url:"-"`
 }
 
 type CreateMetastorePrivilegesItem string
@@ -1044,7 +1044,7 @@ const CreateTableTableTypeView CreateTableTableType = `VIEW`
 // Delete a catalog
 type DeleteCatalogRequest struct {
 	// Required. The name of the catalog.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 // Delete an external location
@@ -1052,7 +1052,7 @@ type DeleteExternalLocationRequest struct {
 	// Force deletion even if there are dependent external tables or mounts.
 	Force bool `json:"-" url:"force,omitempty"`
 	// Required. Name of the storage credential.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 // Delete a Metastore
@@ -1060,31 +1060,31 @@ type DeleteMetastoreRequest struct {
 	// Force deletion even if the metastore is not empty. Default is false.
 	Force bool `json:"-" url:"force,omitempty"`
 	// Required. Unique ID of the Metastore (from URL).
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Delete a provider
 type DeleteProviderRequest struct {
 	// Required. Name of the provider.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 // Delete a share recipient
 type DeleteRecipientRequest struct {
 	// Required. Name of the recipient.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 // Delete a schema
 type DeleteSchemaRequest struct {
 	// Required. Full name of the schema (from URL).
-	FullName string `json:"-" path:"full_name"`
+	FullName string `json:"-" url:"-"`
 }
 
 // Delete a share
 type DeleteShareRequest struct {
 	// The name of the share.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 // Delete a credential
@@ -1093,13 +1093,13 @@ type DeleteStorageCredentialRequest struct {
 	// tables.
 	Force bool `json:"-" url:"force,omitempty"`
 	// Required. Name of the storage credential.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 // Delete a table
 type DeleteTableRequest struct {
 	// Required. Full name of the Table (from URL).
-	FullName string `json:"-" path:"full_name"`
+	FullName string `json:"-" url:"-"`
 }
 
 type ExternalLocationInfo struct {
@@ -1144,13 +1144,13 @@ type GcpServiceAccountKey struct {
 // Get a share activation URL
 type GetActivationUrlInfoRequest struct {
 	// Required. The one time activation url. It also accepts activation token.
-	ActivationUrl string `json:"-" path:"activation_url"`
+	ActivationUrl string `json:"-" url:"-"`
 }
 
 // Get a catalog
 type GetCatalogRequest struct {
 	// Required. The name of the catalog.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type GetCatalogResponse struct {
@@ -1222,7 +1222,7 @@ const GetCatalogResponsePrivilegesItemWriteFiles GetCatalogResponsePrivilegesIte
 // Get an external location
 type GetExternalLocationRequest struct {
 	// Required. Name of the storage credential.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type GetExternalLocationResponse struct {
@@ -1258,17 +1258,17 @@ type GetExternalLocationResponse struct {
 // Get permissions
 type GetGrantRequest struct {
 	// Required. Unique identifier (full name) of Securable (from URL).
-	FullName string `json:"-" path:"full_name"`
+	FullName string `json:"-" url:"-"`
 	// Optional. List permissions granted to this principal.
 	Principal string `json:"-" url:"principal,omitempty"`
 	// Required. Type of Securable (from URL).
-	SecurableType string `json:"-" path:"securable_type"`
+	SecurableType string `json:"-" url:"-"`
 }
 
 // Get a Metastore
 type GetMetastoreRequest struct {
 	// Required. Unique ID of the Metastore (from URL).
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 type GetMetastoreResponse struct {
@@ -1348,7 +1348,7 @@ type GetPermissionsResponse struct {
 // Get a provider
 type GetProviderRequest struct {
 	// Required. Name of the provider.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type GetProviderResponse struct {
@@ -1395,7 +1395,7 @@ const GetProviderResponseAuthenticationTypeUnknown GetProviderResponseAuthentica
 // Get a share recipient
 type GetRecipientRequest struct {
 	// Required. Name of the recipient.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type GetRecipientResponse struct {
@@ -1449,7 +1449,7 @@ type GetRecipientSharePermissionsResponse struct {
 // Get a schema
 type GetSchemaRequest struct {
 	// Required. Full name of the schema (from URL).
-	FullName string `json:"-" path:"full_name"`
+	FullName string `json:"-" url:"-"`
 }
 
 type GetSchemaResponse struct {
@@ -1515,7 +1515,7 @@ type GetShareRequest struct {
 	// Query for data to include in the share.
 	IncludeSharedData bool `json:"-" url:"include_shared_data,omitempty"`
 	// The name of the share.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type GetShareResponse struct {
@@ -1534,7 +1534,7 @@ type GetShareResponse struct {
 // Get a credential
 type GetStorageCredentialRequest struct {
 	// Required. Name of the storage credential.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type GetStorageCredentialResponse struct {
@@ -1570,7 +1570,7 @@ type GetStorageCredentialResponse struct {
 // Get a table
 type GetTableRequest struct {
 	// Required. Full name of the Table (from URL).
-	FullName string `json:"-" path:"full_name"`
+	FullName string `json:"-" url:"-"`
 }
 
 type GetTableResponse struct {
@@ -1747,7 +1747,7 @@ type ListSchemasResponse struct {
 // List shares
 type ListSharesRequest struct {
 	// Required. Name of the provider in which to list shares.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type ListSharesResponse struct {
@@ -2085,7 +2085,7 @@ type RecipientTokenInfo struct {
 // Get an access token
 type RetrieveTokenRequest struct {
 	// Required. The one time activation url. It also accepts activation token.
-	ActivationUrl string `json:"-" path:"activation_url"`
+	ActivationUrl string `json:"-" url:"-"`
 }
 
 type RetrieveTokenResponse struct {
@@ -2105,7 +2105,7 @@ type RotateRecipientToken struct {
 	// the existing token immediately, negative number will return an error.
 	ExistingTokenExpireInSeconds int64 `json:"existing_token_expire_in_seconds,omitempty"`
 	// Required. The name of the recipient.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type RotateRecipientTokenResponse struct {
@@ -2226,7 +2226,7 @@ type ShareInfo struct {
 // Get share permissions
 type SharePermissionsRequest struct {
 	// Required. The name of the Recipient.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type ShareToPrivilegeAssignment struct {
@@ -2485,9 +2485,9 @@ const TableSummaryTableTypeView TableSummaryTableType = `VIEW`
 // Delete an assignment
 type UnassignRequest struct {
 	// Query for the ID of the Metastore to delete.
-	MetastoreId string `json:"-" url:"metastore_id,omitempty"`
+	MetastoreId string `json:"-" url:"metastore_id"`
 	// A workspace ID.
-	WorkspaceId int `json:"-" path:"workspace_id"`
+	WorkspaceId int `json:"-" url:"-"`
 }
 
 type UpdateCatalog struct {
@@ -2503,7 +2503,7 @@ type UpdateCatalog struct {
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// [Create:REQ Update:OPT] Name of Catalog.
-	Name string `json:"name,omitempty" path:"name"`
+	Name string `json:"name,omitempty" url:"-"`
 	// [Create:IGN,Update:OPT] Username of current owner of Catalog.
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Privileges the user has on the Catalog.
@@ -2577,7 +2577,7 @@ type UpdateExternalLocation struct {
 	// Location.
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// [Create:REQ Update:OPT] Name of the External Location.
-	Name string `json:"name,omitempty" path:"name"`
+	Name string `json:"name,omitempty" url:"-"`
 	// [Create:IGN Update:OPT] The owner of the External Location.
 	Owner string `json:"owner,omitempty"`
 	// [Create,Update:IGN] Time at which this was last modified, in epoch
@@ -2606,7 +2606,7 @@ type UpdateMetastore struct {
 	// seconds
 	DeltaSharingRecipientTokenLifetimeInSeconds int `json:"delta_sharing_recipient_token_lifetime_in_seconds,omitempty"`
 	// Required. Unique ID of the Metastore (from URL).
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 	// [Create,Update:IGN] Unique identifier of Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// [Create:REQ Update:OPT] Name of Metastore.
@@ -2635,7 +2635,7 @@ type UpdateMetastoreAssignment struct {
 	// The unique ID of the Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// A workspace ID.
-	WorkspaceId int `json:"-" path:"workspace_id"`
+	WorkspaceId int `json:"-" url:"-"`
 }
 
 type UpdateMetastorePrivilegesItem string
@@ -2662,11 +2662,11 @@ type UpdatePermissions struct {
 	// Array of permissions change objects.
 	Changes []PermissionsChange `json:"changes,omitempty"`
 	// Required. Unique identifier (full name) of Securable (from URL).
-	FullName string `json:"-" path:"full_name"`
+	FullName string `json:"-" url:"-"`
 	// Optional. List permissions granted to this principal.
 	Principal string `json:"-" url:"principal,omitempty"`
 	// Required. Type of Securable (from URL).
-	SecurableType string `json:"-" path:"securable_type"`
+	SecurableType string `json:"-" url:"-"`
 }
 
 type UpdateProvider struct {
@@ -2684,7 +2684,7 @@ type UpdateProvider struct {
 	// [Create,Update:IGN] Username of Provider creator.
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create, Update:REQ] The name of the Provider.
-	Name string `json:"name,omitempty" path:"name"`
+	Name string `json:"name,omitempty" url:"-"`
 	// [Create,Update:IGN] This field is only present when the authentication
 	// type is TOKEN.
 	RecipientProfile *RecipientProfile `json:"recipient_profile,omitempty"`
@@ -2729,7 +2729,7 @@ type UpdateRecipient struct {
 	// [Create:OPT,Update:OPT] IP Access List
 	IpAccessList *IpAccessList `json:"ip_access_list,omitempty"`
 	// [Create:REQ,Update:OPT] Name of Recipient.
-	Name string `json:"name,omitempty" path:"name"`
+	Name string `json:"name,omitempty" url:"-"`
 	// [Create:OPT,Update:IGN] The one-time sharing code provided by the data
 	// recipient. This field is only present when the authentication type is
 	// DATABRICKS.
@@ -2765,7 +2765,7 @@ type UpdateSchema struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// [Create,Update:IGN] Full name of Schema, in form of
 	// <catalog_name>.<schema_name>.
-	FullName string `json:"full_name,omitempty" path:"full_name"`
+	FullName string `json:"full_name,omitempty" url:"-"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// [Create:REQ Update:OPT] Name of Schema, relative to parent Catalog.
@@ -2807,7 +2807,7 @@ const UpdateSchemaPrivilegesItemWriteFiles UpdateSchemaPrivilegesItem = `WRITE_F
 
 type UpdateShare struct {
 	// The name of the share.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 	// Array of shared data object updates.
 	Updates []SharedDataObjectUpdate `json:"updates,omitempty"`
 }
@@ -2816,7 +2816,7 @@ type UpdateSharePermissions struct {
 	// Array of permission changes.
 	Changes []PermissionsChange `json:"changes,omitempty"`
 	// Required. The name of the share.
-	Name string `json:"-" path:"name"`
+	Name string `json:"-" url:"-"`
 }
 
 type UpdateStorageCredential struct {
@@ -2839,7 +2839,7 @@ type UpdateStorageCredential struct {
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// [Create:REQ, Update:OPT] The credential name. The name MUST be unique
 	// within the Metastore.
-	Name string `json:"name,omitempty" path:"name"`
+	Name string `json:"name,omitempty" url:"-"`
 	// [Create:IGN Update:OPT] Username of current owner of credential.
 	Owner string `json:"owner,omitempty"`
 	// Optional. Supplying true to this argument skips validation of the updated
@@ -2872,7 +2872,7 @@ type UpdateTable struct {
 	DataSourceFormat UpdateTableDataSourceFormat `json:"data_source_format,omitempty"`
 	// [Create,Update:IGN] Full name of Table, in form of
 	// <catalog_name>.<schema_name>.<table_name>
-	FullName string `json:"full_name,omitempty" path:"full_name"`
+	FullName string `json:"full_name,omitempty" url:"-"`
 	// [Create,Update:IGN] Unique identifier of parent Metastore.
 	MetastoreId string `json:"metastore_id,omitempty"`
 	// [Create:REQ Update:OPT] Name of Table, relative to parent Schema.

--- a/service/warehouses/model.go
+++ b/service/warehouses/model.go
@@ -134,7 +134,7 @@ type CreateWarehouseResponse struct {
 // Delete a warehouse
 type DeleteWarehouse struct {
 	// Required. Id of the SQL warehouse.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 type EditWarehouseRequest struct {
@@ -176,7 +176,7 @@ type EditWarehouseRequest struct {
 	// Defaults to value in global endpoint settings
 	EnableServerlessCompute bool `json:"enable_serverless_compute,omitempty"`
 	// Required. Id of the warehouse to configure.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 	// Deprecated. Instance profile used to pass IAM role to the cluster
 	InstanceProfileArn string `json:"instance_profile_arn,omitempty"`
 	// Maximum number of clusters that the autoscaler will create to handle
@@ -420,7 +420,7 @@ type EndpointTags struct {
 // Get warehouse info
 type GetWarehouse struct {
 	// Required. Id of the SQL warehouse.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 type GetWarehouseResponse struct {
@@ -892,13 +892,13 @@ const SetWorkspaceWarehouseConfigRequestSecurityPolicyPassthrough SetWorkspaceWa
 // Start a warehouse
 type StartWarehouse struct {
 	// Required. Id of the SQL warehouse.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 // Stop a warehouse
 type StopWarehouse struct {
 	// Required. Id of the SQL warehouse.
-	Id string `json:"-" path:"id"`
+	Id string `json:"-" url:"-"`
 }
 
 type TerminationReason struct {

--- a/service/workspace/model.go
+++ b/service/workspace/model.go
@@ -27,7 +27,7 @@ type Export struct {
 	Format ExportFormat `json:"-" url:"format,omitempty"`
 	// The absolute path of the notebook or directory. Exporting directory is
 	// only support for `DBC` format.
-	Path string `json:"-" url:"path,omitempty"`
+	Path string `json:"-" url:"path"`
 }
 
 // This specifies the format of the file to be imported. By default, this is
@@ -54,7 +54,7 @@ type ExportResponse struct {
 // Get status
 type GetStatus struct {
 	// The absolute path of the notebook or directory.
-	Path string `json:"-" url:"path,omitempty"`
+	Path string `json:"-" url:"path"`
 }
 
 type Import struct {
@@ -97,7 +97,7 @@ type List struct {
 	// <content needed>
 	NotebooksModifiedAfter int `json:"-" url:"notebooks_modified_after,omitempty"`
 	// The absolute path of the notebook or directory.
-	Path string `json:"-" url:"path,omitempty"`
+	Path string `json:"-" url:"path"`
 }
 
 type ListResponse struct {

--- a/service/workspaceconf/model.go
+++ b/service/workspaceconf/model.go
@@ -6,7 +6,7 @@ package workspaceconf
 
 // Check configuration status
 type GetStatus struct {
-	Keys string `json:"-" url:"keys,omitempty"`
+	Keys string `json:"-" url:"keys"`
 }
 
 type WorkspaceConf map[string]string


### PR DESCRIPTION
This PR removes path parameters from URL query strings and fixes `,omitempty` where applicable.