### PR TITLE
Fixed pagination for cluster events

### DIFF
--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -117,7 +117,12 @@ func (a *{{.Service.Name}}API) {{.PascalName}}All(ctx context.Context{{if .Reque
 			{{- end}}
 			results = append(results, v)
 		}
-		{{if .Pagination.Token -}}
+		{{if eq .Path "/api/2.0/clusters/events" -}}
+		if response.NextPage == nil {
+			break
+		}
+		request = *response.NextPage
+		{{- else if .Pagination.Token -}}
 		request.{{.Pagination.Token.PollField.PascalName}} = response.{{.Pagination.Token.Bind.PascalName}}
 		if response.{{.Pagination.Token.Bind.PascalName}} == "" {
 			break

--- a/service/clusters/api.go
+++ b/service/clusters/api.go
@@ -285,7 +285,10 @@ func (a *ClustersAPI) EventsAll(ctx context.Context, request GetEvents) ([]Clust
 		for _, v := range response.Events {
 			results = append(results, v)
 		}
-		request.Offset += int64(len(response.Events))
+		if response.NextPage == nil {
+			break
+		}
+		request = *response.NextPage
 	}
 	return results, nil
 }


### PR DESCRIPTION
This PR uses the correct, unique, pagination style for cluster events. This is an improved version of https://github.com/databricks/terraform-provider-databricks/commit/6be469185d6d426b145ede8e88e9015314f65cb4

Fixes #191