### PR TITLE
Improve integration test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage
 
 raw-specs/**
 out/**
+*.log

--- a/examples/mocking/dbfs_test.go
+++ b/examples/mocking/dbfs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	_ "github.com/golang/mock/mockgen/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/dbfs"

--- a/internal/clusterpolicies_test.go
+++ b/internal/clusterpolicies_test.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/clusterpolicies"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccClusterPolicies(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	created, err := w.ClusterPolicies.Create(ctx, clusterpolicies.CreatePolicy{
+		Name: RandomName("go-sdk-"),
+		Definition: `{
+			"spark_conf.spark.databricks.delta.preview.enabled": {
+				"type": "fixed",
+				"value": true
+			}
+		}`,
+	})
+	require.NoError(t, err)
+	defer w.ClusterPolicies.DeleteByPolicyId(ctx, created.PolicyId)
+
+	policy, err := w.ClusterPolicies.GetByPolicyId(ctx, created.PolicyId)
+	require.NoError(t, err)
+
+	byName, err := w.ClusterPolicies.GetPolicyByName(ctx, policy.Name)
+	require.NoError(t, err)
+	assert.Equal(t, policy.Name, byName.Name)
+
+	all, err := w.ClusterPolicies.ListAll(ctx)
+	require.NoError(t, err)
+
+	names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(names), len(all))
+	assert.Equal(t, policy.PolicyId, names[policy.Name])
+
+	err = w.ClusterPolicies.Edit(ctx, clusterpolicies.EditPolicy{
+		PolicyId: policy.PolicyId,
+		Name:     policy.Name,
+		Definition: `{
+			"spark_conf.spark.databricks.delta.preview.enabled": {
+				"type": "fixed",
+				"value": false
+			}
+		}`,
+	})
+	require.NoError(t, err)
+}

--- a/internal/clusters_test.go
+++ b/internal/clusters_test.go
@@ -3,25 +3,50 @@ package internal
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/clusters"
+	"github.com/databricks/databricks-sdk-go/service/scim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccClustersCreateFailsWithTimeout(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	t.Parallel()
+// use mutex around starting TEST_GOSDK_CLUSTER_ID
+var mu sync.Mutex
 
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
+func sharedRunningCluster(t *testing.T, ctx context.Context,
+	w *databricks.WorkspaceClient) string {
+	mu.Lock()
+	defer mu.Unlock()
+
+	clusterId := GetEnvOrSkipTest(t, "TEST_GOSDK_CLUSTER_ID")
+	info, err := w.Clusters.GetByClusterId(ctx, clusterId)
+	require.NoError(t, err)
+
+	switch info.State {
+	// TODO: OpenAPI: clusters.ClusterInfoStatePending -> clusters.StatePending
+	case clusters.StateRunning:
+		// noop
+	case clusters.StateTerminated:
+		_, err = w.Clusters.StartByClusterIdAndWait(ctx, clusterId)
+		require.NoError(t, err)
+	case clusters.StatePending,
+		clusters.StateResizing,
+		clusters.StateRestarting:
+		_, err = w.Clusters.GetByClusterIdAndWait(ctx, clusterId)
+		require.NoError(t, err)
+	default:
+		t.Errorf("Cluster is in %s state", info.State)
 	}
+	return clusterId
+}
+
+func TestAccClustersCreateFailsWithTimeout(t *testing.T) {
+	ctx, w := workspaceTest(t)
 
 	// Fetch list of spark runtime versions
 	sparkVersions, err := w.Clusters.SparkVersions(ctx)
@@ -48,18 +73,38 @@ func TestAccClustersCreateFailsWithTimeout(t *testing.T) {
 		})
 	assert.True(t, strings.HasPrefix(err.Error(), "timed out: "))
 	_, err = w.Clusters.DeleteByClusterIdAndWait(ctx, clusterId)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+}
+
+func TestAccAwsInstanceProfiles(t *testing.T) {
+	ctx, w := workspaceTest(t)
+	if !w.Config.IsAws() {
+		t.Skipf("runs only on AWS")
+	}
+
+	arn := "arn:aws:iam::000000000000:instance-profile/abc"
+	err := w.InstanceProfiles.Add(ctx, clusters.AddInstanceProfile{
+		InstanceProfileArn: arn,
+		SkipValidation:     true,
+		IamRoleArn:         "arn:aws:iam::000000000000:role/bcd",
+	})
+	require.NoError(t, err)
+
+	defer w.InstanceProfiles.RemoveByInstanceProfileArn(ctx, arn)
+
+	err = w.InstanceProfiles.Edit(ctx, clusters.InstanceProfile{
+		InstanceProfileArn: arn,
+		IamRoleArn:         "arn:aws:iam::000000000000:role/bcdf",
+	})
+	require.NoError(t, err)
+
+	all, err := w.InstanceProfiles.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
 }
 
 func TestAccClustersApiIntegration(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	t.Parallel()
-
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	clusterName := RandomName("sdk-go-cluster-")
 
@@ -155,16 +200,40 @@ func TestAccClustersApiIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, len(events) > 0)
 
-	// List clusters in workspace
-	clusters, err := w.Clusters.ListAll(ctx, clusters.List{})
+	all, err := w.Clusters.ListAll(ctx, clusters.List{})
 	require.NoError(t, err)
 
-	var seen int
-	for _, clusterInfo := range clusters {
-		if clusterInfo.ClusterId == clstr.ClusterId {
-			seen++
-		}
+	// List clusters in workspace
+	names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx,
+		clusters.List{})
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Contains(t, names, clusterName)
+
+	otherOwner, err := w.Users.Create(ctx, scim.User{
+		UserName: RandomEmail("sdk-go-"),
+	})
+	require.NoError(t, err)
+	defer w.Users.DeleteById(ctx, otherOwner.Id)
+
+	// terminate the cluster
+	_, err = w.Clusters.DeleteByClusterIdAndWait(ctx, clstr.ClusterId)
+	require.NoError(t, err)
+
+	// cluster must be terminated to change the owner
+	err = w.Clusters.ChangeOwner(ctx, clusters.ChangeClusterOwner{
+		ClusterId:     clstr.ClusterId,
+		OwnerUsername: otherOwner.UserName,
+	})
+	require.NoError(t, err)
+
+	nodes, err := w.Clusters.ListNodeTypes(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(nodes.NodeTypes) > 1)
+
+	if w.Config.IsAws() {
+		zones, err := w.Clusters.ListZones(ctx)
+		require.NoError(t, err)
+		assert.True(t, len(zones.Zones) > 1)
 	}
-	// The test clusters should only occur once in the list clusters response
-	assert.True(t, seen == 1)
 }

--- a/internal/commands_test.go
+++ b/internal/commands_test.go
@@ -1,33 +1,20 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccCommands(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	wsc := databricks.Must(databricks.NewWorkspaceClient())
+	ctx, w := workspaceTest(t)
+	clusterId := sharedRunningCluster(t, ctx, w)
 
-	clusterId := GetEnvOrSkipTest(t, "TEST_GOSDK_CLUSTER_ID")
-
-	info, err := wsc.Clusters.GetByClusterId(ctx, clusterId)
-	require.NoError(t, err)
-	if !info.IsRunningOrResizing() {
-		_, err = wsc.Clusters.StartByClusterIdAndWait(ctx, clusterId)
-		require.NoError(t, err)
-	}
-
-	res := wsc.CommandExecutor.Execute(ctx, clusterId, "python", "print(1)")
+	res := w.CommandExecutor.Execute(ctx, clusterId, "python", "print(1)")
 	require.NoError(t, res.Err())
 	assert.Equal(t, "1", res.Text())
 
-	res = wsc.CommandExecutor.Execute(ctx, clusterId, "python", "1/0")
+	res = w.CommandExecutor.Execute(ctx, clusterId, "python", "1/0")
 	assert.EqualError(t, res.Err(), "ZeroDivisionError: division by zero")
 }

--- a/internal/dbfs_test.go
+++ b/internal/dbfs_test.go
@@ -2,38 +2,28 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"hash/fnv"
 	"io"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/dbfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func assertAcceptance(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	if env == "gcp" {
-		t.Skip("dbfs tests are skipped because dbfs rest api is disabled on gcp")
-	}
-}
-
 func TestAccDbfsUtilities(t *testing.T) {
-	assertAcceptance(t)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
+	ctx, w := workspaceTest(t)
+	if w.Config.IsGcp() {
+		t.Skip("dbfs not available on gcp")
 	}
 
-	path := RandomName("/tmp/databricks-go-sdk/fake")
+	path := RandomName("/tmp/.sdk/fake")
 	rand.Seed(time.Now().UnixNano())
 	in := make([]byte, 1.44*1e6)
 	_, _ = rand.Read(in)
@@ -65,39 +55,38 @@ func TestAccDbfsUtilities(t *testing.T) {
 }
 
 func TestAccListDbfsIntegration(t *testing.T) {
-	assertAcceptance(t)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
+	ctx, w := workspaceTest(t)
+	if w.Config.IsGcp() {
+		t.Skip("dbfs not available on gcp")
 	}
-	testFile1 := RandomName("test-file-1-")
-	testFile2 := RandomName("test-file-2-")
-	dbfsTestDirPath1 := RandomName("/tmp/databricks-go-sdk/integration/dbfs/TestDir1-")
-	dbfsTestDirPath2 := RandomName("/tmp/databricks-go-sdk/integration/dbfs/TestDir2-")
+
+	testFile1 := RandomName("f001-")
+	testFile2 := RandomName("f002-")
+	testPath1 := RandomName("/tmp/.sdk/001-")
+	testPath2 := RandomName("/tmp/.sdk/002-")
 
 	t.Cleanup(func() {
 		// recursively delete the test dir1 and any test files inside it
 		err := w.Dbfs.Delete(ctx, dbfs.Delete{
-			Path:      dbfsTestDirPath1,
+			Path:      testPath1,
 			Recursive: true,
 		})
 		require.NoError(t, err)
 		// recursively delete the test dir2 and any test files inside it
 		err = w.Dbfs.Delete(ctx, dbfs.Delete{
-			Path:      dbfsTestDirPath2,
+			Path:      testPath2,
 			Recursive: true,
 		})
 		require.NoError(t, err)
 	})
 
 	// make test dir2 in workspace root
-	err := w.Dbfs.MkdirsByPath(ctx, dbfsTestDirPath2)
+	err := w.Dbfs.MkdirsByPath(ctx, testPath2)
 	require.NoError(t, err)
 
 	// create testFile1 in test dir2
 	createdFile, err := w.Dbfs.Create(ctx, dbfs.Create{
-		Path:      filepath.Join(dbfsTestDirPath2, testFile1),
+		Path:      filepath.Join(testPath2, testFile1),
 		Overwrite: true,
 	})
 	require.NoError(t, err)
@@ -114,36 +103,36 @@ func TestAccListDbfsIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get testFile1 status
-	testFileStatus, err := w.Dbfs.GetStatusByPath(ctx, filepath.Join(dbfsTestDirPath2, testFile1))
+	testFileStatus, err := w.Dbfs.GetStatusByPath(ctx, filepath.Join(testPath2, testFile1))
 	require.NoError(t, err)
-	assert.True(t, testFileStatus.Path == filepath.Join(dbfsTestDirPath2, testFile1))
+	assert.True(t, testFileStatus.Path == filepath.Join(testPath2, testFile1))
 	assert.True(t, testFileStatus.IsDir == false)
 
 	// List all files in test dir2 and assert testFile1 is found
-	listOfFilesInWorkspaceRoot, err := w.Dbfs.ListByPath(ctx, dbfsTestDirPath2)
+	listOfFilesInWorkspaceRoot, err := w.Dbfs.ListByPath(ctx, testPath2)
 	require.NoError(t, err)
 	foundTestFile := false
 	for _, fileInfo := range listOfFilesInWorkspaceRoot.Files {
-		if fileInfo.Path == filepath.Join(dbfsTestDirPath2, testFile1) {
+		if fileInfo.Path == filepath.Join(testPath2, testFile1) {
 			foundTestFile = true
 		}
 	}
 	assert.True(t, foundTestFile)
 
 	// make test dir1 in workspace root
-	err = w.Dbfs.MkdirsByPath(ctx, dbfsTestDirPath1)
+	err = w.Dbfs.MkdirsByPath(ctx, testPath1)
 	require.NoError(t, err)
 
 	// move testFile1 to test dir1
 	err = w.Dbfs.Move(ctx, dbfs.Move{
-		SourcePath:      filepath.Join(dbfsTestDirPath2, testFile1),
-		DestinationPath: filepath.Join(dbfsTestDirPath1, testFile1),
+		SourcePath:      filepath.Join(testPath2, testFile1),
+		DestinationPath: filepath.Join(testPath1, testFile1),
 	})
 	require.NoError(t, err)
 
 	// put a new file testFile2 in test dir1
 	err = w.Dbfs.Put(ctx, dbfs.Put{
-		Path:      filepath.Join(dbfsTestDirPath1, testFile2),
+		Path:      filepath.Join(testPath1, testFile2),
 		Contents:  base64.StdEncoding.EncodeToString([]byte("Bye Bye, World!")),
 		Overwrite: true,
 	})
@@ -151,15 +140,19 @@ func TestAccListDbfsIntegration(t *testing.T) {
 
 	// assert on contents of testFile1
 	contentsTestFile, err := w.Dbfs.Read(ctx, dbfs.Read{
-		Path: filepath.Join(dbfsTestDirPath1, testFile1),
+		Path: filepath.Join(testPath1, testFile1),
 	})
 	require.NoError(t, err)
 	assert.True(t, contentsTestFile.Data == base64.StdEncoding.EncodeToString([]byte("Hello, World!")))
 
 	// assert on contents of testFile2
 	contentsByeByeWorldFile, err := w.Dbfs.Read(ctx, dbfs.Read{
-		Path: filepath.Join(dbfsTestDirPath1, testFile2),
+		Path: filepath.Join(testPath1, testFile2),
 	})
 	require.NoError(t, err)
 	assert.True(t, contentsByeByeWorldFile.Data == base64.StdEncoding.EncodeToString([]byte("Bye Bye, World!")))
+
+	files, err := w.Dbfs.RecursiveList(ctx, path.Dir(testPath1))
+	require.NoError(t, err)
+	assert.True(t, len(files) >= 2)
 }

--- a/internal/dbsql_test.go
+++ b/internal/dbsql_test.go
@@ -1,23 +1,16 @@
 package internal
 
 import (
-	"context"
+	"strconv"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/dbsql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccQueries(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	srcs, err := w.DataSources.ListDataSources(ctx)
 	require.NoError(t, err)
@@ -32,38 +25,139 @@ func TestAccQueries(t *testing.T) {
 		Query:        "SHOW TABLES",
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		err := w.Queries.DeleteQueryByQueryId(ctx, query.Id)
-		require.NoError(t, err)
+
+	err = w.Queries.DeleteQueryByQueryId(ctx, query.Id)
+	require.NoError(t, err)
+
+	err = w.Queries.RestoreQuery(ctx, dbsql.RestoreQueryRequest{
+		QueryId: query.Id,
 	})
+	require.NoError(t, err)
+
+	updated, err := w.Queries.UpdateQuery(ctx, dbsql.QueryPostContent{
+		QueryId:      query.Id,
+		Name:         RandomName("go-sdk-updated"),
+		DataSourceId: srcs[0].Id,
+		Description:  "UPDATED: test query from Go SDK",
+		Query:        "SELECT 2+2",
+	})
+	require.NoError(t, err)
 
 	loaded, err := w.Queries.GetQueryByQueryId(ctx, query.Id)
 	require.NoError(t, err)
-	assert.Equal(t, query.Query, loaded.Query)
+	assert.NotEqual(t, query.Query, loaded.Query)
+	assert.Equal(t, updated.Query, loaded.Query)
+}
+
+func TestAccAlerts(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	srcs, err := w.DataSources.ListDataSources(ctx)
+	require.NoError(t, err)
+	if len(srcs) == 0 {
+		t.Skipf("no sql warehouses found")
+	}
+
+	query, err := w.Queries.CreateQuery(ctx, dbsql.QueryPostContent{
+		Name:         RandomName("go-sdk/test/"),
+		DataSourceId: srcs[0].Id,
+		Description:  "test query from Go SDK",
+		Query:        "SHOW TABLES",
+	})
+	require.NoError(t, err)
+	defer w.Queries.DeleteQueryByQueryId(ctx, query.Id)
+
+	alert, err := w.Alerts.CreateAlert(ctx, dbsql.EditAlert{
+		Name:    RandomName("go-sdk-"),
+		QueryId: query.Id,
+	})
+	require.NoError(t, err)
+	defer w.Alerts.DeleteAlertByAlertId(ctx, alert.Id)
+
+	err = w.Alerts.UpdateAlert(ctx, dbsql.EditAlert{
+		AlertId: alert.Id,
+		Name:    RandomName("go-sdk-updated-"),
+		QueryId: query.Id,
+	})
+	require.NoError(t, err)
+
+	byId, err := w.Alerts.GetAlertByAlertId(ctx, alert.Id)
+	require.NoError(t, err)
+
+	all, err := w.Alerts.ListAlerts(ctx)
+	require.NoError(t, err)
+
+	names, err := w.Alerts.AlertNameToIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, alert.Id, names[byId.Name])
+
+	schedule, err := w.Alerts.CreateSchedule(ctx, dbsql.CreateRefreshSchedule{
+		AlertId:      alert.Id,
+		Cron:         "5 4 * * *",
+		DataSourceId: srcs[0].Id,
+	})
+	require.NoError(t, err)
+	defer w.Alerts.DeleteScheduleByAlertIdAndScheduleId(ctx, alert.Id, schedule.Id)
+
+	schedules, err := w.Alerts.ListSchedulesByAlertId(ctx, alert.Id)
+	require.NoError(t, err)
+	assert.True(t, len(schedules) >= 1)
+
+	me, err := w.CurrentUser.Me(ctx)
+	require.NoError(t, err)
+
+	userId, err := strconv.ParseInt(me.Id, 10, 64)
+	require.NoError(t, err)
+
+	sub, err := w.Alerts.Subscribe(ctx, dbsql.CreateSubscription{
+		AlertId: alert.Id,
+		UserId:  userId,
+	})
+	require.NoError(t, err)
+
+	allSubs, err := w.Alerts.GetSubscriptionsByAlertId(ctx, alert.Id)
+	require.NoError(t, err)
+	assert.True(t, len(allSubs) >= 1)
+
+	err = w.Alerts.UnsubscribeByAlertIdAndSubscriptionId(ctx, alert.Id, sub.Id)
+	require.NoError(t, err)
 }
 
 func TestAccDashboards(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
+
+	created, err := w.Dashboards.CreateDashboard(ctx, dbsql.CreateDashboardRequest{
+		Name:                    RandomName("go-sdk-"),
+		DashboardFiltersEnabled: false,
+		IsDraft:                 true,
+	})
+	require.NoError(t, err)
+
+	defer w.Dashboards.DeleteDashboardByDashboardId(ctx, created.Id)
+
+	byId, err := w.Dashboards.GetDashboardByDashboardId(ctx, created.Id)
+	require.NoError(t, err)
 
 	all, err := w.Dashboards.ListDashboardsAll(ctx, dbsql.ListDashboardsRequest{})
 	require.NoError(t, err)
-	t.Log(len(all))
+
+	names, err := w.Dashboards.DashboardNameToIdMap(ctx, dbsql.ListDashboardsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, created.Id, names[byId.Name])
+	assert.Equal(t, len(all), len(names))
+
+	err = w.Dashboards.DeleteDashboardByDashboardId(ctx, created.Id)
+	require.NoError(t, err)
+
+	err = w.Dashboards.RestoreDashboard(ctx, dbsql.RestoreDashboardRequest{
+		DashboardId: created.Id,
+	})
+	require.NoError(t, err)
 }
 
 func TestAccQueriesList(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	srcs, err := w.DataSources.ListDataSources(ctx)
 	require.NoError(t, err)

--- a/internal/deployment_test.go
+++ b/internal/deployment_test.go
@@ -1,23 +1,16 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/deployment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMwsAccStorage(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	a := databricks.Must(databricks.NewAccountClient(&databricks.Config{
-		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
-	}))
-	if !a.Config.IsAccountsClient() || !a.Config.IsAws() {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
 		t.SkipNow()
 	}
 
@@ -43,13 +36,8 @@ func TestMwsAccStorage(t *testing.T) {
 }
 
 func TestMwsAccNetworks(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	a := databricks.Must(databricks.NewAccountClient(&databricks.Config{
-		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
-	}))
-	if !a.Config.IsAccountsClient() || !a.Config.IsAws() {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
 		t.SkipNow()
 	}
 	netw, err := a.Networks.Create(ctx, deployment.CreateNetworkRequest{
@@ -73,13 +61,8 @@ func TestMwsAccNetworks(t *testing.T) {
 }
 
 func TestMwsAccCredentials(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	a := databricks.Must(databricks.NewAccountClient(&databricks.Config{
-		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
-	}))
-	if !a.Config.IsAccountsClient() || !a.Config.IsAws() {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
 		t.SkipNow()
 	}
 	role, err := a.Credentials.Create(ctx, deployment.CreateCredentialRequest{
@@ -92,10 +75,10 @@ func TestMwsAccCredentials(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		err = a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
 		require.NoError(t, err)
-	}()
+	})
 
 	_, err = a.Credentials.GetByCredentialsId(ctx, role.CredentialsId)
 	require.NoError(t, err)
@@ -103,4 +86,179 @@ func TestMwsAccCredentials(t *testing.T) {
 	configs, err := a.Credentials.List(ctx)
 	require.NoError(t, err)
 	assert.True(t, len(configs) > 0)
+}
+
+func TestMwsAccEncryptionKeys(t *testing.T) {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
+		t.SkipNow()
+	}
+
+	created, err := a.EncryptionKeys.Create(ctx, deployment.CreateCustomerManagedKeyRequest{
+		AwsKeyInfo: deployment.CreateAwsKeyInfo{
+			KeyArn:   GetEnvOrSkipTest(t, "TEST_MANAGED_KMS_KEY_ARN"),
+			KeyAlias: GetEnvOrSkipTest(t, "TEST_STORAGE_KMS_KEY_ALIAS"),
+		},
+		UseCases: []string{"MANAGED_SERVICES"}, // TODO: OpenAPI: add enum
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := a.EncryptionKeys.DeleteByCustomerManagedKeyId(ctx, created.CustomerManagedKeyId)
+		require.NoError(t, err)
+	})
+
+	byId, err := a.EncryptionKeys.GetByCustomerManagedKeyId(ctx, created.CustomerManagedKeyId)
+	require.NoError(t, err)
+	assert.Equal(t, "MANAGED_SERVICES", byId.UseCases[0])
+
+	all, err := a.EncryptionKeys.List(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestMwsAccPrivateAccess(t *testing.T) {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
+		t.SkipNow()
+	}
+
+	// TODO: OpenAPI: rename entities
+	created, err := a.PrivateAccess.Create(ctx, deployment.UpsertPrivateAccessSettingsRequest{
+		PrivateAccessSettingsName: RandomName("go-sdk-"),
+		Region:                    GetEnvOrSkipTest(t, "AWS_REGION"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := a.PrivateAccess.DeleteByPrivateAccessSettingsId(ctx, created.PrivateAccessSettingsId)
+		require.NoError(t, err)
+	})
+	err = a.PrivateAccess.Replace(ctx, deployment.UpsertPrivateAccessSettingsRequest{
+		PrivateAccessSettingsId:   created.PrivateAccessSettingsId,
+		PrivateAccessSettingsName: RandomName("go-sdk-"),
+		Region:                    GetEnvOrSkipTest(t, "AWS_REGION"),
+	})
+	require.NoError(t, err)
+
+	byId, err := a.PrivateAccess.GetByPrivateAccessSettingsId(ctx, created.PrivateAccessSettingsId)
+	require.NoError(t, err)
+
+	all, err := a.PrivateAccess.List(ctx)
+	require.NoError(t, err)
+
+	names, err := a.PrivateAccess.PrivateAccessSettingsPrivateAccessSettingsNameToPrivateAccessSettingsIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(names), len(all))
+	assert.Equal(t, byId.PrivateAccessSettingsId, names[byId.PrivateAccessSettingsName])
+}
+
+func TestMwsAccVpcEndpoints(t *testing.T) {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
+		t.SkipNow()
+	}
+
+	created, err := a.VpcEndpoints.Create(ctx, deployment.CreateVpcEndpointRequest{
+		AwsVpcEndpointId: GetEnvOrSkipTest(t, "TEST_RELAY_VPC_ENDPOINT"),
+		Region:           GetEnvOrSkipTest(t, "AWS_REGION"),
+		VpcEndpointName:  RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := a.VpcEndpoints.DeleteByVpcEndpointId(ctx, created.VpcEndpointId)
+		require.NoError(t, err)
+	})
+
+	byId, err := a.VpcEndpoints.GetByVpcEndpointId(ctx, created.VpcEndpointId)
+	require.NoError(t, err)
+	assert.Equal(t, deployment.EndpointUseCaseDataplaneRelayAccess, byId.UseCase)
+
+	all, err := a.VpcEndpoints.List(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestMwsAccWorkspaces(t *testing.T) {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
+		t.SkipNow()
+	}
+
+	storage, err := a.Storage.Create(ctx, deployment.CreateStorageConfigurationRequest{
+		StorageConfigurationName: RandomName("go-sdk-"),
+		RootBucketInfo: deployment.RootBucketInfo{
+			BucketName: GetEnvOrSkipTest(t, "TEST_ROOT_BUCKET"),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := a.Storage.DeleteByStorageConfigurationId(ctx, storage.StorageConfigurationId)
+		require.NoError(t, err)
+	})
+
+	// TODO: OpenAPI: Document retry protocol on AWS IAM registration errors
+	// See https://github.com/databricks/terraform-provider-databricks/issues/1424
+	role, err := a.Credentials.Create(ctx, deployment.CreateCredentialRequest{
+		CredentialsName: RandomName("go-sdk-"),
+		AwsCredentials: deployment.AwsCredentials{
+			StsRole: &deployment.StsRole{
+				RoleArn: GetEnvOrSkipTest(t, "TEST_CROSSACCOUNT_ARN"),
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
+		require.NoError(t, err)
+	})
+
+	// TODO: Add DNS reachability utility
+	created, err := a.Workspaces.CreateAndWait(ctx, deployment.CreateWorkspaceRequest{
+		WorkspaceName:          RandomName("go-sdk-"),
+		AwsRegion:              GetEnvOrSkipTest(t, "AWS_REGION"),
+		CredentialsId:          role.CredentialsId,
+		StorageConfigurationId: storage.StorageConfigurationId,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := a.Workspaces.DeleteByWorkspaceId(ctx, created.WorkspaceId)
+		require.NoError(t, err)
+	})
+
+	updateRole, err := a.Credentials.Create(ctx, deployment.CreateCredentialRequest{
+		CredentialsName: RandomName("go-sdk-"),
+		AwsCredentials: deployment.AwsCredentials{
+			StsRole: &deployment.StsRole{
+				RoleArn: GetEnvOrSkipTest(t, "TEST_CROSSACCOUNT_ARN"),
+			},
+		},
+	})
+	require.NoError(t, err)
+	// TODO: OpenAPI: add error retry to properly wait for things like
+	// 409 Conflict - INVALID_STATE: Unable to delete, credential is being used by an active workspace
+	defer a.Credentials.DeleteByCredentialsId(ctx, updateRole.CredentialsId)
+	// t.Cleanup(func() {
+	// 	err := a.Credentials.DeleteByCredentialsId(ctx, updateRole.CredentialsId)
+	// 	require.NoError(t, err)
+	// })
+
+	// this also takes a while
+	_, err = a.Workspaces.UpdateAndWait(ctx, deployment.UpdateWorkspaceRequest{
+		WorkspaceId:   created.WorkspaceId,
+		CredentialsId: updateRole.CredentialsId,
+	})
+	require.NoError(t, err)
+
+	byId, err := a.Workspaces.GetByWorkspaceId(ctx, created.WorkspaceId)
+	require.NoError(t, err)
+
+	all, err := a.Workspaces.List(ctx)
+	require.NoError(t, err)
+
+	names, err := a.Workspaces.WorkspaceWorkspaceNameToWorkspaceIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(names), len(all))
+	assert.Equal(t, byId.WorkspaceId, names[byId.WorkspaceName])
 }

--- a/internal/git_credentials_test.go
+++ b/internal/git_credentials_test.go
@@ -1,23 +1,15 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/gitcredentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccGitCredentials(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	list, err := w.GitCredentials.ListAll(ctx)
 	require.NoError(t, err)
@@ -49,4 +41,8 @@ func TestAccGitCredentials(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEqual(t, cr.GitUsername, load.GitUsername)
+
+	names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, names, load.GitProvider)
 }

--- a/internal/globalinitscripts_test.go
+++ b/internal/globalinitscripts_test.go
@@ -1,0 +1,46 @@
+package internal
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/globalinitscripts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccGlobalInitScripts(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	created, err := w.GlobalInitScripts.CreateScript(ctx, globalinitscripts.GlobalInitScriptCreateRequest{
+		Name:     RandomName("go-sdk-"),
+		Script:   base64.StdEncoding.EncodeToString([]byte("echo 1")),
+		Enabled:  true,
+		Position: 10,
+	})
+	require.NoError(t, err)
+
+	defer w.GlobalInitScripts.DeleteScriptByScriptId(ctx, created.ScriptId)
+
+	err = w.GlobalInitScripts.UpdateScript(ctx, globalinitscripts.GlobalInitScriptUpdateRequest{
+		ScriptId: created.ScriptId,
+		Name:     RandomName("go-sdk-updated-"),
+		Script:   base64.StdEncoding.EncodeToString([]byte("echo 2")),
+	})
+	require.NoError(t, err)
+
+	script, err := w.GlobalInitScripts.GetScriptByScriptId(ctx, created.ScriptId)
+	require.NoError(t, err)
+
+	all, err := w.GlobalInitScripts.ListScriptsAll(ctx)
+	require.NoError(t, err)
+
+	names, err := w.GlobalInitScripts.GlobalInitScriptDetailsNameToScriptIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, script.ScriptId, names[script.Name])
+
+	byName, err := w.GlobalInitScripts.GetGlobalInitScriptDetailsByName(ctx, script.Name)
+	require.NoError(t, err)
+	assert.Equal(t, byName.ScriptId, script.ScriptId)
+}

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -1,15 +1,20 @@
 package internal
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
 )
 
 const fullCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -19,11 +24,55 @@ func init() {
 	databricks.WithProduct("integration-tests", databricks.Version())
 }
 
+// prelude for all workspace-level tests
+func workspaceTest(t *testing.T) (context.Context, *databricks.WorkspaceClient) {
+	loadDebugEnvIfRunsFromIDE(t, "workspace")
+	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
+	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
+		skipf(t)("Skipping workspace test on account level")
+	}
+	t.Parallel()
+	ctx := context.Background()
+	return ctx, databricks.Must(databricks.NewWorkspaceClient())
+}
+
+// prelude for all workspace-level UC tests
+func ucwsTest(t *testing.T) (context.Context, *databricks.WorkspaceClient) {
+	loadDebugEnvIfRunsFromIDE(t, "ucws")
+	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
+		skipf(t)("Skipping workspace test on account level")
+	}
+	GetEnvOrSkipTest(t, "TEST_METASTORE_ID")
+	t.Parallel()
+	ctx := context.Background()
+	return ctx, databricks.Must(databricks.NewWorkspaceClient())
+}
+
+// prelude for all account-level tests
+func accountTest(t *testing.T) (context.Context, *databricks.AccountClient) {
+	loadDebugEnvIfRunsFromIDE(t, "account")
+	cfg := &config.Config{
+		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
+	}
+	err := cfg.EnsureResolved()
+	if err != nil {
+		skipf(t)("error: %s", err)
+	}
+	if !cfg.IsAccountsClient() {
+		skipf(t)("Not in account env: %s/%s", cfg.AccountID, cfg.Host)
+	}
+	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
+	t.Parallel()
+	ctx := context.Background()
+	return ctx, databricks.Must(databricks.NewAccountClient(
+		(*databricks.Config)(cfg)))
+}
+
 // GetEnvOrSkipTest proceeds with test only with that env variable
 func GetEnvOrSkipTest(t *testing.T, name string) string {
 	value := os.Getenv(name)
 	if value == "" {
-		t.Skipf("Environment variable %s is missing", name)
+		skipf(t)("Environment variable %s is missing", name)
 	}
 	return value
 }
@@ -32,7 +81,7 @@ func GetEnvInt64OrSkipTest(t *testing.T, name string) int64 {
 	v := GetEnvOrSkipTest(t, name)
 	i, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
-		t.Skipf("`%s` is not int64: %s", v, err)
+		skipf(t)("`%s` is not int64: %s", v, err)
 	}
 	return i
 }
@@ -68,4 +117,46 @@ func RandomHex(prefix string, randLen int) string {
 		return fmt.Sprintf("%s%s", prefix, b)
 	}
 	return string(b)
+}
+
+func skipf(t *testing.T) func(format string, args ...any) {
+	if isInDebug() {
+		// VSCode "debug test" feature doesn't show dlv logs,
+		// so that we fail here for maintainer productivity.
+		return t.Fatalf
+	}
+	return t.Skipf
+}
+
+// detects if test is run from "debug test" feature in VSCode
+func isInDebug() bool {
+	ex, _ := os.Executable()
+	return path.Base(ex) == "__debug_bin"
+}
+
+// loads debug environment from ~/.databricks/debug-env.json
+func loadDebugEnvIfRunsFromIDE(t *testing.T, key string) {
+	if !isInDebug() {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("cannot find user home: %s", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".databricks/debug-env.json"))
+	if err != nil {
+		t.Fatalf("cannot load ~/.databricks/debug-env.json: %s", err)
+	}
+	var conf map[string]map[string]string
+	err = json.Unmarshal(raw, &conf)
+	if err != nil {
+		t.Fatalf("cannot parse ~/.databricks/debug-env.json: %s", err)
+	}
+	vars, ok := conf[key]
+	if !ok {
+		t.Fatalf("~/.databricks/debug-env.json#%s not configured", key)
+	}
+	for k, v := range vars {
+		os.Setenv(k, v)
+	}
 }

--- a/internal/instancepools_test.go
+++ b/internal/instancepools_test.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/clusters"
+	"github.com/databricks/databricks-sdk-go/service/instancepools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccInstancePools(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	vms, err := w.Clusters.ListNodeTypes(ctx)
+	require.NoError(t, err)
+
+	smallest, err := vms.Smallest(clusters.NodeTypeRequest{
+		LocalDisk: true,
+	})
+	require.NoError(t, err)
+
+	created, err := w.InstancePools.Create(ctx, instancepools.CreateInstancePool{
+		InstancePoolName: RandomName("go-sdk-"),
+		NodeTypeId:       smallest,
+	})
+	require.NoError(t, err)
+
+	defer w.InstancePools.DeleteByInstancePoolId(ctx, created.InstancePoolId)
+
+	err = w.InstancePools.Edit(ctx, instancepools.EditInstancePool{
+		InstancePoolId:   created.InstancePoolId,
+		InstancePoolName: RandomName("go-sdk-updated"),
+		NodeTypeId:       smallest,
+	})
+	require.NoError(t, err)
+
+	pool, err := w.InstancePools.GetByInstancePoolId(ctx, created.InstancePoolId)
+	require.NoError(t, err)
+
+	all, err := w.InstancePools.ListAll(ctx)
+	require.NoError(t, err)
+
+	names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, pool.InstancePoolId, names[pool.InstancePoolName])
+
+	byName, err := w.InstancePools.GetInstancePoolAndStatsByInstancePoolName(ctx, pool.InstancePoolName)
+	require.NoError(t, err)
+	assert.Equal(t, byName.InstancePoolId, pool.InstancePoolId)
+}

--- a/internal/ipaccesslists_test.go
+++ b/internal/ipaccesslists_test.go
@@ -1,0 +1,46 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/ipaccesslists"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccIpAccessLists(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	created, err := w.IpAccessLists.Create(ctx, ipaccesslists.CreateIpAccessList{
+		Label:       RandomName("go-sdk-"),
+		IpAddresses: []string{"1.0.0.0/16"},
+		ListType:    ipaccesslists.ListTypeBlock,
+	})
+	require.NoError(t, err)
+
+	defer w.IpAccessLists.DeleteByIpAccessListId(ctx, created.IpAccessList.ListId)
+
+	err = w.IpAccessLists.Replace(ctx, ipaccesslists.ReplaceIpAccessList{
+		IpAccessListId: created.IpAccessList.ListId,
+		Label:          RandomName("go-sdk-updated-"),
+		IpAddresses:    []string{"1.0.0.0/24"},
+		ListType:       ipaccesslists.ListTypeBlock,
+		Enabled:        false,
+	})
+	require.NoError(t, err)
+
+	list, err := w.IpAccessLists.GetByIpAccessListId(ctx, created.IpAccessList.ListId)
+	require.NoError(t, err)
+
+	all, err := w.IpAccessLists.ListAll(ctx)
+	require.NoError(t, err)
+
+	names, err := w.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, list.IpAccessList.ListId, names[list.IpAccessList.Label])
+
+	byName, err := w.IpAccessLists.GetIpAccessListInfoByLabel(ctx, list.IpAccessList.Label)
+	require.NoError(t, err)
+	assert.Equal(t, list.IpAccessList.ListId, byName.ListId)
+}

--- a/internal/libraries_test.go
+++ b/internal/libraries_test.go
@@ -1,24 +1,15 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/libraries"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccLibraries(t *testing.T) {
-	GetEnvOrSkipTest(t, "CLOUD_ENV")
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
-
-	clusterId := createTestCluster(ctx, w, t)
-	defer w.Clusters.PermanentDeleteByClusterId(ctx, clusterId)
+	ctx, w := workspaceTest(t)
+	clusterId := sharedRunningCluster(t, ctx, w)
 
 	err := w.Libraries.UpdateAndWait(ctx, libraries.Update{
 		ClusterId: clusterId,
@@ -30,5 +21,17 @@ func TestAccLibraries(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	err = w.Libraries.UpdateAndWait(ctx, libraries.Update{
+		ClusterId: clusterId,
+		Uninstall: []libraries.Library{
+			{
+				Pypi: &libraries.PythonPyPiLibrary{
+					Package: "dbl-tempo",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
 }

--- a/internal/mlflow_test.go
+++ b/internal/mlflow_test.go
@@ -1,0 +1,250 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/mlflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccExperiments(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	created, err := w.Experiments.Create(ctx, mlflow.CreateExperiment{
+		Name: RandomName("/tmp/go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.Experiments.DeleteByExperimentId(ctx, created.ExperimentId)
+		require.NoError(t, err)
+	})
+
+	err = w.Experiments.Update(ctx, mlflow.UpdateExperiment{
+		NewName:      RandomName("/tmp/go-sdk-"),
+		ExperimentId: created.ExperimentId,
+	})
+	require.NoError(t, err)
+
+	_, err = w.Experiments.GetByExperimentId(ctx, created.ExperimentId)
+	require.NoError(t, err)
+
+	all, err := w.Experiments.ListAll(ctx, mlflow.ListExperimentsRequest{})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestAccMLflowRuns(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	experiment, err := w.Experiments.Create(ctx, mlflow.CreateExperiment{
+		Name: RandomName("/tmp/go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.Experiments.DeleteByExperimentId(ctx, experiment.ExperimentId)
+		require.NoError(t, err)
+	})
+
+	created, err := w.MLflowRuns.Create(ctx, mlflow.CreateRun{
+		ExperimentId: experiment.ExperimentId,
+		Tags: []mlflow.RunTag{
+			{
+				Key:   "foo",
+				Value: "bar",
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// TODO: OpenAPI: fix mapping
+		err := w.MLflowRuns.DeleteByRunId(ctx, created.Run.Info.RunId)
+		require.NoError(t, err)
+	})
+
+	_, err = w.MLflowRuns.Update(ctx, mlflow.UpdateRun{
+		RunId:  created.Run.Info.RunId,
+		Status: mlflow.UpdateRunStatusKilled,
+	})
+	require.NoError(t, err)
+}
+
+func TestAccRegisteredModels(t *testing.T) {
+	t.Skip("fixme")
+	t.Skip("Missing required field: name?...")
+	ctx, w := workspaceTest(t)
+
+	created, err := w.RegisteredModels.Create(ctx, mlflow.CreateRegisteredModelRequest{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// TODO: OpenAPI: x-databricks-sdk-inline
+		// FIXME: Missing required field: name?..
+		err := w.RegisteredModels.DeleteByName(ctx, created.RegisteredModel.Name)
+		require.NoError(t, err)
+	})
+
+	err = w.RegisteredModels.Update(ctx, mlflow.UpdateRegisteredModelRequest{
+		Name:        created.RegisteredModel.Name,
+		Description: RandomName("comment "),
+	})
+	require.NoError(t, err)
+
+	_, err = w.RegisteredModels.GetByName(ctx, created.RegisteredModel.Name)
+	require.NoError(t, err)
+
+	all, err := w.RegisteredModels.ListAll(ctx, mlflow.ListRegisteredModelsRequest{})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestAccRegistryWebhooks(t *testing.T) {
+	t.Skip("incorrect OpenAPI spec")
+	ctx, w := workspaceTest(t)
+
+	// TODO: incomplete ID?...
+	created, err := w.RegistryWebhooks.Create(ctx, mlflow.CreateRegistryWebhook{
+		Description: RandomName("comment "),
+		Events:      []mlflow.RegistryWebhookEvent{mlflow.RegistryWebhookEventModelVersionCreated},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.RegistryWebhooks.DeleteById(ctx, created.Comment.Comment)
+		require.NoError(t, err)
+	})
+	err = w.RegistryWebhooks.Update(ctx, mlflow.UpdateRegistryWebhook{
+		Id: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	all, err := w.RegistryWebhooks.ListAll(ctx, mlflow.ListRegistryWebhooksRequest{})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestAccModelVersions(t *testing.T) {
+	t.Skip("fixme")
+	ctx, w := workspaceTest(t)
+
+	model, err := w.RegisteredModels.Create(ctx, mlflow.CreateRegisteredModelRequest{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// TODO: OpenAPI: x-databricks-sdk-inline
+		// FIXME: Missing required field: name?..
+		err := w.RegisteredModels.DeleteByName(ctx, model.RegisteredModel.Name)
+		require.NoError(t, err)
+	})
+
+	created, err := w.ModelVersions.Create(ctx, mlflow.CreateModelVersionRequest{
+		Name:   model.RegisteredModel.Name,
+		Source: "dbfs:/tmp",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.ModelVersions.Delete(ctx, mlflow.DeleteModelVersionRequest{
+			// TODO: OpenAPI: x-databricks-sdk-inline
+			Name:    created.ModelVersion.Name,
+			Version: created.ModelVersion.Version,
+		})
+		require.NoError(t, err)
+	})
+
+	err = w.ModelVersions.Update(ctx, mlflow.UpdateModelVersionRequest{
+		Description: RandomName("description "),
+		Name:        created.ModelVersion.Name,
+		Version:     created.ModelVersion.Version,
+	})
+	require.NoError(t, err)
+}
+
+func TestAccModelVersionComments(t *testing.T) {
+	t.Skip("fixme")
+	ctx, w := workspaceTest(t)
+
+	model, err := w.RegisteredModels.Create(ctx, mlflow.CreateRegisteredModelRequest{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// TODO: OpenAPI: x-databricks-sdk-inline
+		// FIXME: Missing required field: name?..
+		err := w.RegisteredModels.DeleteByName(ctx, model.RegisteredModel.Name)
+		require.NoError(t, err)
+	})
+
+	mv, err := w.ModelVersions.Create(ctx, mlflow.CreateModelVersionRequest{
+		Name:   model.RegisteredModel.Name,
+		Source: "dbfs:/tmp",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.ModelVersions.Delete(ctx, mlflow.DeleteModelVersionRequest{
+			// TODO: OpenAPI: x-databricks-sdk-inline
+			Name:    mv.ModelVersion.Name,
+			Version: mv.ModelVersion.Version,
+		})
+		require.NoError(t, err)
+	})
+
+	created, err := w.ModelVersionComments.Create(ctx, mlflow.CreateComment{
+		Comment: RandomName("comment "),
+		Name:    model.RegisteredModel.Name,
+		Version: mv.ModelVersion.Version,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// TODO: OpenAPI: x-databricks-sdk-inline
+		// FIXME: missing ID?..
+		err := w.ModelVersionComments.DeleteById(ctx, created.Comment.UserId)
+		require.NoError(t, err)
+	})
+	_, err = w.ModelVersionComments.Update(ctx, mlflow.UpdateComment{
+		Comment: RandomName("updated "),
+		Id:      created.Comment.UserId,
+	})
+	require.NoError(t, err)
+}
+
+func TestAccTransitionRequests(t *testing.T) {
+	t.Skip("fixme")
+	ctx, w := workspaceTest(t)
+
+	model, err := w.RegisteredModels.Create(ctx, mlflow.CreateRegisteredModelRequest{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// TODO: OpenAPI: x-databricks-sdk-inline
+		// FIXME: Missing required field: name?..
+		err := w.RegisteredModels.DeleteByName(ctx, model.RegisteredModel.Name)
+		require.NoError(t, err)
+	})
+
+	version := model.RegisteredModel.LatestVersions[0].Version
+	_, err = w.TransitionRequests.Create(ctx, mlflow.CreateTransitionRequest{
+		Name:    model.RegisteredModel.Name,
+		Stage:   mlflow.StageProduction,
+		Version: version,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.TransitionRequests.Delete(ctx, mlflow.DeleteTransitionRequestRequest{
+			Name:    model.RegisteredModel.Name,
+			Version: version,
+			Stage:   string(mlflow.StageProduction), // TODO: OpenAPI: make enum
+		})
+		require.NoError(t, err)
+	})
+
+	all, err := w.TransitionRequests.ListAll(ctx, mlflow.ListTransitionRequestsRequest{})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}

--- a/internal/permissions_test.go
+++ b/internal/permissions_test.go
@@ -1,24 +1,62 @@
 package internal
 
 import (
-	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/permissions"
 	"github.com/databricks/databricks-sdk-go/service/scim"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestAccGenericPermissions(t *testing.T) {
+	ctx, w := workspaceTest(t)
+	notebookPath := myNotebookPath(t, w)
+
+	err := w.Workspace.Import(ctx, workspace.PythonNotebookOverwrite(
+		notebookPath, `print(1)`))
+	require.NoError(t, err)
+
+	obj, err := w.Workspace.GetStatusByPath(ctx, notebookPath)
+	require.NoError(t, err)
+
+	levels, err := w.Permissions.GetPermissionLevels(ctx, permissions.GetPermissionLevels{
+		RequestObjectType: "notebooks",
+		RequestObjectId:   fmt.Sprintf("%d", obj.ObjectId),
+	})
+	require.NoError(t, err)
+	assert.True(t, len(levels.PermissionLevels) > 1)
+
+	group, err := w.Groups.Create(ctx, scim.Group{
+		DisplayName: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	err = w.Permissions.Set(ctx, permissions.PermissionsRequest{
+		RequestObjectType: "notebooks",
+		RequestObjectId:   fmt.Sprintf("%d", obj.ObjectId),
+		AccessControlList: []permissions.AccessControlRequest{
+			{
+				GroupName:       group.DisplayName,
+				PermissionLevel: permissions.PermissionLevelCanRun,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = w.Permissions.Get(ctx, permissions.Get{
+		RequestObjectType: "notebooks",
+		RequestObjectId:   fmt.Sprintf("%d", obj.ObjectId),
+	})
+	require.NoError(t, err)
+}
+
 func TestMwsAccWorkspaceAssignment(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	a := databricks.Must(databricks.NewAccountClient(&databricks.Config{
-		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
-	}))
-	if !a.Config.IsAccountsClient() || !a.Config.IsAws() {
+	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
 		t.SkipNow()
 	}
 	spn, err := a.ServicePrincipals.Create(ctx, scim.ServicePrincipal{

--- a/internal/pipelines_test.go
+++ b/internal/pipelines_test.go
@@ -1,0 +1,106 @@
+package internal
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccPipelines(t *testing.T) {
+	ctx, w := workspaceTest(t)
+	notebookPath := myNotebookPath(t, w)
+
+	err := w.Workspace.Import(ctx, workspace.Import{
+		Content:   base64.StdEncoding.EncodeToString([]byte(dltNotebook)),
+		Format:    workspace.ExportFormatSource,
+		Language:  workspace.LanguageSql,
+		Overwrite: true,
+		Path:      notebookPath,
+	})
+	require.NoError(t, err)
+
+	libs := []pipelines.PipelineLibrary{
+		{
+			Notebook: &pipelines.NotebookLibrary{
+				Path: notebookPath,
+			},
+		},
+	}
+
+	clstrs := []pipelines.PipelineCluster{
+		{
+			InstancePoolId: GetEnvOrSkipTest(t, "TEST_INSTANCE_POOL_ID"),
+			Label:          "default",
+			NumWorkers:     1,
+			CustomTags: map[string]string{
+				"cluster_type": "default",
+			},
+		},
+	}
+
+	created, err := w.Pipelines.CreatePipeline(ctx, pipelines.CreatePipeline{
+		Continuous: false,
+		Name:       RandomName("go-sdk-"),
+		Libraries:  libs,
+		Clusters:   clstrs,
+	})
+	require.NoError(t, err)
+
+	defer w.Pipelines.DeletePipelineByPipelineId(ctx, created.PipelineId)
+
+	err = w.Pipelines.UpdatePipeline(ctx, pipelines.EditPipeline{
+		PipelineId: created.PipelineId,
+		Name:       RandomName("go-sdk-updated-"),
+		Libraries:  libs,
+		Clusters:   clstrs,
+	})
+	require.NoError(t, err)
+
+	pipeline, err := w.Pipelines.GetPipelineByPipelineId(ctx, created.PipelineId)
+	require.NoError(t, err)
+
+	all, err := w.Pipelines.ListPipelinesAll(ctx, pipelines.ListPipelines{})
+	require.NoError(t, err)
+
+	names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelines{})
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, pipeline.PipelineId, names[pipeline.Name])
+
+	byName, err := w.Pipelines.GetPipelineStateInfoByName(ctx, pipeline.Name)
+	require.NoError(t, err)
+	assert.Equal(t, byName.PipelineId, pipeline.PipelineId)
+}
+
+// taken from Databricks Terraform Provider acceptance tests
+const dltNotebook = `CREATE LIVE TABLE clickstream_raw AS 
+SELECT * FROM json.` + "`/databricks-datasets/wikipedia-datasets/data-001/clickstream/raw-uncompressed-json/2015_2_clickstream.json`" + `
+
+-- COMMAND ----------
+
+CREATE LIVE TABLE clickstream_clean(
+  CONSTRAINT valid_current_page EXPECT (current_page_id IS NOT NULL and current_page_title IS NOT NULL),
+  CONSTRAINT valid_count EXPECT (click_count > 0) ON VIOLATION FAIL UPDATE
+) TBLPROPERTIES ("quality" = "silver")
+AS SELECT
+  CAST (curr_id AS INT) AS current_page_id,
+  curr_title AS current_page_title,
+  CAST(n AS INT) AS click_count,
+  CAST (prev_id AS INT) AS previous_page_id,
+  prev_title AS previous_page_title
+FROM live.clickstream_raw
+
+-- COMMAND ----------
+
+CREATE LIVE TABLE top_spark_referers TBLPROPERTIES ("quality" = "gold")
+AS SELECT
+  previous_page_title as referrer,
+  click_count
+FROM live.clickstream_clean
+WHERE current_page_title = 'Apache_Spark'
+ORDER BY click_count DESC
+LIMIT 10`

--- a/internal/repos_test.go
+++ b/internal/repos_test.go
@@ -1,11 +1,9 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/repos"
 	"github.com/databricks/databricks-sdk-go/service/workspaceconf"
 	"github.com/stretchr/testify/assert"
@@ -13,13 +11,7 @@ import (
 )
 
 func TestAccRepos(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	// Skip this test if "Files in Repos" is not enabled.
 	conf, err := w.WorkspaceConf.GetStatus(ctx, workspaceconf.GetStatus{
@@ -30,11 +22,8 @@ func TestAccRepos(t *testing.T) {
 		t.Skipf("Files in Repos not enabled in this workspace")
 	}
 
-	me, err := w.CurrentUser.Me(ctx)
-	require.NoError(t, err)
-
 	// Synthesize unique path for this checkout in this user's home.
-	root := RandomName(fmt.Sprintf("/Repos/%s/tf-", me.UserName))
+	root := RandomName(fmt.Sprintf("/Repos/%s/tf-", me(t, w).UserName))
 	ri, err := w.Repos.Create(ctx, repos.CreateRepo{
 		Path:     root,
 		Url:      "https://github.com/shreyas-goenka/empty-repo.git",
@@ -43,7 +32,7 @@ func TestAccRepos(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = w.Repos.DeleteByRepoId(ctx, ri.Id)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	assert.Equal(t, "main", ri.Branch)
@@ -56,4 +45,10 @@ func TestAccRepos(t *testing.T) {
 	all, err := w.Repos.ListAll(ctx, repos.List{})
 	require.NoError(t, err)
 	assert.True(t, len(all) >= 1)
+
+	paths, err := w.Repos.RepoInfoPathToIdMap(ctx, repos.List{
+		PathPrefix: "/",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, len(paths), len(all))
 }

--- a/internal/scim_test.go
+++ b/internal/scim_test.go
@@ -11,31 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccCurrentUser(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	t.Parallel()
+func me(t *testing.T, w *databricks.WorkspaceClient) *scim.User {
+	ctx := context.Background()
+	me, err := w.CurrentUser.Me(ctx)
+	require.NoError(t, err)
+	return me
+}
 
-	ctx := context.TODO()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+func TestAccCurrentUser(t *testing.T) {
+	ctx, w := workspaceTest(t)
 
 	me, err := w.CurrentUser.Me(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.NotEmpty(t, me.UserName)
 }
 
 func TestAccUsers(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	t.Parallel()
-
-	ctx := context.TODO()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	// create new user
 	user, err := w.Users.Create(ctx, scim.User{
@@ -58,10 +51,11 @@ func TestAccUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify that the user we've creates is in the list
-	namesToIds := map[string]string{}
-	for _, u := range allUsers {
-		namesToIds[u.UserName] = u.Id
-	}
+	namesToIds, err := w.Users.UserUserNameToIdMap(ctx, scim.ListUsersRequest{
+		Attributes: "id,userName",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, len(namesToIds), len(allUsers))
 	assert.Equal(t, user.Id, namesToIds[user.UserName])
 
 	// remove user by ID
@@ -74,14 +68,7 @@ func TestAccUsers(t *testing.T) {
 }
 
 func TestAccGroups(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	t.Parallel()
-
-	ctx := context.TODO()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	// create new group
 	group, err := w.Groups.Create(ctx, scim.Group{
@@ -95,17 +82,11 @@ func TestAccGroups(t *testing.T) {
 	assert.Equal(t, group.DisplayName, fetch.DisplayName)
 
 	// list all groups that start with `go-sdk-`
-	allGroups, err := w.Groups.ListAll(ctx, scim.ListGroupsRequest{
+	namesToIds, err := w.Groups.GroupDisplayNameToIdMap(ctx, scim.ListGroupsRequest{
 		SortOrder: scim.ListSortOrderDescending,
 		Filter:    "displayName sw 'go-sdk-'",
 	})
 	require.NoError(t, err)
-
-	// verify that the group we've creates is in the list
-	namesToIds := map[string]string{}
-	for _, u := range allGroups {
-		namesToIds[u.DisplayName] = u.Id
-	}
 	assert.Equal(t, group.Id, namesToIds[group.DisplayName])
 
 	// remove group by ID
@@ -115,4 +96,42 @@ func TestAccGroups(t *testing.T) {
 	// and verify the group is missing
 	_, err = w.Groups.GetById(ctx, group.Id)
 	assert.True(t, apierr.IsMissing(err))
+}
+
+func TestAccServicePrincipalsOnAWS(t *testing.T) {
+	ctx, w := workspaceTest(t)
+	if !w.Config.IsAws() {
+		t.Skip("test only for aws")
+	}
+
+	created, err := w.ServicePrincipals.Create(ctx, scim.ServicePrincipal{
+		DisplayName: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.ServicePrincipals.DeleteById(ctx, created.Id)
+		require.NoError(t, err)
+	})
+	err = w.ServicePrincipals.Update(ctx, scim.ServicePrincipal{
+		Id:          created.Id,
+		DisplayName: RandomName("go-sdk-updated-"),
+		Roles: []scim.ComplexValue{
+			{
+				Value: "xyz",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	byId, err := w.ServicePrincipals.GetById(ctx, created.Id)
+	require.NoError(t, err)
+
+	all, err := w.ServicePrincipals.ListAll(ctx, scim.ListServicePrincipalsRequest{})
+	require.NoError(t, err)
+
+	names, err := w.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, scim.ListServicePrincipalsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, len(names), len(all))
+	assert.Equal(t, byId.Id, names[byId.DisplayName])
 }

--- a/internal/secrets_test.go
+++ b/internal/secrets_test.go
@@ -1,10 +1,8 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/scim"
 	"github.com/databricks/databricks-sdk-go/service/secrets"
 	"github.com/stretchr/testify/assert"
@@ -12,13 +10,7 @@ import (
 )
 
 func TestAccSecrets(t *testing.T) {
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
-	t.Log(env)
-	ctx := context.Background()
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountsClient() {
-		t.SkipNow()
-	}
+	ctx, w := workspaceTest(t)
 
 	scope := secrets.CreateScope{
 		Scope: RandomEmail("sdk-go"),

--- a/internal/unitycatalog_test.go
+++ b/internal/unitycatalog_test.go
@@ -1,0 +1,289 @@
+package internal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/unitycatalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUcAccStorageCredentials(t *testing.T) {
+	ctx, w := ucwsTest(t)
+	if !w.Config.IsAws() {
+		skipf(t)("not not aws")
+	}
+
+	// TODO: OpenAPI: retry protocol on late validation for storage
+	// See https://github.com/databricks/terraform-provider-databricks/issues/1424
+	created, err := w.StorageCredentials.Create(ctx, unitycatalog.CreateStorageCredential{
+		Name: RandomName("go-sdk-"),
+		AwsIamRole: &unitycatalog.AwsIamRole{
+			RoleArn: GetEnvOrSkipTest(t, "TEST_METASTORE_DATA_ACCESS_ARN"),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.StorageCredentials.DeleteByName(ctx, created.Name)
+		require.NoError(t, err)
+	})
+
+	err = w.StorageCredentials.Update(ctx, unitycatalog.UpdateStorageCredential{
+		Name:    created.Name,
+		Comment: RandomName("comment "),
+		AwsIamRole: &unitycatalog.AwsIamRole{
+			RoleArn: GetEnvOrSkipTest(t, "TEST_METASTORE_DATA_ACCESS_ARN"),
+		},
+	})
+	require.NoError(t, err)
+
+	byName, err := w.StorageCredentials.GetByName(ctx, created.Name)
+	require.NoError(t, err)
+	assert.NotEqual(t, "", byName.Id)
+
+	all, err := w.StorageCredentials.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccExternalLocations(t *testing.T) {
+	ctx, w := ucwsTest(t)
+	if !w.Config.IsAws() {
+		skipf(t)("not not aws")
+	}
+
+	credential, err := w.StorageCredentials.Create(ctx, unitycatalog.CreateStorageCredential{
+		Name: RandomName("go-sdk-"),
+		AwsIamRole: &unitycatalog.AwsIamRole{
+			RoleArn: GetEnvOrSkipTest(t, "TEST_METASTORE_DATA_ACCESS_ARN"),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.StorageCredentials.DeleteByName(ctx, credential.Name)
+		require.NoError(t, err)
+	})
+
+	created, err := w.ExternalLocations.Create(ctx, unitycatalog.CreateExternalLocation{
+		Name:           RandomName("go-sdk-"),
+		CredentialName: credential.Name,
+		Url:            fmt.Sprintf("s3://%s/%s", GetEnvOrSkipTest(t, "TEST_BUCKET"), RandomName("l-")),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.ExternalLocations.DeleteByName(ctx, created.Name)
+		require.NoError(t, err)
+	})
+
+	err = w.ExternalLocations.Update(ctx, unitycatalog.UpdateExternalLocation{
+		Name:           created.Name,
+		CredentialName: credential.Name,
+		Url:            fmt.Sprintf("s3://%s/%s", GetEnvOrSkipTest(t, "TEST_BUCKET"), RandomName("l-")),
+	})
+	require.NoError(t, err)
+
+	_, err = w.ExternalLocations.GetByName(ctx, created.Name)
+	require.NoError(t, err)
+
+	all, err := w.ExternalLocations.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccMetastores(t *testing.T) {
+	t.Skip("metastore force delete doesn't work yet")
+	ctx, w := ucwsTest(t)
+	created, err := w.Metastores.Create(ctx, unitycatalog.CreateMetastore{
+		Name:        RandomName("go-sdk-"),
+		StorageRoot: fmt.Sprintf("s3://%s/%s", GetEnvOrSkipTest(t, "TEST_BUCKET"), RandomName("t=")),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.Metastores.Delete(ctx, unitycatalog.DeleteMetastoreRequest{
+			Id:    created.MetastoreId,
+			Force: true,
+		})
+		require.NoError(t, err)
+	})
+
+	// TODO: OpenAPI: fix create mapping: remove assignments from cruds
+	err = w.Metastores.Update(ctx, unitycatalog.UpdateMetastore{
+		Id:   created.MetastoreId,
+		Name: RandomName("go-sdk-updated"),
+	})
+	require.NoError(t, err)
+
+	_, err = w.Metastores.GetById(ctx, created.MetastoreId)
+	require.NoError(t, err)
+
+	err = w.Metastores.Assign(ctx, unitycatalog.CreateMetastoreAssignment{
+		MetastoreId: created.MetastoreId,
+		WorkspaceId: int(GetEnvInt64OrSkipTest(t, "TEST_WORKSPACE_ID")),
+	})
+	require.NoError(t, err)
+
+	// TODO: metastore_id in query?...
+	err = w.Metastores.Unassign(ctx, unitycatalog.UnassignRequest{
+		MetastoreId: created.MetastoreId,
+		WorkspaceId: int(GetEnvInt64OrSkipTest(t, "TEST_WORKSPACE_ID")),
+	})
+	require.NoError(t, err)
+
+	_, err = w.Metastores.Summary(ctx)
+	require.NoError(t, err)
+
+	// TODO: OpenAPI: x-databricks-id & x-databricks-name
+	all, err := w.Metastores.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccCatalogs(t *testing.T) {
+	t.Skip("needs force delete")
+	ctx, w := ucwsTest(t)
+
+	created, err := w.Catalogs.Create(ctx, unitycatalog.CreateCatalog{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.Catalogs.DeleteByName(ctx, created.Name)
+		require.NoError(t, err)
+	})
+
+	err = w.Catalogs.Update(ctx, unitycatalog.UpdateCatalog{})
+	require.NoError(t, err)
+
+	_, err = w.Catalogs.GetByName(ctx, created.Name)
+	require.NoError(t, err)
+
+	all, err := w.Catalogs.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccSchemas(t *testing.T) {
+	t.Skip("needs force delete")
+	ctx, w := ucwsTest(t)
+
+	catalog, err := w.Catalogs.Create(ctx, unitycatalog.CreateCatalog{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// TODO: force delete
+		err := w.Catalogs.DeleteByName(ctx, catalog.Name)
+		require.NoError(t, err)
+	})
+
+	created, err := w.Schemas.Create(ctx, unitycatalog.CreateSchema{
+		Name:        RandomName("go-sdk-"),
+		CatalogName: catalog.Name,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.Schemas.DeleteByFullName(ctx, created.FullName)
+		require.NoError(t, err)
+	})
+	err = w.Schemas.Update(ctx, unitycatalog.UpdateSchema{
+		FullName: created.FullName,
+		Comment:  RandomName("comment "),
+	})
+	require.NoError(t, err)
+
+	_, err = w.Schemas.GetByFullName(ctx, created.FullName)
+	require.NoError(t, err)
+
+	all, err := w.Schemas.ListAll(ctx, unitycatalog.ListSchemasRequest{
+		CatalogName: catalog.Name,
+	})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccProviders(t *testing.T) {
+	t.Skip("fixme")
+	ctx, w := ucwsTest(t)
+
+	created, err := w.Providers.Create(ctx, unitycatalog.CreateProvider{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.Providers.DeleteByName(ctx, created.Name)
+		require.NoError(t, err)
+	})
+	err = w.Providers.Update(ctx, unitycatalog.UpdateProvider{})
+	require.NoError(t, err)
+
+	_, err = w.Providers.GetByName(ctx, created.Name)
+	require.NoError(t, err)
+
+	all, err := w.Providers.ListAll(ctx, unitycatalog.ListProvidersRequest{})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccRecipients(t *testing.T) {
+	ctx, w := ucwsTest(t)
+
+	created, err := w.Recipients.Create(ctx, unitycatalog.CreateRecipient{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.Recipients.DeleteByName(ctx, created.Name)
+		require.NoError(t, err)
+	})
+	err = w.Recipients.Update(ctx, unitycatalog.UpdateRecipient{
+		Name:    created.Name,
+		Comment: RandomName("comment "),
+	})
+	require.NoError(t, err)
+
+	_, err = w.Recipients.GetByName(ctx, created.Name)
+	require.NoError(t, err)
+
+	all, err := w.Recipients.ListAll(ctx, unitycatalog.ListRecipientsRequest{})
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}
+
+func TestUcAccShares(t *testing.T) {
+	t.Skip("expand with catalogs")
+	ctx, w := ucwsTest(t)
+
+	created, err := w.Shares.Create(ctx, unitycatalog.CreateShare{
+		Name: RandomName("go-sdk-"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := w.Shares.DeleteByName(ctx, created.Name)
+		require.NoError(t, err)
+	})
+	err = w.Shares.Update(ctx, unitycatalog.UpdateShare{
+		Name: RandomName("go-sdk-"),
+		Updates: []unitycatalog.SharedDataObjectUpdate{
+			{
+				Action: unitycatalog.SharedDataObjectUpdateActionAdd,
+				DataObject: &unitycatalog.SharedDataObject{
+					Name: RandomName("go-sdk-"),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// TODO: OpenAPI: fix x-databricks-crud: read
+	_, err = w.Shares.GetByName(ctx, created.Name)
+	require.NoError(t, err)
+
+	all, err := w.Shares.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(all) >= 1)
+}

--- a/internal/warehouses_test.go
+++ b/internal/warehouses_test.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/warehouses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccSqlWarehouses(t *testing.T) {
+	ctx, w := workspaceTest(t)
+
+	created, err := w.Warehouses.CreateWarehouseAndWait(ctx, warehouses.CreateWarehouseRequest{
+		Name:           RandomName("go-sdk-"),
+		ClusterSize:    "2X-Small", // TODO: add enum
+		MaxNumClusters: 1,
+		AutoStopMins:   10,
+	})
+	require.NoError(t, err)
+
+	defer w.Warehouses.DeleteWarehouseByIdAndWait(ctx, created.Id)
+
+	err = w.Warehouses.EditWarehouse(ctx, warehouses.EditWarehouseRequest{
+		Id:             created.Id,
+		Name:           RandomName("go-sdk-updated-"),
+		ClusterSize:    "2X-Small",
+		MaxNumClusters: 1,
+		AutoStopMins:   10,
+	})
+	require.NoError(t, err)
+
+	wh, err := w.Warehouses.GetWarehouseById(ctx, created.Id)
+	require.NoError(t, err)
+
+	all, err := w.Warehouses.ListWarehousesAll(ctx, warehouses.ListWarehouses{})
+	require.NoError(t, err)
+
+	names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, warehouses.ListWarehouses{})
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, wh.Id, names[wh.Name])
+
+	byName, err := w.Warehouses.GetEndpointInfoByName(ctx, wh.Name)
+	require.NoError(t, err)
+	assert.Equal(t, wh.Id, byName.Id)
+}

--- a/internal/workspaceconf_test.go
+++ b/internal/workspaceconf_test.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/workspaceconf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccWorkspaceConf(t *testing.T) {
+	ctx, w := workspaceTest(t)
+	conf, err := w.WorkspaceConf.GetStatus(ctx, workspaceconf.GetStatus{
+		Keys: "maxTokenLifetimeDays,enableIpAccessLists,enableWorkspaceFilesystem",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(*conf))
+
+	err = w.WorkspaceConf.SetStatus(ctx, workspaceconf.WorkspaceConf{
+		"maxTokenLifetimeDays": "30",
+	})
+	require.NoError(t, err)
+}

--- a/service/dbfs/utilities.go
+++ b/service/dbfs/utilities.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/useragent"
 )
 
@@ -104,6 +105,10 @@ func (a DbfsAPI) RecursiveList(ctx context.Context, path string) ([]FileInfo, er
 		batch, err := a.ListAll(ctx, List{
 			Path: path,
 		})
+		if apierr.IsMissing(err) {
+			// skip on path deleted during iteration
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("list %s: %w", path, err)
 		}

--- a/service/workspace/utilities.go
+++ b/service/workspace/utilities.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/commands"
 	"github.com/databricks/databricks-sdk-go/useragent"
 )
@@ -52,6 +53,10 @@ func (a *WorkspaceAPI) RecursiveList(ctx context.Context, path string) ([]Object
 		batch, err := a.ListAll(ctx, List{
 			Path: path,
 		})
+		if apierr.IsMissing(err) {
+			// skip on path deleted during iteration
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("list %s: %w", path, err)
 		}


### PR DESCRIPTION
This PR multiplies integration test coverage for workspaces and starts adding some coverage for accounts and unity catalog. Some tests are yet skipped, but they'll be fixed in the follow-up PRs.