### PR TITLE
Host-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,6 @@ For [Databricks native authentication](#databricks-native-authentication), you c
 |-------------------------------|-------------|----------------------|
 | `Profile` | _(String)_ A connection profile specified within `.databrickscfg` to use instead of `DEFAULT`. | `DATABRICKS_CONFIG_PROFILE` |
 | `ConfigFile` | _(String)_ A non-default location of the Databricks CLI credentials file. | `DATABRICKS_CONFIG_FILE` |
-| `ResolveProfile` | _(Boolean)_ - If you specify `host`, but no other credentials either through direct configuration or through environment variables, Databricks SDK for Go will try picking up profile with the matching host from ~/.databrickscfg. This allows keeping the hostname checked in to version control, but have ability to pick up different credentials either from local development machine or production server. | `DATABRICKS_PROFILE_RESOLVE` |
-
 
 For example, to use a profile named `MYPROFILE` instead of `DEFAULT`:
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ By default, the Databricks SDK for Go initially tries Databricks token authentic
 
 - For Databricks token authentication, you must provide `Host` and `Token`; or their environment variable or `.databrickscfg` file field equivalents.
 - For Databricks basic authentication, you must provide `Host`, `Username`, and `Password` _(for AWS workspace-level operations)_; or `Host`, `AccountID`, `Username`, and `Password` _(for AWS, Azure, or GCP account-level operations)_; or their environment variable or `.databrickscfg` file field equivalents.
-- If you specify `host`, but no other credentials either through direct configuration or through environment variables, Databricks SDK for Go will try picking up profile with the matching host from [~/.databrickscfg](#overriding-databrickscfg). This allows keeping the hostname checked in to version control, but have ability to pick up different credentials either from local development machine or production server.
 
 | `*databricks.Config` argument | Description | Environment variable / `.databrickscfg` file field |
 |-------------------------------|-------------|----------------------------------------------------|
@@ -276,6 +275,8 @@ For [Databricks native authentication](#databricks-native-authentication), you c
 |-------------------------------|-------------|----------------------|
 | `Profile` | _(String)_ A connection profile specified within `.databrickscfg` to use instead of `DEFAULT`. | `DATABRICKS_CONFIG_PROFILE` |
 | `ConfigFile` | _(String)_ A non-default location of the Databricks CLI credentials file. | `DATABRICKS_CONFIG_FILE` |
+| `ResolveProfile` | _(Boolean)_ - If you specify `host`, but no other credentials either through direct configuration or through environment variables, Databricks SDK for Go will try picking up profile with the matching host from ~/.databrickscfg. This allows keeping the hostname checked in to version control, but have ability to pick up different credentials either from local development machine or production server. | `DATABRICKS_PROFILE_RESOLVE` |
+
 
 For example, to use a profile named `MYPROFILE` instead of `DEFAULT`:
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ By default, the Databricks SDK for Go initially tries Databricks token authentic
 
 - For Databricks token authentication, you must provide `Host` and `Token`; or their environment variable or `.databrickscfg` file field equivalents.
 - For Databricks basic authentication, you must provide `Host`, `Username`, and `Password` _(for AWS workspace-level operations)_; or `Host`, `AccountID`, `Username`, and `Password` _(for AWS, Azure, or GCP account-level operations)_; or their environment variable or `.databrickscfg` file field equivalents.
+- If you specify `host`, but no other credentials either through direct configuration or through environment variables, Databricks SDK for Go will try picking up profile with the matching host from [~/.databrickscfg](#overriding-databrickscfg). This allows keeping the hostname checked in to version control, but have ability to pick up different credentials either from local development machine or production server.
 
 | `*databricks.Config` argument | Description | Environment variable / `.databrickscfg` file field |
 |-------------------------------|-------------|----------------------------------------------------|

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -235,21 +235,35 @@ func TestConfig_PatFromDatabricksCfg_NohostProfile(t *testing.T) {
 func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost(t *testing.T) {
 	configFixture{
 		env: map[string]string{
-			"HOME":            "testdata",
-			"DATABRICKS_HOST": "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
+			"HOME":                       "testdata",
+			"DATABRICKS_PROFILE_RESOLVE": "true",
+			"DATABRICKS_HOST":            "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
 		},
 		assertHost: "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
 		assertAuth: "basic",
 	}.apply(t)
 }
 
+func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost_WithToken(t *testing.T) {
+	configFixture{
+		env: map[string]string{
+			"HOME":                       "testdata",
+			"DATABRICKS_PROFILE_RESOLVE": "true",
+			"DATABRICKS_HOST":            "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
+			"DATABRICKS_TOKEN":           "abcd",
+		},
+		assertError: "validate: more than one authorization method configured: basic and pat. Config: host=https://dbc-XXXXXXXX-ABCD.cloud.databricks.com, token=***, username=abc, password=***, resolve_profile=true. Env: DATABRICKS_HOST, DATABRICKS_TOKEN, DATABRICKS_PROFILE_RESOLVE",
+	}.apply(t)
+}
+
 func TestConfig_Implicit_DatabricksCfg_Profile_Conflicts(t *testing.T) {
 	configFixture{
 		env: map[string]string{
-			"HOME":            "testdata",
-			"DATABRICKS_HOST": "https://adb-123.4.azuredatabricks.net",
+			"HOME":                       "testdata",
+			"DATABRICKS_PROFILE_RESOLVE": "true",
+			"DATABRICKS_HOST":            "https://adb-123.4.azuredatabricks.net",
 		},
-		assertError: "resolve: azure-justhost and azure-pat and azure-spn match https://adb-123.4.azuredatabricks.net in testdata/.databrickscfg. Config: host=https://adb-123.4.azuredatabricks.net. Env: DATABRICKS_HOST",
+		assertError: "resolve: azure-justhost and azure-pat and azure-spn match https://adb-123.4.azuredatabricks.net in testdata/.databrickscfg. Config: host=https://adb-123.4.azuredatabricks.net, resolve_profile=true. Env: DATABRICKS_HOST, DATABRICKS_PROFILE_RESOLVE",
 	}.apply(t)
 }
 
@@ -379,7 +393,7 @@ func TestConfig_AzureAndPasswordConflict(t *testing.T) { // TODO: this breaks
 			"HOME":                "testdata/azure",
 			"DATABRICKS_USERNAME": "x",
 		},
-		assertError: "validate: more than one authorization method configured: azure and basic. Config: host=https://x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
+		assertError: "validate: more than one authorization method configured: azure and basic. Config: host=x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
 	}.apply(t)
 }
 

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -232,7 +232,7 @@ func TestConfig_PatFromDatabricksCfg_NohostProfile(t *testing.T) {
 	}.apply(t)
 }
 
-func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost(t *testing.T) {
+func TestConfig_DatabricksCfgProfileResolve_ThroughHost(t *testing.T) {
 	configFixture{
 		env: map[string]string{
 			"HOME":                       "testdata",
@@ -244,7 +244,7 @@ func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost(t *testing.T) {
 	}.apply(t)
 }
 
-func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost_WithToken(t *testing.T) {
+func TestConfig_DatabricksCfgProfileResolve_ThroughHost_WithToken(t *testing.T) {
 	configFixture{
 		env: map[string]string{
 			"HOME":                       "testdata",
@@ -256,7 +256,7 @@ func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost_WithToken(t *testing.
 	}.apply(t)
 }
 
-func TestConfig_Implicit_DatabricksCfg_Profile_Conflicts(t *testing.T) {
+func TestConfig_DatabricksCfgProfileResolve_Conflicts(t *testing.T) {
 	configFixture{
 		env: map[string]string{
 			"HOME":                       "testdata",

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -232,6 +232,27 @@ func TestConfig_PatFromDatabricksCfg_NohostProfile(t *testing.T) {
 	}.apply(t)
 }
 
+func TestConfig_Implicit_DatabricksCfg_Profile_ThroughHost(t *testing.T) {
+	configFixture{
+		env: map[string]string{
+			"HOME":            "testdata",
+			"DATABRICKS_HOST": "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
+		},
+		assertHost: "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
+		assertAuth: "basic",
+	}.apply(t)
+}
+
+func TestConfig_Implicit_DatabricksCfg_Profile_Conflicts(t *testing.T) {
+	configFixture{
+		env: map[string]string{
+			"HOME":            "testdata",
+			"DATABRICKS_HOST": "https://adb-123.4.azuredatabricks.net",
+		},
+		assertError: "resolve: azure-justhost and azure-pat and azure-spn match https://adb-123.4.azuredatabricks.net in testdata/.databrickscfg. Config: host=https://adb-123.4.azuredatabricks.net. Env: DATABRICKS_HOST",
+	}.apply(t)
+}
+
 func TestConfig_ConfigProfileAndToken(t *testing.T) {
 	configFixture{
 		env: map[string]string{
@@ -358,7 +379,7 @@ func TestConfig_AzureAndPasswordConflict(t *testing.T) { // TODO: this breaks
 			"HOME":                "testdata/azure",
 			"DATABRICKS_USERNAME": "x",
 		},
-		assertError: "validate: more than one authorization method configured: azure and basic. Config: host=x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
+		assertError: "validate: more than one authorization method configured: azure and basic. Config: host=https://x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME",
 	}.apply(t)
 }
 

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -238,7 +238,6 @@ func TestConfig_DatabricksCfgProfileResolve_ThroughHost(t *testing.T) {
 	configFixture{
 		loaders: []Loader{
 			ConfigAttributes,
-			KnownConfigLoader{},
 			ImplicitProfileLoader{},
 		},
 		env: map[string]string{
@@ -254,7 +253,6 @@ func TestConfig_DatabricksCfgProfileResolve_ThroughHost_WithToken(t *testing.T) 
 	configFixture{
 		loaders: []Loader{
 			ConfigAttributes,
-			KnownConfigLoader{},
 			ImplicitProfileLoader{},
 		},
 		env: map[string]string{
@@ -262,7 +260,7 @@ func TestConfig_DatabricksCfgProfileResolve_ThroughHost_WithToken(t *testing.T) 
 			"DATABRICKS_HOST":  "https://dbc-XXXXXXXX-ABCD.cloud.databricks.com",
 			"DATABRICKS_TOKEN": "abcd",
 		},
-		assertError: "validate: more than one authorization method configured: basic and pat. Config: host=https://dbc-XXXXXXXX-ABCD.cloud.databricks.com, token=***, username=abc, password=***. Env: DATABRICKS_HOST, DATABRICKS_TOKEN",
+		assertError: "validate: more than one authorization method configured: basic and pat. Config: host=https://dbc-XXXXXXXX-ABCD.cloud.databricks.com, token=***, username=abc, password=***, profile=basic. Env: DATABRICKS_HOST, DATABRICKS_TOKEN",
 	}.apply(t)
 }
 
@@ -270,14 +268,13 @@ func TestConfig_DatabricksCfgProfileResolve_Conflicts(t *testing.T) {
 	configFixture{
 		loaders: []Loader{
 			ConfigAttributes,
-			KnownConfigLoader{},
 			ImplicitProfileLoader{},
 		},
 		env: map[string]string{
 			"HOME":            "testdata",
 			"DATABRICKS_HOST": "https://adb-123.4.azuredatabricks.net",
 		},
-		assertError: "resolve: azure-justhost and azure-pat and azure-spn match https://adb-123.4.azuredatabricks.net in . Config: host=https://adb-123.4.azuredatabricks.net, token=***. Env: DATABRICKS_HOST",
+		assertError: "resolve: azure-justhost and azure-pat and azure-spn match https://adb-123.4.azuredatabricks.net in . Config: host=https://adb-123.4.azuredatabricks.net. Env: DATABRICKS_HOST",
 	}.apply(t)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -214,15 +214,25 @@ func (c *Config) fixHostIfNeeded() error {
 	if c.Host == "" {
 		return nil
 	}
-	parsedHost, err := url.Parse(c.Host)
+	canonical, err := canonicalHost(c.Host)
 	if err != nil {
 		return err
 	}
+	// Store sanitized version of c.Host.
+	c.Host = canonical
+	return nil
+}
+
+func canonicalHost(host string) (string, error) {
+	parsedHost, err := url.Parse(host)
+	if err != nil {
+		return "", err
+	}
 	// If the host is empty, assume the scheme wasn't included.
 	if parsedHost.Host == "" {
-		parsedHost, err = url.Parse("https://" + c.Host)
+		parsedHost, err = url.Parse("https://" + host)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 	// Create new instance to ensure other fields are initialized as empty.
@@ -230,7 +240,5 @@ func (c *Config) fixHostIfNeeded() error {
 		Scheme: parsedHost.Scheme,
 		Host:   parsedHost.Host,
 	}
-	// Store sanitized version of c.Host.
-	c.Host = parsedHost.String()
-	return nil
+	return parsedHost.String(), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,13 @@ type Config struct {
 	// Connection profile specified within ~/.databrickscfg.
 	Profile string `name:"profile" env:"DATABRICKS_CONFIG_PROFILE"`
 
+	// If you specify `host`, but no other credentials either through direct configuration
+	// or through environment variables, Databricks SDK for Go will try picking up profile
+	// with the matching host from ~/.databrickscfg. This allows keeping the hostname checked
+	// in to version control, but have ability to pick up different credentials either from
+	// local development machine or production server.
+	ResolveProfile bool `name:"resolve_profile" env:"DATABRICKS_PROFILE_RESOLVE"`
+
 	// Location of the Databricks CLI credentials file, that is created
 	// by `databricks configure --token` command. By default, it is located
 	// in ~/.databrickscfg.

--- a/config/config.go
+++ b/config/config.go
@@ -48,13 +48,6 @@ type Config struct {
 	// Connection profile specified within ~/.databrickscfg.
 	Profile string `name:"profile" env:"DATABRICKS_CONFIG_PROFILE"`
 
-	// If you specify `host`, but no other credentials either through direct configuration
-	// or through environment variables, Databricks SDK for Go will try picking up profile
-	// with the matching host from ~/.databrickscfg. This allows keeping the hostname checked
-	// in to version control, but have ability to pick up different credentials either from
-	// local development machine or production server.
-	ResolveProfile bool `name:"resolve_profile" env:"DATABRICKS_PROFILE_RESOLVE"`
-
 	// Location of the Databricks CLI credentials file, that is created
 	// by `databricks configure --token` command. By default, it is located
 	// in ~/.databrickscfg.

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -16,22 +16,14 @@ func (l KnownConfigLoader) Name() string {
 }
 
 func (l KnownConfigLoader) Configure(cfg *Config) error {
-	configFile := cfg.ConfigFile
-	if configFile == "" {
-		configFile = "~/.databrickscfg"
-	}
-	if strings.HasPrefix(configFile, "~") {
-		homedir, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("cannot find homedir: %w", err)
-		}
-		configFile = fmt.Sprintf("%s%s", homedir, configFile[1:])
-	}
-	_, err := os.Stat(configFile)
+	configFile, err := l.resolveConfigFile(cfg)
 	if os.IsNotExist(err) {
 		// early return for non-configured machines
 		logger.Debugf("%s not found on current host", configFile)
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf(".databrickscfg: %w", err)
 	}
 	iniFile, err := ini.Load(configFile)
 	if err != nil {
@@ -43,42 +35,6 @@ func (l KnownConfigLoader) Configure(cfg *Config) error {
 	if !hasExplicitProfile {
 		profile = "DEFAULT"
 	}
-	if cfg.ResolveProfile && cfg.Host != "" && cfg.Profile == "" {
-		err := cfg.fixHostIfNeeded()
-		if err != nil {
-			return err
-		}
-		profiles := []string{}
-		for _, section := range iniFile.Sections() {
-			values := section.KeysHash()
-			host := values["host"]
-			if host == "" {
-				// if host is not set or is empty
-				continue
-			}
-			canonical, err := canonicalHost(host)
-			if err != nil {
-				// we're fine with other corrupt profiles
-				continue
-			}
-			if canonical != cfg.Host {
-				continue
-			}
-			profiles = append(profiles, section.Name())
-		}
-		// in the real situations, we don't expect this to happen often (if not at all),
-		// hence we don't trim the list
-		if len(profiles) > 1 {
-			return fmt.Errorf("%s match %s in %s",
-				strings.Join(profiles, " and "),
-				cfg.Host, configFile)
-		}
-		if len(profiles) == 1 {
-			profile = profiles[0]
-			logger.Debugf("%s config profile detected for %s",
-				profile, cfg.Host)
-		}
-	}
 	profileValues := iniFile.Section(profile)
 	if len(profileValues.Keys()) == 0 {
 		if !hasExplicitProfile {
@@ -89,6 +45,108 @@ func (l KnownConfigLoader) Configure(cfg *Config) error {
 	}
 	logger.Debugf("Loading %s profile from %s", profile, configFile)
 	err = ConfigAttributes.ResolveFromStringMap(cfg, profileValues.KeysHash())
+	if err != nil {
+		return fmt.Errorf("%s %s profile: %w", configFile, profile, err)
+	}
+	return nil
+}
+
+func (l KnownConfigLoader) resolveConfigFile(cfg *Config) (string, error) {
+	configFile := cfg.ConfigFile
+	if configFile == "" {
+		configFile = "~/.databrickscfg"
+	}
+	if strings.HasPrefix(configFile, "~") {
+		homedir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot find homedir: %w", err)
+		}
+		configFile = fmt.Sprintf("%s%s", homedir, configFile[1:])
+	}
+	_, err := os.Stat(configFile)
+	if err != nil {
+		return "", err
+	}
+	return configFile, nil
+}
+
+// ImplicitProfileLoader is an opt-in loader, which triggers if you specify
+// `host`, but no other credentials either through direct configuration or
+// through environment variables, Databricks SDK for Go will try picking up
+// profile with the matching host from ~/.databrickscfg. This allows keeping
+// the hostname checked in to version control, but have ability to pick up
+// different credentials either from local development machine or production
+// server.
+type ImplicitProfileLoader struct {
+	KnownConfigLoader
+}
+
+func (l ImplicitProfileLoader) Name() string {
+	return "implicit-profile"
+}
+
+func (l ImplicitProfileLoader) resolveSection(
+	cfg *Config, iniFile *ini.File) (*ini.Section, error) {
+	var candidates []*ini.Section
+	for _, section := range iniFile.Sections() {
+		hash := section.KeysHash()
+		host, ok := hash["host"]
+		if !ok {
+			// if host is not set
+			continue
+		}
+		canonical, err := canonicalHost(host)
+		if err != nil {
+			// we're fine with other corrupt profiles
+			continue
+		}
+		if canonical != cfg.Host {
+			continue
+		}
+		candidates = append(candidates, section)
+	}
+	// in the real situations, we don't expect this to happen often
+	// (if not at all), hence we don't trim the list
+	if len(candidates) > 1 {
+		var profiles []string
+		for _, v := range candidates {
+			profiles = append(profiles, v.Name())
+		}
+		return nil, fmt.Errorf("%s match %s in %s",
+			strings.Join(profiles, " and "), cfg.Host, cfg.ConfigFile)
+	}
+	return candidates[0], nil
+}
+
+func (l ImplicitProfileLoader) Configure(cfg *Config) error {
+	if cfg.Host == "" || cfg.Profile != "" {
+		// no host to match or profile already configured
+		return nil
+	}
+	configFile, err := l.resolveConfigFile(cfg)
+	if os.IsNotExist(err) {
+		// early return for non-configured machines
+		logger.Debugf("%s not found on current host", configFile)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf(".databrickscfg: %w", err)
+	}
+	iniFile, err := ini.Load(configFile)
+	if err != nil {
+		return fmt.Errorf("cannot parse config file: %w", err)
+	}
+	err = cfg.fixHostIfNeeded()
+	if err != nil {
+		return err
+	}
+	section, err := l.resolveSection(cfg, iniFile)
+	if err != nil {
+		return err
+	}
+	profile := section.Name()
+	logger.Debugf("Loading %s profile from %s", profile, configFile)
+	err = ConfigAttributes.ResolveFromStringMap(cfg, section.KeysHash())
 	if err != nil {
 		return fmt.Errorf("%s %s profile: %w", configFile, profile, err)
 	}

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -43,7 +43,7 @@ func (l KnownConfigLoader) Configure(cfg *Config) error {
 	if !hasExplicitProfile {
 		profile = "DEFAULT"
 	}
-	if cfg.Host != "" && cfg.Profile == "" {
+	if cfg.ResolveProfile && cfg.Host != "" && cfg.Profile == "" {
 		err := cfg.fixHostIfNeeded()
 		if err != nil {
 			return err

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -70,7 +70,7 @@ func (l KnownConfigLoader) resolveConfigFile(cfg *Config) (string, error) {
 	return configFile, nil
 }
 
-// ImplicitProfileLoader is an alternative config loader, which triggers if you 
+// ImplicitProfileLoader is an alternative config loader, which triggers if you
 // specify  `host`, but no other credentials either through direct configuration
 // or through environment variables, Databricks SDK for Go will try picking up
 // profile with the matching host from ~/.databrickscfg. This allows keeping

--- a/config/testdata/.databrickscfg
+++ b/config/testdata/.databrickscfg
@@ -15,14 +15,14 @@ rate_limit=34
 host = https://adb-123.4.azuredatabricks.net/
 
 [azure-pat]
-host = https://adb-123.4.azuredatabricks.net/
+host = https://adb-123.4.azuredatabricks.net
 token = PT0+IC9kZXYvdXJhbmRvbSA8PT0KYFZ
 
 [notoken]
 host = https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/
 
 [basic]
-host = https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/
+host = https://dbc-XXXXXXXX-ABCD.cloud.databricks.com/
 username = abc
 password = bcd
 


### PR DESCRIPTION
Changes to the following configuration behavior:

ImplicitProfileLoader is an alternative config loader, which triggers if you specify  `host`, but no other credentials either through direct configuration or through environment variables, Databricks SDK for Go will try picking up profile with the matching host from ~/.databrickscfg. This allows keeping the hostname checked in to version control, but have ability to pick up different credentials either from local development machine or production server.
