### PR TITLE
Add concept of `main` service for the package

### DIFF
--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -39,6 +39,17 @@ func (pkg *Package) Services() (types []*Service) {
 	return types
 }
 
+// MainService returns a Service that matches Package name
+func (pkg *Package) MainService() *Service {
+	for _, svc := range pkg.services {
+		if !svc.MatchesPackageName() {
+			continue
+		}
+		return svc
+	}
+	return nil
+}
+
 // Types returns sorted slice of types
 func (pkg *Package) Types() (types []*Entity) {
 	for _, v := range pkg.types {

--- a/openapi/code/tmpl_util_funcs.go
+++ b/openapi/code/tmpl_util_funcs.go
@@ -1,10 +1,13 @@
 package code
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"text/template"
 )
+
+var ErrSkipThisFile = errors.New("skip generating this file")
 
 var HelperFuncs = template.FuncMap{
 	"notLast": func(idx int, a interface{}) bool {
@@ -15,5 +18,11 @@ var HelperFuncs = template.FuncMap{
 	},
 	"without": func(left, right string) string {
 		return strings.ReplaceAll(right, left, "")
+	},
+	"skipThisFile": func() error {
+		// error is rendered as string in the resulting file, so we must panic,
+		// so that we handle this error in [gen.Pass[T].File] gracefully
+		// via errors.Is(err, code.ErrSkipThisFile)
+		panic(ErrSkipThisFile)
 	},
 }


### PR DESCRIPTION
This PR adds an advanced code generation feature for "main services" per package, which could be "flattened down" to the same namespace as the package itself, producing better end-user UX for the generated code. This manifests in the following templates:

package-level generation:
```
{{if .MainService -}}
    // code for a package with a main service
    {{load ".codegen/service.go.tmpl"}}
    {{template "service" .MainService}}
{{- else -}}
    // code for a package with multiple services
{{end}}
```

service-level generation:
```
{{if not .MatchesPackageName}}
	{{template "service" .}}
{{else}}
	{{skipThisFile}}
{{end}}

{{define "service"}}
	// code for a service
{{end}}
```