### PR TITLE
Implement io.WriterTo for DBFS file reader

### DIFF
--- a/service/dbfs/doc.go
+++ b/service/dbfs/doc.go
@@ -4,10 +4,14 @@
 // [github.com/databricks/databricks-sdk-go/workspaces.New] to simplify
 // configuration experience.
 //
-// Please use higher-level [DbfsAPI.Open] and [DbfsAPI.Overwrite] to work with
-// remote files via [io.Reader] interface. Internally, these methods wrap
-// the low level [DbfsAPI.Create], [DbfsAPI.Close], [DbfsAPI.Read], and
-// [DbfsAPI.AddBlock]:
+// Please use the high-level [DbfsAPI.Open] and [DbfsAPI.Overwrite] methods
+// to work with remote files through Go's [io] interfaces. The return value
+// of [DbfsAPI.Open] implements the [io.Reader] and [io.WriterTo] interfaces.
+// The [io.WriterTo] interface is used by [io.Copy] and maximizes throughput by
+// reading data with the DBFS maximum read chunk size of 1MB.
+//
+// Internally, these methods wrap the low level [DbfsAPI.Create],
+// [DbfsAPI.Close], [DbfsAPI.Read], and [DbfsAPI.AddBlock] methods:
 //
 //	upload, _ := os.Open("/path/to/local/file.ext")
 //	_ = w.Dbfs.Overwrite(ctx, "/path/to/remote/file", upload)


### PR DESCRIPTION
I noticed ~30 API calls to download a 1.44M file from DBFS and it turns out that `io.ReadAll` starts out with a small buffer and grows it conservatively.

Through the `io.WriterTo` interface we can make the same reader use the maximum DBFS read size of 1MB and reduce the number of API calls for the same file down to 2.

This PR also contains a related fix for `FileReader.Read` such that it no longer requires a final zero-length read call.