### PR TITLE
Added more entity-generation utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ doc:
 	@go run golang.org/x/tools/cmd/godoc@latest -http=localhost:6060
 
 install-codegen: vendor
-	@go build -o ~/go/bin/openapi-codegen openapi/gen/main.go
+	@go build -o ~/go/bin/oac openapi/gen/main.go
 
 gen:
 	@go run openapi/gen/main.go

--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -149,6 +149,26 @@ func (e *Entity) Fields() (fields []Field) {
 	return fields
 }
 
+// HasQueryField returns true if any of the fields is from query
+func (e *Entity) HasQueryField() bool {
+	for _, v := range e.fields {
+		if v.IsQuery {
+			return true
+		}
+	}
+	return false
+}
+
+// HasJsonField returns true if any of the fields is in the body
+func (e *Entity) HasJsonField() bool {
+	for _, v := range e.fields {
+		if v.IsJson {
+			return true
+		}
+	}
+	return false
+}
+
 // Does this type have x-databricks-id field?
 func (e *Entity) HasIdentifierField() bool {
 	return e.IdentifierField() != nil

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -146,6 +146,10 @@ func (m *Method) Shortcut() *Shortcut {
 	}
 }
 
+func (m *Method) IsCrudRead() bool {
+	return m.operation.Crud == "read"
+}
+
 // Wait returns definition for long-running operation
 func (m *Method) Wait() *Wait {
 	if m.wait == nil {

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -157,8 +157,17 @@ func (svc *Service) newRequest(params []openapi.Parameter, op *openapi.Operation
 		field.IsQuery = param.IsQuery
 		request.fields[param.Name] = field
 		if param.Required {
-			// TODO: figure out what to do with entity+param requests
-			request.RequiredOrder = append(request.RequiredOrder, param.Name)
+			var alreadyRequired bool
+			for _, v := range request.RequiredOrder {
+				if v == param.Name {
+					alreadyRequired = true
+					break
+				}
+			}
+			if !alreadyRequired {
+				// TODO: figure out what to do with entity+param requests
+				request.RequiredOrder = append(request.RequiredOrder, param.Name)
+			}
 		}
 	}
 	if request.Name == "" {

--- a/openapi/code/tmpl_util_funcs.go
+++ b/openapi/code/tmpl_util_funcs.go
@@ -3,11 +3,14 @@ package code
 import (
 	"errors"
 	"reflect"
+	"regexp"
 	"strings"
 	"text/template"
 )
 
 var ErrSkipThisFile = errors.New("skip generating this file")
+
+var alphanumRE = regexp.MustCompile(`^\w*$`)
 
 var HelperFuncs = template.FuncMap{
 	"notLast": func(idx int, a interface{}) bool {
@@ -28,5 +31,14 @@ var HelperFuncs = template.FuncMap{
 		// so that we handle this error in [gen.Pass[T].File] gracefully
 		// via errors.Is(err, code.ErrSkipThisFile)
 		panic(ErrSkipThisFile)
+	},
+	"alphanumOnly": func(in []Field) (out []Field) {
+		for _, v := range in {
+			if !alphanumRE.MatchString(v.Name) {
+				continue
+			}
+			out = append(out, v)
+		}
+		return out
 	},
 }

--- a/openapi/code/tmpl_util_funcs.go
+++ b/openapi/code/tmpl_util_funcs.go
@@ -41,4 +41,7 @@ var HelperFuncs = template.FuncMap{
 		}
 		return out
 	},
+	"list": func(l ...any) []any {
+		return l
+	},
 }


### PR DESCRIPTION
* Renamed `~/bin/openapi-codegen` to `~/bin/oac`
* Added `HasQueryField` and `HasJsonField` for Entity
* De-duplicate entries in `Entity.RequiredOrder`
* Added `alphanumOnly` and `list` template helpers