### PR TITLE
Cleaner callbacks for polling status

### DIFF
--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -71,7 +71,6 @@ func (a *{{.Service.Name}}API) {{.PascalName}}AndWait(ctx context.Context{{if .R
 			o(&retries.Info[{{.Wait.Poll.Response.PascalName}}]{
 				Info: {{.Wait.Poll.Response.CamelName}},
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := {{.Wait.Poll.Response.CamelName}}{{range .Wait.StatusPath}}.{{.PascalName}}{{end}}

--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -69,8 +69,9 @@ func (a *{{.Service.Name}}API) {{.PascalName}}AndWait(ctx context.Context{{if .R
 		}
 		for _, o := range options {
 			o(&retries.Info[{{.Wait.Poll.Response.PascalName}}]{
-				Info: *{{.Wait.Poll.Response.CamelName}},
+				Info: {{.Wait.Poll.Response.CamelName}},
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := {{.Wait.Poll.Response.CamelName}}{{range .Wait.StatusPath}}.{{.PascalName}}{{end}}

--- a/internal/clusters_test.go
+++ b/internal/clusters_test.go
@@ -124,7 +124,10 @@ func TestAccClustersApiIntegration(t *testing.T) {
 		InstancePoolId:         GetEnvOrSkipTest(t, "TEST_INSTANCE_POOL_ID"),
 		AutoterminationMinutes: 15,
 		NumWorkers:             1,
-	}, retries.Timeout[clusters.ClusterInfo](20*time.Minute))
+	}, retries.Timeout[clusters.ClusterInfo](20*time.Minute),
+		retries.OnPoll(func(i *clusters.ClusterInfo) {
+			t.Logf("cluster is %s", i.State)
+		}))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -23,12 +23,12 @@ func Timeout[T any](dur time.Duration) Option[T] {
 	}
 }
 
-func OnPoll[T any](cb func(*T)) Option[T] {
+func OnPoll[T any](callback func(*T)) Option[T] {
 	return func(i *Info[T]) {
 		if i.Info == nil {
 			return
 		}
-		cb(i.Info)
+		callback(i.Info)
 	}
 }
 

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -12,7 +12,6 @@ import (
 
 type Info[T any] struct {
 	Info    *T
-	Polling bool
 	Timeout time.Duration
 }
 

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Info[T any] struct {
-	Info    T
+	Info    *T
+	Polling bool
 	Timeout time.Duration
 }
 
@@ -20,6 +21,15 @@ type Option[T any] func(*Info[T])
 func Timeout[T any](dur time.Duration) Option[T] {
 	return func(i *Info[T]) {
 		i.Timeout = dur
+	}
+}
+
+func OnPoll[T any](cb func (*T)) Option[T] {
+	return func(i *Info[T]) {
+		if i.Info == nil {
+			return
+		}
+		cb(i.Info)
 	}
 }
 

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -24,7 +24,7 @@ func Timeout[T any](dur time.Duration) Option[T] {
 	}
 }
 
-func OnPoll[T any](cb func (*T)) Option[T] {
+func OnPoll[T any](cb func(*T)) Option[T] {
 	return func(i *Info[T]) {
 		if i.Info == nil {
 			return

--- a/service/clusters/api.go
+++ b/service/clusters/api.go
@@ -118,7 +118,6 @@ func (a *ClustersAPI) CreateAndWait(ctx context.Context, createCluster CreateClu
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -171,7 +170,6 @@ func (a *ClustersAPI) DeleteAndWait(ctx context.Context, deleteCluster DeleteClu
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -250,7 +248,6 @@ func (a *ClustersAPI) EditAndWait(ctx context.Context, editCluster EditCluster, 
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -331,7 +328,6 @@ func (a *ClustersAPI) GetAndWait(ctx context.Context, get Get, options ...retrie
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -554,7 +550,6 @@ func (a *ClustersAPI) ResizeAndWait(ctx context.Context, resizeCluster ResizeClu
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -605,7 +600,6 @@ func (a *ClustersAPI) RestartAndWait(ctx context.Context, restartCluster Restart
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -670,7 +664,6 @@ func (a *ClustersAPI) StartAndWait(ctx context.Context, startCluster StartCluste
 			o(&retries.Info[ClusterInfo]{
 				Info:    clusterInfo,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := clusterInfo.State

--- a/service/clusters/api.go
+++ b/service/clusters/api.go
@@ -116,8 +116,9 @@ func (a *ClustersAPI) CreateAndWait(ctx context.Context, createCluster CreateClu
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -168,8 +169,9 @@ func (a *ClustersAPI) DeleteAndWait(ctx context.Context, deleteCluster DeleteClu
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -246,8 +248,9 @@ func (a *ClustersAPI) EditAndWait(ctx context.Context, editCluster EditCluster, 
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -326,8 +329,9 @@ func (a *ClustersAPI) GetAndWait(ctx context.Context, get Get, options ...retrie
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -548,8 +552,9 @@ func (a *ClustersAPI) ResizeAndWait(ctx context.Context, resizeCluster ResizeClu
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -598,8 +603,9 @@ func (a *ClustersAPI) RestartAndWait(ctx context.Context, restartCluster Restart
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State
@@ -662,8 +668,9 @@ func (a *ClustersAPI) StartAndWait(ctx context.Context, startCluster StartCluste
 		}
 		for _, o := range options {
 			o(&retries.Info[ClusterInfo]{
-				Info:    *clusterInfo,
+				Info:    clusterInfo,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := clusterInfo.State

--- a/service/commands/api.go
+++ b/service/commands/api.go
@@ -75,8 +75,9 @@ func (a *CommandExecutionAPI) CancelAndWait(ctx context.Context, cancelCommand C
 		}
 		for _, o := range options {
 			o(&retries.Info[CommandStatusResponse]{
-				Info:    *commandStatusResponse,
+				Info:    commandStatusResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := commandStatusResponse.Status
@@ -147,8 +148,9 @@ func (a *CommandExecutionAPI) CreateAndWait(ctx context.Context, createContext C
 		}
 		for _, o := range options {
 			o(&retries.Info[ContextStatusResponse]{
-				Info:    *contextStatusResponse,
+				Info:    contextStatusResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := contextStatusResponse.Status
@@ -209,8 +211,9 @@ func (a *CommandExecutionAPI) ExecuteAndWait(ctx context.Context, command Comman
 		}
 		for _, o := range options {
 			o(&retries.Info[CommandStatusResponse]{
-				Info:    *commandStatusResponse,
+				Info:    commandStatusResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := commandStatusResponse.Status

--- a/service/commands/api.go
+++ b/service/commands/api.go
@@ -77,7 +77,6 @@ func (a *CommandExecutionAPI) CancelAndWait(ctx context.Context, cancelCommand C
 			o(&retries.Info[CommandStatusResponse]{
 				Info:    commandStatusResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := commandStatusResponse.Status
@@ -150,7 +149,6 @@ func (a *CommandExecutionAPI) CreateAndWait(ctx context.Context, createContext C
 			o(&retries.Info[ContextStatusResponse]{
 				Info:    contextStatusResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := contextStatusResponse.Status
@@ -213,7 +211,6 @@ func (a *CommandExecutionAPI) ExecuteAndWait(ctx context.Context, command Comman
 			o(&retries.Info[CommandStatusResponse]{
 				Info:    commandStatusResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := commandStatusResponse.Status

--- a/service/deployment/api.go
+++ b/service/deployment/api.go
@@ -1244,7 +1244,6 @@ func (a *WorkspacesAPI) CreateAndWait(ctx context.Context, createWorkspaceReques
 			o(&retries.Info[Workspace]{
 				Info:    workspace,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := workspace.WorkspaceStatus
@@ -1532,7 +1531,6 @@ func (a *WorkspacesAPI) UpdateAndWait(ctx context.Context, updateWorkspaceReques
 			o(&retries.Info[Workspace]{
 				Info:    workspace,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := workspace.WorkspaceStatus

--- a/service/deployment/api.go
+++ b/service/deployment/api.go
@@ -1242,8 +1242,9 @@ func (a *WorkspacesAPI) CreateAndWait(ctx context.Context, createWorkspaceReques
 		}
 		for _, o := range options {
 			o(&retries.Info[Workspace]{
-				Info:    *workspace,
+				Info:    workspace,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := workspace.WorkspaceStatus
@@ -1529,8 +1530,9 @@ func (a *WorkspacesAPI) UpdateAndWait(ctx context.Context, updateWorkspaceReques
 		}
 		for _, o := range options {
 			o(&retries.Info[Workspace]{
-				Info:    *workspace,
+				Info:    workspace,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := workspace.WorkspaceStatus

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -105,8 +105,9 @@ func (a *JobsAPI) CancelRunAndWait(ctx context.Context, cancelRun CancelRun, opt
 		}
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    *run,
+				Info:    run,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -235,8 +236,9 @@ func (a *JobsAPI) GetRunAndWait(ctx context.Context, getRun GetRun, options ...r
 		}
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    *run,
+				Info:    run,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -440,8 +442,9 @@ func (a *JobsAPI) RepairRunAndWait(ctx context.Context, repairRun RepairRun, opt
 		}
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    *run,
+				Info:    run,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -500,8 +503,9 @@ func (a *JobsAPI) RunNowAndWait(ctx context.Context, runNow RunNow, options ...r
 		}
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    *run,
+				Info:    run,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -555,8 +559,9 @@ func (a *JobsAPI) SubmitAndWait(ctx context.Context, submitRun SubmitRun, option
 		}
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    *run,
+				Info:    run,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -107,7 +107,6 @@ func (a *JobsAPI) CancelRunAndWait(ctx context.Context, cancelRun CancelRun, opt
 			o(&retries.Info[Run]{
 				Info:    run,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -238,7 +237,6 @@ func (a *JobsAPI) GetRunAndWait(ctx context.Context, getRun GetRun, options ...r
 			o(&retries.Info[Run]{
 				Info:    run,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -444,7 +442,6 @@ func (a *JobsAPI) RepairRunAndWait(ctx context.Context, repairRun RepairRun, opt
 			o(&retries.Info[Run]{
 				Info:    run,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -505,7 +502,6 @@ func (a *JobsAPI) RunNowAndWait(ctx context.Context, runNow RunNow, options ...r
 			o(&retries.Info[Run]{
 				Info:    run,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState
@@ -561,7 +557,6 @@ func (a *JobsAPI) SubmitAndWait(ctx context.Context, submitRun SubmitRun, option
 			o(&retries.Info[Run]{
 				Info:    run,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := run.State.LifeCycleState

--- a/service/libraries/utilities.go
+++ b/service/libraries/utilities.go
@@ -187,7 +187,8 @@ func (a *LibrariesAPI) Wait(ctx context.Context, wait Wait,
 		for _, o := range options {
 			o(&retries.Info[ClusterLibraryStatuses]{
 				Timeout: i.Timeout,
-				Info:    *status,
+				Info:    status,
+				Polling: true,
 			})
 		}
 		if err != nil {

--- a/service/libraries/utilities.go
+++ b/service/libraries/utilities.go
@@ -188,7 +188,6 @@ func (a *LibrariesAPI) Wait(ctx context.Context, wait Wait,
 			o(&retries.Info[ClusterLibraryStatuses]{
 				Timeout: i.Timeout,
 				Info:    status,
-				Polling: true,
 			})
 		}
 		if err != nil {

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -105,8 +105,9 @@ func (a *PipelinesAPI) GetAndWait(ctx context.Context, get Get, options ...retri
 		}
 		for _, o := range options {
 			o(&retries.Info[GetPipelineResponse]{
-				Info:    *getPipelineResponse,
+				Info:    getPipelineResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getPipelineResponse.State
@@ -280,8 +281,9 @@ func (a *PipelinesAPI) ResetAndWait(ctx context.Context, reset Reset, options ..
 		}
 		for _, o := range options {
 			o(&retries.Info[GetPipelineResponse]{
-				Info:    *getPipelineResponse,
+				Info:    getPipelineResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getPipelineResponse.State
@@ -336,8 +338,9 @@ func (a *PipelinesAPI) StopAndWait(ctx context.Context, stop Stop, options ...re
 		}
 		for _, o := range options {
 			o(&retries.Info[GetPipelineResponse]{
-				Info:    *getPipelineResponse,
+				Info:    getPipelineResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getPipelineResponse.State

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -107,7 +107,6 @@ func (a *PipelinesAPI) GetAndWait(ctx context.Context, get Get, options ...retri
 			o(&retries.Info[GetPipelineResponse]{
 				Info:    getPipelineResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getPipelineResponse.State
@@ -283,7 +282,6 @@ func (a *PipelinesAPI) ResetAndWait(ctx context.Context, reset Reset, options ..
 			o(&retries.Info[GetPipelineResponse]{
 				Info:    getPipelineResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getPipelineResponse.State
@@ -340,7 +338,6 @@ func (a *PipelinesAPI) StopAndWait(ctx context.Context, stop Stop, options ...re
 			o(&retries.Info[GetPipelineResponse]{
 				Info:    getPipelineResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getPipelineResponse.State

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -893,8 +893,9 @@ func (a *WarehousesAPI) CreateAndWait(ctx context.Context, createWarehouseReques
 		}
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    *getWarehouseResponse,
+				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -945,8 +946,9 @@ func (a *WarehousesAPI) DeleteAndWait(ctx context.Context, deleteWarehouseReques
 		}
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    *getWarehouseResponse,
+				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1008,8 +1010,9 @@ func (a *WarehousesAPI) EditAndWait(ctx context.Context, editWarehouseRequest Ed
 		}
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    *getWarehouseResponse,
+				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1060,8 +1063,9 @@ func (a *WarehousesAPI) GetAndWait(ctx context.Context, getWarehouseRequest GetW
 		}
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    *getWarehouseResponse,
+				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1209,8 +1213,9 @@ func (a *WarehousesAPI) StartAndWait(ctx context.Context, startRequest StartRequ
 		}
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    *getWarehouseResponse,
+				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1261,8 +1266,9 @@ func (a *WarehousesAPI) StopAndWait(ctx context.Context, stopRequest StopRequest
 		}
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    *getWarehouseResponse,
+				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
+				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -895,7 +895,6 @@ func (a *WarehousesAPI) CreateAndWait(ctx context.Context, createWarehouseReques
 			o(&retries.Info[GetWarehouseResponse]{
 				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -948,7 +947,6 @@ func (a *WarehousesAPI) DeleteAndWait(ctx context.Context, deleteWarehouseReques
 			o(&retries.Info[GetWarehouseResponse]{
 				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1012,7 +1010,6 @@ func (a *WarehousesAPI) EditAndWait(ctx context.Context, editWarehouseRequest Ed
 			o(&retries.Info[GetWarehouseResponse]{
 				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1065,7 +1062,6 @@ func (a *WarehousesAPI) GetAndWait(ctx context.Context, getWarehouseRequest GetW
 			o(&retries.Info[GetWarehouseResponse]{
 				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1215,7 +1211,6 @@ func (a *WarehousesAPI) StartAndWait(ctx context.Context, startRequest StartRequ
 			o(&retries.Info[GetWarehouseResponse]{
 				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State
@@ -1268,7 +1263,6 @@ func (a *WarehousesAPI) StopAndWait(ctx context.Context, stopRequest StopRequest
 			o(&retries.Info[GetWarehouseResponse]{
 				Info:    getWarehouseResponse,
 				Timeout: i.Timeout,
-				Polling: true,
 			})
 		}
 		status := getWarehouseResponse.State


### PR DESCRIPTION
This PR ensures that `i.Info == nil` is a clear indicator for a long-running operation callback that it's run in the polling mode. For convenience, `retries.OnPoll` is added as well:

```go
clstr, err := w.Clusters.CreateAndWait(ctx, clusters.CreateCluster{
		ClusterName:            clusterName,
		SparkVersion:           latest,
		InstancePoolId:         GetEnvOrSkipTest(t, "TEST_INSTANCE_POOL_ID"),
		AutoterminationMinutes: 15,
		NumWorkers:             1,
	}, retries.Timeout[clusters.ClusterInfo](20*time.Minute),
		retries.OnPoll(func(i *clusters.ClusterInfo) {
			t.Logf("cluster is %s", i.State)
		}))
```

Fixes #251