### PR TITLE
Added Azure MSI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ To authenticate as an Azure Active Directory (Azure AD) service principal, you m
 | `*databricks.Config` argument | Description | Environment variable / `.databrickscfg` file field |
 |-------------------------------|-------------|----------------------------------------------------|
 | `AzureResourceID` | _(String)_ The Azure Resource Manager ID for the Azure Databricks workspace, which is exchanged for a Databricks host URL. |  `DATABRICKS_AZURE_RESOURCE_ID` / `azure_workspace_resource_id` |
-| `AzureUseMSI` | _(Boolean)_ `true` to use Azure Managed Service Identity passwordless authentication flow for service principals. _This feature is not yet implemented in the Databricks SDK for Go._ | `ARM_USE_MSI` / `azure_use_msi` |
+| `AzureUseMSI` | _(Boolean)_ `true` to use Azure Managed Service Identity passwordless authentication flow for service principals. Requires `AzureResourceID` to be set. | `ARM_USE_MSI` / `azure_use_msi` |
 | `AzureClientSecret` | _(String)_ The Azure AD service principal's client secret. | `ARM_CLIENT_SECRET` / `azure_client_secret` |
 | `AzureClientID` | _(String)_ The Azure AD service principal's application ID. | `ARM_CLIENT_ID` / `azure_client_id` |
 | `AzureTenantID` | _(String)_ The Azure AD service principal's tenant ID. | `ARM_TENANT_ID` / `azure_tenant_id` |

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/logger"
+	"golang.org/x/oauth2"
+)
+
+// well-known URL for Azure Instance Metadata Service (IMDS)
+// https://learn.microsoft.com/en-us/azure-stack/user/instance-metadata-service
+var instanceMetadataPrefix = "http://169.254.169.254/metadata"
+
+// timeout to wait for IMDS response
+const azureMsiTimeout = 10 * time.Second
+
+type AzureMsiCredentials struct {
+}
+
+func (c AzureMsiCredentials) Name() string {
+	return "azure-msi"
+}
+
+func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*http.Request) error, error) {
+	if !cfg.IsAzure() || !cfg.AzureUseMSI || cfg.AzureResourceID == "" {
+		return nil, nil
+	}
+	env, err := c.getInstanceEnvironment(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = cfg.azureEnsureWorkspaceUrl(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("resolve host: %w", err)
+	}
+	logger.Debugf("Generating AAD token via Azure MSI")
+	inner := azureMsiTokenSource(cfg.getAzureLoginAppID())
+	platform := azureMsiTokenSource(env.ServiceManagementEndpoint)
+	return func(r *http.Request) error {
+		r.Header.Set("X-Databricks-Azure-Workspace-Resource-Id", cfg.AzureResourceID)
+		return serviceToServiceVisitor(inner, platform,
+			"X-Databricks-Azure-SP-Management-Token")(r)
+	}, nil
+}
+
+func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azureEnvironment, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s/instance", instanceMetadataPrefix), nil)
+	if err != nil {
+		return nil, fmt.Errorf("metadata request: %w", err)
+	}
+	query := req.URL.Query()
+	query.Add("api-version", "2021-12-13")
+	req.URL.RawQuery = query.Encode()
+	req.Header.Add("Metadata", "true")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("metadata response: %w", err)
+	}
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("metadata read: %w", err)
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("metadata error: %s", raw)
+	}
+	var metadata struct {
+		Compute struct {
+			Environment string `json:"azEnvironment"`
+		} `json:"compute"`
+	}
+	err = json.Unmarshal(raw, &metadata)
+	if err != nil {
+		return nil, fmt.Errorf("metadata parse: %w", err)
+	}
+	for _, v := range azureEnvironments {
+		if v.Name == metadata.Compute.Environment {
+			return &v, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot determine environment: %s",
+		metadata.Compute.Environment)
+}
+
+// implementing azureHostResolver for ensureWorkspaceUrl to work
+func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, _ *Config, _ azureEnvironment, resource string) oauth2.TokenSource {
+	return azureMsiTokenSource(resource)
+}
+
+type azureMsiTokenSource string
+
+func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), azureMsiTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s/identity/oauth2/token", instanceMetadataPrefix), nil)
+	if err != nil {
+		return nil, fmt.Errorf("token request: %w", err)
+	}
+	query := req.URL.Query()
+	query.Add("api-version", "2018-02-01")
+	query.Add("resource", string(s))
+	req.URL.RawQuery = query.Encode()
+	req.Header.Add("Metadata", "true")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token response: %w", err)
+	}
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("token read: %w", err)
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("token error: %s", raw)
+	}
+	var token azureMsiToken
+	err = json.Unmarshal(raw, &token)
+	if err != nil {
+		return nil, fmt.Errorf("token parse: %w", err)
+	}
+	epoch, err := token.ExpiresOn.Int64()
+	if err != nil {
+		return nil, fmt.Errorf("token expires on: %w", err)
+	}
+	return &oauth2.Token{
+		TokenType:   token.TokenType,
+		AccessToken: token.AccessToken,
+		Expiry:      time.Unix(epoch, 0),
+	}, nil
+}
+
+type azureMsiToken struct {
+	AccessToken string      `json:"access_token"`
+	TokenType   string      `json:"token_type"`
+	ExpiresOn   json.Number `json:"expires_on"`
+}

--- a/config/auth_default.go
+++ b/config/auth_default.go
@@ -15,6 +15,7 @@ var (
 		BasicCredentials{},
 		M2mCredentials{},
 		BricksCliCredentials{},
+		AzureMsiCredentials{},
 		AzureClientSecretCredentials{},
 		AzureCliCredentials{},
 		GoogleDefaultCredentials{},

--- a/config/azure.go
+++ b/config/azure.go
@@ -100,7 +100,7 @@ func (c *Config) azureEnsureWorkspaceUrl(ctx context.Context, ahr azureHostResol
 		return fmt.Errorf("cannot unmarshal: %w", err)
 	}
 	c.Host = fmt.Sprintf("https://%s", workspaceMetadata.Properties.WorkspaceURL)
-	logger.Infof("Discovered workspace url: %s", c.Host)
+	logger.Debugf("Discovered workspace url: %s", c.Host)
 	return nil
 }
 


### PR DESCRIPTION
Added native [Azure Active Directory Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) integration. Use `ARM_USE_MSI` & `DATABRICKS_AZURE_RESOURCE_ID` environment variables (or their configuration counterparts) to trigger this auth type.

Special thanks to @alexott for the research of zero-dependency MSI in scope of https://github.com/databricks/databricks-cli/pull/412