### PR TITLE
Fixed bricks CLI auth

### DIFF
--- a/config/auth_u2m.go
+++ b/config/auth_u2m.go
@@ -23,6 +23,9 @@ func (c BricksCliCredentials) Configure(ctx context.Context, cfg *Config) (func(
 	if !cfg.IsAws() {
 		return nil, nil
 	}
+	if cfg.Host == "" {
+		return nil, nil
+	}
 	ts := bricksCliTokenSource{cfg}
 	_, err := ts.Token()
 	if err != nil {


### PR DESCRIPTION
Propagating an empty host was causing `cannot fetch credentials` error.