### PR TITLE
fix[#285]: change APIError to use pointer receiver

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -173,7 +173,8 @@ func (c *DatabricksClient) attempt(
 		}
 
 		retry, err := apierr.CheckForRetry(ctx, response, err, responseBody.Bytes(), responseBodyErr)
-		if err != nil && !errors.As(err, &apierr.APIError{}) {
+		var apiErr *apierr.APIError
+		if err != nil && !errors.As(err, &apiErr) {
 			err = fmt.Errorf("failed request: %w", err)
 		}
 		if err == nil && response == nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -254,9 +254,10 @@ func TestSimpleRequestAPIError(t *testing.T) {
 		rateLimiter: rate.NewLimiter(rate.Inf, 1),
 	}
 	err := c.Do(context.Background(), "PATCH", "/a", map[string]any{}, nil)
-	aerr, ok := err.(apierr.APIError)
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "NOT_FOUND", aerr.ErrorCode)
+	var aerr *apierr.APIError
+	if assert.ErrorAs(t, err, &aerr) {
+		assert.Equal(t, "NOT_FOUND", aerr.ErrorCode)
+	}
 }
 
 func TestSimpleRequestNilResponseNoError(t *testing.T) {


### PR DESCRIPTION
Allows APIError to be used as expected with `errors.As`. Closes #285.