### PR TITLE
Drop duplicate prefix in randomized email

### DIFF
--- a/internal/clusters_test.go
+++ b/internal/clusters_test.go
@@ -220,7 +220,7 @@ func TestAccClustersApiIntegration(t *testing.T) {
 	assert.Contains(t, names, clusterName)
 
 	otherOwner, err := w.Users.Create(ctx, scim.User{
-		UserName: RandomEmail("sdk-go-"),
+		UserName: RandomEmail(),
 	})
 	require.NoError(t, err)
 	defer w.Users.DeleteById(ctx, otherOwner.Id)

--- a/internal/secrets_test.go
+++ b/internal/secrets_test.go
@@ -13,7 +13,7 @@ func TestAccSecrets(t *testing.T) {
 	ctx, w := workspaceTest(t)
 
 	scope := secrets.CreateScope{
-		Scope: RandomEmail("sdk-go"),
+		Scope: RandomEmail(),
 	}
 	err := w.Secrets.CreateScope(ctx, scope)
 	require.NoError(t, err)


### PR DESCRIPTION
As is, the integration tests created email addresses such as `sdk-go-sdk-go-bflaglaacell@example.com`.