### PR TITLE
Don't load `~/.databrickscfg` if `azure-cli` auth is implicitly configured

### DIFF
--- a/config/config_file.go
+++ b/config/config_file.go
@@ -19,7 +19,7 @@ func (l KnownConfigLoader) Configure(cfg *Config) error {
 	// Skip loading config file if some authentication is already explicitly
 	// configured directly in the config by a user.
 	// See: https://github.com/databricks/databricks-sdk-go/issues/304
-	if cfg.Profile == "" && l.isAnyAuthConfigured(cfg) {
+	if cfg.Profile == "" && (l.isAnyAuthConfigured(cfg) || cfg.IsAzure()) {
 		return nil
 	}
 	configFile := cfg.ConfigFile


### PR DESCRIPTION
Checking for presence of `host` isn't enough as it should happen only on Azure, so checking with `IsAzure` works better.