### PR TITLE
Add option to configure the location of the bricks CLI

### DIFF
--- a/config/auth_u2m.go
+++ b/config/auth_u2m.go
@@ -49,10 +49,17 @@ type bricksCliTokenSource struct {
 
 func (ts *bricksCliTokenSource) Token() (*oauth2.Token, error) {
 	what := []string{"auth", "token", "--host", ts.cfg.Host}
+
 	if ts.cfg.IsAccountClient() {
 		what = append(what, "--account-id", ts.cfg.AccountID)
 	}
-	out, err := exec.Command("bricks", what...).Output()
+
+	bricksCli := ts.cfg.BricksCliPath
+	if bricksCli == "" {
+		bricksCli = "bricks"
+	}
+
+	out, err := exec.Command(bricksCli, what...).Output()
 	if ee, ok := err.(*exec.ExitError); ok {
 		return nil, fmt.Errorf("cannot get access token: %s", string(ee.Stderr))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,9 @@ type Config struct {
 	ClientID     string `name:"client_id" env:"DATABRICKS_CLIENT_ID" auth:"oauth"`
 	ClientSecret string `name:"client_secret" env:"DATABRICKS_CLIENT_SECRET" auth:"oauth,sensitive"`
 
+	// Path to the 'bricks' CLI
+	BricksCliPath string `name:"bricks_cli_path" env:"BRICKS_CLI_PATH"`
+
 	// When multiple auth attributes are available in the environment, use the auth type
 	// specified by this argument. This argument also holds currently selected auth.
 	AuthType string `name:"auth_type" env:"DATABRICKS_AUTH_TYPE" auth:"-"`


### PR DESCRIPTION
Especially for the VS Code extension this is easier and more robust than messing the the `PATH`