### PR TITLE
Remove extra space in comments of PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,7 @@
 
 ## Tests
 <!-- 
-How is this tested? Please see the checklist below and also describe any other relevant 
-tests 
+How is this tested? Please see the checklist below and also describe any other relevant tests 
 -->
 
 - [ ] `make test` passing


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
An additional "\n" got in comments due to editing on editor vs terminal. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

