### PR TITLE
Adds named `Wait` the level of services

### DIFF
--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -155,7 +155,20 @@ func (m *Method) Wait() *Wait {
 	if m.wait == nil {
 		return nil
 	}
+	// here it's easier to follow the snake_case, as success states are already
+	// in the CONSTANT_CASE and it's easier to convert from constant to snake,
+	// than from constant to camel or pascal.
+	name := m.Service.Singular().SnakeName()
+	success := strings.ToLower(strings.Join(m.wait.Success, "_or_"))
+	getStatus, ok := m.Service.methods[m.wait.Poll]
+	if !ok {
+		panic(fmt.Errorf("cannot find %s.%s", m.Service.Name, m.wait.Poll))
+	}
+	name = fmt.Sprintf("wait_%s_%s_%s", getStatus.SnakeName(), name, success)
 	return &Wait{
+		Named: Named{
+			Name: name,
+		},
 		Method: m,
 	}
 }

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -271,3 +271,31 @@ func (svc *Service) newMethod(verb, path string, params []openapi.Parameter, op 
 		shortcut:          op.Shortcut,
 	}
 }
+
+func (svc *Service) HasWaits() bool {
+	for _, v := range svc.methods {
+		if v.wait != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (svc *Service) Waits() (waits []*Wait) {
+	seen := map[string]bool{}
+	for _, m := range svc.methods {
+		if m.wait == nil {
+			continue
+		}
+		wait := m.Wait()
+		if seen[wait.Name] {
+			continue
+		}
+		waits = append(waits, wait)
+		seen[wait.Name] = true
+	}
+	slices.SortFunc(waits, func(a, b *Wait) bool {
+		return a.Name < b.Name
+	})
+	return waits
+}

--- a/openapi/code/wait.go
+++ b/openapi/code/wait.go
@@ -8,6 +8,7 @@ import (
 
 // Wait represents a long-running operation, that requires multiple RPC calls
 type Wait struct {
+	Named
 	// represents a method that triggers the start of the long-running operation
 	Method *Method
 }


### PR DESCRIPTION
## Changes
- Adds named `Wait` the level of services
- Allow generating independent wait methods on the level of services
- `Waits` are named as `wait_<poll-method>_<service-singular>_<success-states>`

## Tests

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

