### PR TITLE
Pass `azure_client_id` to Azure MSI if specified

### DIFF
--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -102,13 +102,9 @@ func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, cfg *Config, _ az
 	}
 }
 
-//type azureMsiTokenSource string
-
 type azureMsiTokenSource struct {
-	resource      string
-	clientId      string
-	objectId      string
-	msiResourceId string
+	resource string
+	clientId string
 }
 
 func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
@@ -125,15 +121,7 @@ func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
 	if s.clientId != "" {
 		query.Add("client_id", s.clientId)
 	}
-	if s.objectId != "" {
-		query.Add("object_id", s.objectId)
-	}
-	if s.msiResourceId != "" {
-		query.Add("msi_res_id", s.msiResourceId)
-	}
-	fmt.Printf("%+v\n", s)
 	req.URL.RawQuery = query.Encode()
-	fmt.Printf("URL: %+v\n", req.URL.RawQuery)
 	req.Header.Add("Metadata", "true")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -39,8 +39,12 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 		return nil, fmt.Errorf("resolve host: %w", err)
 	}
 	logger.Debugf(ctx, "Generating AAD token via Azure MSI")
-	inner := azureMsiTokenSource(cfg.getAzureLoginAppID())
-	platform := azureMsiTokenSource(env.ServiceManagementEndpoint)
+	inner := azureMsiTokenSource{
+		resource: cfg.getAzureLoginAppID(),
+	}
+	platform := azureMsiTokenSource{
+		resource: env.ServiceManagementEndpoint,
+	}
 	return func(r *http.Request) error {
 		r.Header.Set("X-Databricks-Azure-Workspace-Resource-Id", cfg.AzureResourceID)
 		return serviceToServiceVisitor(inner, platform,
@@ -88,13 +92,19 @@ func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azure
 }
 
 // implementing azureHostResolver for ensureWorkspaceUrl to work
-func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, _ *Config, _ azureEnvironment, resource string) oauth2.TokenSource {
-	return azureMsiTokenSource(resource)
+func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, cfg *Config, _ azureEnvironment, resource string) oauth2.TokenSource {
+	return azureMsiTokenSource{
+		resource: resource,
+		clientId: cfg.ClientID,
+	}
 }
 
-type azureMsiTokenSource string
+//type azureMsiTokenSource string
 
-//type azureMsiTokenSource struct with additional information like client id.
+type azureMsiTokenSource struct {
+	resource string
+	clientId string
+}
 
 func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), azureMsiTimeout)
@@ -106,7 +116,10 @@ func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
 	}
 	query := req.URL.Query()
 	query.Add("api-version", "2018-02-01")
-	query.Add("resource", string(s))
+	query.Add("resource", s.resource)
+	if s.clientId != "" {
+		query.Add("client_id", s.clientId)
+	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Add("Metadata", "true")
 	res, err := http.DefaultClient.Do(req)

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -94,6 +94,8 @@ func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, _ *Config, _ azur
 
 type azureMsiTokenSource string
 
+//type azureMsiTokenSource struct with additional information like client id.
+
 func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), azureMsiTimeout)
 	defer cancel()

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -94,16 +94,20 @@ func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azure
 // implementing azureHostResolver for ensureWorkspaceUrl to work
 func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, cfg *Config, _ azureEnvironment, resource string) oauth2.TokenSource {
 	return azureMsiTokenSource{
-		resource: resource,
-		clientId: cfg.ClientID,
+		resource:      resource,
+		clientId:      cfg.ClientID,
+		objectId:      cfg.AzureMSIObjectId,
+		msiResourceId: cfg.AzureMSIResourceId,
 	}
 }
 
 //type azureMsiTokenSource string
 
 type azureMsiTokenSource struct {
-	resource string
-	clientId string
+	resource      string
+	clientId      string
+	objectId      string
+	msiResourceId string
 }
 
 func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -130,7 +130,9 @@ func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
 	if s.msiResourceId != "" {
 		query.Add("msi_res_id", s.msiResourceId)
 	}
+	fmt.Printf("%+v\n", s)
 	req.URL.RawQuery = query.Encode()
+	fmt.Printf("URL: %+v\n", req.URL.RawQuery)
 	req.Header.Add("Metadata", "true")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -40,7 +40,6 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 	}
 	logger.Debugf(ctx, "Generating AAD token via Azure MSI")
 	inner := azureMsiTokenSource{
-		// for inner aad token generation
 		resource: cfg.getAzureLoginAppID(),
 		clientId: cfg.AzureClientID,
 	}

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -124,6 +124,12 @@ func (s azureMsiTokenSource) Token() (*oauth2.Token, error) {
 	if s.clientId != "" {
 		query.Add("client_id", s.clientId)
 	}
+	if s.objectId != "" {
+		query.Add("object_id", s.objectId)
+	}
+	if s.msiResourceId != "" {
+		query.Add("msi_res_id", s.msiResourceId)
+	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Add("Metadata", "true")
 	res, err := http.DefaultClient.Do(req)

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -40,16 +40,13 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 	}
 	logger.Debugf(ctx, "Generating AAD token via Azure MSI")
 	inner := azureMsiTokenSource{
-		resource:      cfg.getAzureLoginAppID(),
-		clientId:      cfg.ClientID,
-		objectId:      cfg.AzureMSIObjectId,
-		msiResourceId: cfg.AzureMSIResourceId,
+		// for inner aad token generation
+		resource: cfg.getAzureLoginAppID(),
+		clientId: cfg.AzureClientID,
 	}
 	platform := azureMsiTokenSource{
-		resource:      env.ServiceManagementEndpoint,
-		clientId:      cfg.ClientID,
-		objectId:      cfg.AzureMSIObjectId,
-		msiResourceId: cfg.AzureMSIResourceId,
+		resource: env.ServiceManagementEndpoint,
+		clientId: cfg.ClientID,
 	}
 	return func(r *http.Request) error {
 		r.Header.Set("X-Databricks-Azure-Workspace-Resource-Id", cfg.AzureResourceID)
@@ -100,10 +97,8 @@ func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azure
 // implementing azureHostResolver for ensureWorkspaceUrl to work
 func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, cfg *Config, _ azureEnvironment, resource string) oauth2.TokenSource {
 	return azureMsiTokenSource{
-		resource:      resource,
-		clientId:      cfg.ClientID,
-		objectId:      cfg.AzureMSIObjectId,
-		msiResourceId: cfg.AzureMSIResourceId,
+		resource: resource,
+		clientId: cfg.AzureClientID,
 	}
 }
 

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -46,7 +46,7 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 	}
 	platform := azureMsiTokenSource{
 		resource: env.ServiceManagementEndpoint,
-		clientId: cfg.ClientID,
+		clientId: cfg.AzureClientID,
 	}
 	return func(r *http.Request) error {
 		r.Header.Set("X-Databricks-Azure-Workspace-Resource-Id", cfg.AzureResourceID)

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -40,10 +40,16 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 	}
 	logger.Debugf(ctx, "Generating AAD token via Azure MSI")
 	inner := azureMsiTokenSource{
-		resource: cfg.getAzureLoginAppID(),
+		resource:      cfg.getAzureLoginAppID(),
+		clientId:      cfg.ClientID,
+		objectId:      cfg.AzureMSIObjectId,
+		msiResourceId: cfg.AzureMSIResourceId,
 	}
 	platform := azureMsiTokenSource{
-		resource: env.ServiceManagementEndpoint,
+		resource:      env.ServiceManagementEndpoint,
+		clientId:      cfg.ClientID,
+		objectId:      cfg.AzureMSIObjectId,
+		msiResourceId: cfg.AzureMSIResourceId,
 	}
 	return func(r *http.Request) error {
 		r.Header.Set("X-Databricks-Azure-Workspace-Resource-Id", cfg.AzureResourceID)

--- a/config/config.go
+++ b/config/config.go
@@ -59,10 +59,12 @@ type Config struct {
 	// Azure Resource Manager ID for Azure Databricks workspace, which is exhanged for a Host
 	AzureResourceID string `name:"azure_workspace_resource_id" env:"DATABRICKS_AZURE_RESOURCE_ID" auth:"azure"`
 
-	AzureUseMSI       bool   `name:"azure_use_msi" env:"ARM_USE_MSI" auth:"azure"`
-	AzureClientSecret string `name:"azure_client_secret" env:"ARM_CLIENT_SECRET" auth:"azure,sensitive"`
-	AzureClientID     string `name:"azure_client_id" env:"ARM_CLIENT_ID" auth:"azure"`
-	AzureTenantID     string `name:"azure_tenant_id" env:"ARM_TENANT_ID" auth:"azure"`
+	AzureUseMSI        bool   `name:"azure_use_msi" env:"ARM_USE_MSI" auth:"azure"`
+	AzureClientSecret  string `name:"azure_client_secret" env:"ARM_CLIENT_SECRET" auth:"azure,sensitive"`
+	AzureClientID      string `name:"azure_client_id" env:"ARM_CLIENT_ID" auth:"azure"`
+	AzureMSIObjectId   string `name:"azure_msi_object_id" env:"ARM_MSI_OBJECT_ID" auth:"azure"`
+	AzureMSIResourceId string `name:"azure_msi_resource_id" env:"ARM_MSI_RESOURCE_ID" auth:"azure"`
+	AzureTenantID      string `name:"azure_tenant_id" env:"ARM_TENANT_ID" auth:"azure"`
 
 	// AzureEnvironment (Public, UsGov, China, Germany) has specific set of API endpoints.
 	AzureEnvironment string `name:"azure_environment" env:"ARM_ENVIRONMENT"`

--- a/config/config.go
+++ b/config/config.go
@@ -59,12 +59,10 @@ type Config struct {
 	// Azure Resource Manager ID for Azure Databricks workspace, which is exhanged for a Host
 	AzureResourceID string `name:"azure_workspace_resource_id" env:"DATABRICKS_AZURE_RESOURCE_ID" auth:"azure"`
 
-	AzureUseMSI        bool   `name:"azure_use_msi" env:"ARM_USE_MSI" auth:"azure"`
-	AzureClientSecret  string `name:"azure_client_secret" env:"ARM_CLIENT_SECRET" auth:"azure,sensitive"`
-	AzureClientID      string `name:"azure_client_id" env:"ARM_CLIENT_ID" auth:"azure"`
-	AzureMSIObjectId   string `name:"azure_msi_object_id" env:"ARM_MSI_OBJECT_ID" auth:"azure"`
-	AzureMSIResourceId string `name:"azure_msi_resource_id" env:"ARM_MSI_RESOURCE_ID" auth:"azure"`
-	AzureTenantID      string `name:"azure_tenant_id" env:"ARM_TENANT_ID" auth:"azure"`
+	AzureUseMSI       bool   `name:"azure_use_msi" env:"ARM_USE_MSI" auth:"azure"`
+	AzureClientSecret string `name:"azure_client_secret" env:"ARM_CLIENT_SECRET" auth:"azure,sensitive"`
+	AzureClientID     string `name:"azure_client_id" env:"ARM_CLIENT_ID" auth:"azure"`
+	AzureTenantID     string `name:"azure_tenant_id" env:"ARM_TENANT_ID" auth:"azure"`
 
 	// AzureEnvironment (Public, UsGov, China, Germany) has specific set of API endpoints.
 	AzureEnvironment string `name:"azure_environment" env:"ARM_ENVIRONMENT"`


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Added support for providing client id for MSI use case with multiple MSIs attached to an azure vm.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

Manually tested on a vm with multiple MSI.

Created failure first:
![10F7B5BF-23E3-4B62-ACF3-204D91149F5D](https://user-images.githubusercontent.com/54602805/229562710-d6aca548-39b9-4f76-aab8-10b6cab5a62d.png)

Same VM:
![2D0DFC9B-C2E8-468D-ADA0-5C5064D88A11](https://user-images.githubusercontent.com/54602805/229562783-793ae505-4e62-4930-b5b6-99c7b36f192f.png)

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied
