### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Version changelog
 
+## 0.7.0
+
+ * Update from OpenAPI ([#359](https://github.com/databricks/databricks-sdk-go/pull/359)).
+ * Experimental credentials provider via local server ([#340](https://github.com/databricks/databricks-sdk-go/pull/340)).
+ * Added `isTesting` marker to support `ResourceFixture` in Terraform ([#358](https://github.com/databricks/databricks-sdk-go/pull/358)).
+
+Dependency updates:
+ 
+ * Bump golang.org/x/mod from 0.9.0 to 0.10.0 ([#356](https://github.com/databricks/databricks-sdk-go/pull/356)).
+ * Bump google.golang.org/api from 0.114.0 to 0.115.0 ([#357](https://github.com/databricks/databricks-sdk-go/pull/357)).
+
 ## 0.6.0
 
  * Added type to represent a loaded configuration file ([#349](https://github.com/databricks/databricks-sdk-go/pull/349)).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Databricks SDK for Go includes functionality to accelerate development with 
 
     go 1.18
 
-    require github.com/databricks/databricks-sdk-go v0.6.0
+    require github.com/databricks/databricks-sdk-go v0.7.0
 
     // Indirect dependencies will go here.
     ```

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -146,16 +146,13 @@ func makeMsiRequest(req *http.Request) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("token parse: %w", err)
 	}
-
 	if token.AccessToken == "" {
 		return nil, fmt.Errorf("token parse: invalid token")
 	}
-
 	epoch, err := token.ExpiresOn.Int64()
 	if err != nil {
 		return nil, fmt.Errorf("token expires on: %w", err)
 	}
-
 	return &oauth2.Token{
 		TokenType:   token.TokenType,
 		AccessToken: token.AccessToken,

--- a/config/auth_default.go
+++ b/config/auth_default.go
@@ -11,11 +11,11 @@ import (
 
 var (
 	authProviders = []CredentialsProvider{
-		MetadataServiceCredentials{},
 		PatCredentials{},
 		BasicCredentials{},
 		M2mCredentials{},
 		BricksCliCredentials{},
+		MetadataServiceCredentials{},
 
 		// Attempt to configure auth from most specific to most generic (the Azure CLI).
 		AzureMsiCredentials{},

--- a/config/auth_metadata_service.go
+++ b/config/auth_metadata_service.go
@@ -47,31 +47,25 @@ func (c MetadataServiceCredentials) Configure(ctx context.Context, cfg *Config) 
 	if cfg.MetadataServiceURL == "" || cfg.Host == "" {
 		return nil, nil
 	}
-
 	parsedMetadataServiceURL, err := url.Parse(cfg.MetadataServiceURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid auth server URL: %w", err)
 	}
-
 	// only allow localhost URLs
 	if parsedMetadataServiceURL.Hostname() != "localhost" && parsedMetadataServiceURL.Hostname() != "127.0.0.1" {
 		return nil, fmt.Errorf("invalid auth server URL: %s", cfg.MetadataServiceURL)
 	}
-
 	ms := metadataService{
 		metadataServiceURL: parsedMetadataServiceURL,
 		config:             cfg,
 	}
-
 	response, err := ms.Get()
 	if err != nil {
 		return nil, err
 	}
-
 	if response == nil {
 		return nil, nil
 	}
-
 	return refreshableVisitor(&ms), nil
 }
 
@@ -84,29 +78,25 @@ type metadataService struct {
 func (s metadataService) Get() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), metadataServiceTimeout)
 	defer cancel()
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.metadataServiceURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("token request: %w", err)
 	}
-
 	req.Header.Add(MetadataServiceVersionHeader, MetadataServiceVersion)
 	req.Header.Add(MetadataServiceHostHeader, s.config.Host)
-
 	return makeMsiRequest(req)
 }
 
 func (t metadataService) Token() (*oauth2.Token, error) {
 	token, err := t.Get()
-
 	if err != nil {
 		return nil, err
 	}
 	if token == nil {
 		return nil, fmt.Errorf("no token returned from metadata service")
 	}
-
-	logger.Infof(context.Background(), "Refreshed access token from local metadata service, which expires on %s", token.Expiry.Format(time.RFC3339))
-
+	logger.Debugf(context.Background(),
+		"Refreshed access token from local metadata service, which expires on %s",
+		token.Expiry.Format(time.RFC3339))
 	return token, nil
 }

--- a/internal/scim_test.go
+++ b/internal/scim_test.go
@@ -91,8 +91,9 @@ func TestAccGroups(t *testing.T) {
 
 	// list all groups that start with `go-sdk-`
 	namesToIds, err := w.Groups.GroupDisplayNameToIdMap(ctx, scim.ListGroupsRequest{
-		SortOrder: scim.ListSortOrderDescending,
-		Filter:    "displayName sw 'go-sdk-'",
+		SortOrder:          scim.ListSortOrderDescending,
+		ExcludedAttributes: "roles",
+		Filter:             "displayName sw 'go-sdk-'",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, group.Id, namesToIds[group.DisplayName])

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version of the SDK, updated manually before every tag
-const Version = "0.6.0"
+const Version = "0.7.0"


### PR DESCRIPTION
# Version changelog

## 0.7.0

 * Update from OpenAPI ([#359](https://github.com/databricks/databricks-sdk-go/pull/359)).
 * Experimental credentials provider via local server ([#340](https://github.com/databricks/databricks-sdk-go/pull/340)).
 * Added `isTesting` marker to support `ResourceFixture` in Terraform ([#358](https://github.com/databricks/databricks-sdk-go/pull/358)).

Dependency updates:
 
 * Bump golang.org/x/mod from 0.9.0 to 0.10.0 ([#356](https://github.com/databricks/databricks-sdk-go/pull/356)).
 * Bump google.golang.org/api from 0.114.0 to 0.115.0 ([#357](https://github.com/databricks/databricks-sdk-go/pull/357)).
