### PR TITLE
Skip loading default profile if host is already configured

### DIFF
--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -254,6 +254,17 @@ func TestConfig_ConfigFile(t *testing.T) {
 	}.apply(t)
 }
 
+func TestConfig_ConfigFileSkipDefaultProfileIfHostSpecified(t *testing.T) {
+	configFixture{
+		Host: "https://dbc-XXXXXXXX-YYYY.cloud.databricks.com",
+		Env: map[string]string{
+			// This directory has a DEFAULT profile in databrickscfg
+			"HOME": "testdata",
+		},
+		AssertError: "default auth: cannot configure default credentials. Config: host=https://dbc-XXXXXXXX-YYYY.cloud.databricks.com",
+	}.apply(t)
+}
+
 func TestConfig_PatFromDatabricksCfg(t *testing.T) {
 	configFixture{
 		// loading with DEFAULT profile in databrickscfs

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -256,12 +256,12 @@ func TestConfig_ConfigFile(t *testing.T) {
 
 func TestConfig_ConfigFileSkipDefaultProfileIfHostSpecified(t *testing.T) {
 	configFixture{
-		Host: "https://dbc-XXXXXXXX-YYYY.cloud.databricks.com",
+		Host: "x",
 		Env: map[string]string{
 			// This directory has a DEFAULT profile in databrickscfg
 			"HOME": "testdata",
 		},
-		AssertError: "default auth: cannot configure default credentials. Config: host=https://dbc-XXXXXXXX-YYYY.cloud.databricks.com",
+		AssertError: "default auth: cannot configure default credentials. Config: host=https://x",
 	}.apply(t)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -150,7 +150,7 @@ func (c *Config) IsGcp() bool {
 
 // IsAws returns if the client is configured for Databricks on AWS.
 func (c *Config) IsAws() bool {
-	return strings.Contains(c.Host, ".databricks.com") && !c.IsAzure() && !c.IsGcp()
+	return c.Host != "" && !c.IsAzure() && !c.IsGcp()
 }
 
 // IsAccountClient returns true if client is configured for Accounts API

--- a/config/config.go
+++ b/config/config.go
@@ -134,7 +134,7 @@ func (c *Config) Authenticate(r *http.Request) error {
 	return c.auth(r)
 }
 
-// IsAzure returns true if client is configured for Azure Databricks
+// IsAzure returns if the client is configured for Azure Databricks.
 func (c *Config) IsAzure() bool {
 	isAzureHost := strings.Contains(c.Host, ".azuredatabricks.net") ||
 		strings.Contains(c.Host, "databricks.azure.cn") ||
@@ -143,14 +143,14 @@ func (c *Config) IsAzure() bool {
 	return isAzureHost || c.AzureResourceID != ""
 }
 
-// IsGcp returns true if client is configured for GCP
+// IsGcp returns if the client is configured for Databricks on Google Cloud.
 func (c *Config) IsGcp() bool {
 	return strings.Contains(c.Host, ".gcp.databricks.com")
 }
 
-// IsAws returns true if client is configured for AWS
+// IsAws returns if the client is configured for Databricks on AWS.
 func (c *Config) IsAws() bool {
-	return !c.IsAzure() && !c.IsGcp()
+	return strings.Contains(c.Host, ".databricks.com") && !c.IsAzure() && !c.IsGcp()
 }
 
 // IsAccountClient returns true if client is configured for Accounts API

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -65,7 +65,7 @@ func (l configFileLoader) Configure(cfg *Config) error {
 	// Skip loading config file if some authentication is already explicitly
 	// configured directly in the config by a user.
 	// See: https://github.com/databricks/databricks-sdk-go/issues/304
-	if cfg.Profile == "" && (l.isAnyAuthConfigured(cfg) || cfg.IsAzure()) {
+	if cfg.Profile == "" && (l.isAnyAuthConfigured(cfg) || cfg.IsAws() || cfg.IsAzure() || cfg.IsGcp()) {
 		return nil
 	}
 

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -65,7 +65,7 @@ func (l configFileLoader) Configure(cfg *Config) error {
 	// Skip loading config file if some authentication is already explicitly
 	// configured directly in the config by a user.
 	// See: https://github.com/databricks/databricks-sdk-go/issues/304
-	if cfg.Profile == "" && (l.isAnyAuthConfigured(cfg) || cfg.IsAws() || cfg.IsAzure() || cfg.IsGcp()) {
+	if cfg.Profile == "" && (l.isAnyAuthConfigured(cfg) || cfg.Host != "" || cfg.AzureResourceID != "") {
 		return nil
 	}
 


### PR DESCRIPTION
## Changes

If a user specified a host to connect to without authentication details (either directly or via the `DATABRICKS_HOST` environment variable), the config file loader would load the profile named `DEFAULT` from the config file and overwrite whatever was already configured. This means it was possible to configure the host of workspace A and end up connecting to workspace B (if configured as `DEFAULT` profile in the config file). This PR prevents this behavior.

Also see https://github.com/databricks/databricks-sdk-go/issues/304.

## Tests

- Added unit tests.
- Confirmed behavior with manual test.