### PR TITLE
Body logger for non-JSON payload as well

### DIFF
--- a/client/body_logger.go
+++ b/client/body_logger.go
@@ -107,7 +107,8 @@ func (b bodyLogger) redactedDump(prefix string, body []byte) string {
 	err := json.Unmarshal(body, &tmp)
 	if err != nil {
 		// Unable to unmarshal means the body isn't JSON.
-		return fmt.Sprintf("[non-JSON document of %d bytes]", len(body))
+		return fmt.Sprintf("[non-JSON document of %d bytes]. %s", len(body),
+			onlyNBytes(string(body), b.debugTruncateBytes))
 	}
 
 	maxBytes := b.maxBytes

--- a/client/body_logger_test.go
+++ b/client/body_logger_test.go
@@ -63,3 +63,8 @@ func TestBodyLoggerEmpty(t *testing.T) {
 	dump := bodyLogger{}.redactedDump("", []byte(""))
 	assert.Empty(t, dump)
 }
+
+func TestBodyLoggerNotJson(t *testing.T) {
+	dump := bodyLogger{debugTruncateBytes: 10}.redactedDump("", []byte("<html>"))
+	assert.Equal(t, dump, "[non-JSON document of 6 bytes]. <html>")
+}


### PR DESCRIPTION
## Changes

When debugging problems, like, private link (that doesn't return JSON, but HTML message), etc., it's crucial to get correct error in case when non-JSON payload is returned.  This PR adds the logging of non-JSON payload as well

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

