### PR TITLE
Cleanup ephemeral groups in integration tests

### DIFF
--- a/internal/permissions_test.go
+++ b/internal/permissions_test.go
@@ -34,6 +34,10 @@ func TestAccGenericPermissions(t *testing.T) {
 		DisplayName: RandomName("go-sdk-"),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.Groups.DeleteById(ctx, group.Id)
+		require.NoError(t, err)
+	})
 
 	err = w.Permissions.Set(ctx, permissions.PermissionsRequest{
 		RequestObjectType: "notebooks",

--- a/internal/scim_test.go
+++ b/internal/scim_test.go
@@ -81,7 +81,7 @@ func TestAccGroups(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := w.Groups.DeleteById(ctx, group.Id)
-		require.NoError(t, err)
+		require.True(t, err == nil || apierr.IsMissing(err))
 	})
 
 	// fetch the group we've just created

--- a/internal/scim_test.go
+++ b/internal/scim_test.go
@@ -79,6 +79,10 @@ func TestAccGroups(t *testing.T) {
 		DisplayName: RandomName("go-sdk-"),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := w.Groups.DeleteById(ctx, group.Id)
+		require.NoError(t, err)
+	})
 
 	// fetch the group we've just created
 	fetch, err := w.Groups.GetById(ctx, group.Id)

--- a/internal/secrets_test.go
+++ b/internal/secrets_test.go
@@ -45,9 +45,13 @@ func TestAccSecrets(t *testing.T) {
 	assert.True(t, len(scrts.Secrets) == 1)
 
 	group, err := w.Groups.Create(ctx, scim.Group{
-		DisplayName: RandomName("sdk-go-secret-managers"),
+		DisplayName: RandomName("go-sdk-"),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = w.Groups.DeleteById(ctx, group.Id)
+		require.NoError(t, err)
+	})
 
 	err = w.Secrets.PutAcl(ctx, secrets.PutAcl{
 		Scope:      scope.Scope,


### PR DESCRIPTION
## Changes

These tests left groups around that had to be removed manually/separately.

## Tests

Manually ran changed integration tests.