### PR TITLE
Added more code generation utilities

### DIFF
--- a/openapi/code/named.go
+++ b/openapi/code/named.go
@@ -197,6 +197,18 @@ func (n *Named) AbbrName() string {
 	return string(abbr)
 }
 
+// TrimPrefix returns *Named, but with a prefix trimmed from CamelName()
+//
+// Example:
+//
+//	(&Named{Name: "AccountMetastoreAssigment"}).TrimPrefix("account").CamelName() == "metastoreAssignment"
+func (n *Named) TrimPrefix(prefix string) *Named {
+	return &Named{
+		Name:        strings.TrimPrefix(n.CamelName(), prefix),
+		Description: n.Description,
+	}
+}
+
 func (n *Named) HasComment() bool {
 	return n.Description != ""
 }

--- a/openapi/code/tmpl_util_funcs.go
+++ b/openapi/code/tmpl_util_funcs.go
@@ -2,6 +2,7 @@ package code
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -49,5 +50,28 @@ var HelperFuncs = template.FuncMap{
 	},
 	"list": func(l ...any) []any {
 		return l
+	},
+	"dict": func(args ...any) map[string]any {
+		if len(args)%2 != 0 {
+			panic("number of arguments to dict is not even")
+		}
+		result := map[string]any{}
+		for i := 0; i < len(args); i += 2 {
+			k := fmt.Sprint(args[i])
+			v := args[i+1]
+			result[k] = v
+		}
+		return result
+	},
+	"getOrDefault": func(dict map[string]any, key string, def any) any {
+		v, ok := dict[key]
+		if ok {
+			return v
+		}
+		return def
+	},
+	"fmt": fmt.Sprintf,
+	"concat": func(v ...string) string {
+		return strings.Join(v, "")
 	},
 }

--- a/openapi/code/wait.go
+++ b/openapi/code/wait.go
@@ -55,6 +55,7 @@ func (w *Wait) Binding() (binding []Binding) {
 			})
 		}
 		// ensure generated code is deterministic
+		// Java SDK relies on bind parameter order.
 		slices.SortFunc(binding, func(a, b Binding) bool {
 			return a.PollField.Name < b.PollField.Name
 		})
@@ -156,6 +157,15 @@ func (w *Wait) MessagePath() (path []*Field) {
 		current = field.Entity
 	}
 	return path
+}
+
+func (w *Wait) Status() *Field {
+	path := w.StatusPath()
+	if path == nil {
+		// unreachable
+		return nil
+	}
+	return path[len(path)-1]
 }
 
 func (w *Wait) ComplexMessagePath() bool {


### PR DESCRIPTION
## Changes

- added `dict "k" "v" "k2" "v2"` function to construct `map[string]string{"k": "v", "k2": "v2"}`
- added `getOrDefault $dict "default value"`
- added `fmt` as template alias for `fmt.Sprintf`
- added `concat "a" "b" "c"` to join strings to "abc"
- added `TrimPrefix` on `*Named` to `(.TrimPrefix "account").CamelName`

## Tests

- [ ] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

