### PR TITLE
Remove dead code from apierr/errors.go

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -157,11 +157,6 @@ func parseErrorFromResponse(resp *http.Response, body []byte, err error) *APIErr
 		errorBody.Message = strings.Trim(errorBody.Message, " ")
 		errorBody.ErrorCode = fmt.Sprintf("SCIM_%s", errorBody.ScimStatus)
 	}
-	// if resp.StatusCode == 403 {
-	// 	errorBody.Message = fmt.Sprintf("%s. Using %s auth: %s",
-	// 		strings.Trim(errorBody.Message, "."), c.AuthType,
-	// 		c.configDebugString())
-	// }
 	return &APIError{
 		Message:    errorBody.Message,
 		ErrorCode:  errorBody.ErrorCode,


### PR DESCRIPTION
## Changes
Remove commented code from the error retry pathway. This is no longer needed and isn't included in any other SDKs.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

