### PR TITLE
Fix mlflow acceptance tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -215,7 +215,7 @@ func (c *Config) authenticateIfNeeded(ctx context.Context) error {
 	if c.Credentials == nil {
 		c.Credentials = &DefaultCredentials{}
 	}
-	c.fixHostIfNeeded()
+	c.FixHostIfNeeded()
 	visitor, err := c.Credentials.Configure(ctx, c)
 	if err != nil {
 		return c.wrapDebug(fmt.Errorf("%s auth: %w", c.Credentials.Name(), err))
@@ -225,12 +225,12 @@ func (c *Config) authenticateIfNeeded(ctx context.Context) error {
 	}
 	c.auth = visitor
 	c.AuthType = c.Credentials.Name()
-	c.fixHostIfNeeded()
+	c.FixHostIfNeeded()
 	// TODO: error customization
 	return nil
 }
 
-func (c *Config) fixHostIfNeeded() error {
+func (c *Config) FixHostIfNeeded() error {
 	// Nothing to fix if the host isn't set.
 	if c.Host == "" {
 		return nil

--- a/config/config.go
+++ b/config/config.go
@@ -194,6 +194,11 @@ func (c *Config) WithTesting() *Config {
 	return c
 }
 
+func (c *Config) CanonicalHostName() string {
+	c.fixHostIfNeeded()
+	return c.Host
+}
+
 func (c *Config) wrapDebug(err error) error {
 	debug := ConfigAttributes.DebugString(c)
 	if debug == "" {
@@ -215,7 +220,7 @@ func (c *Config) authenticateIfNeeded(ctx context.Context) error {
 	if c.Credentials == nil {
 		c.Credentials = &DefaultCredentials{}
 	}
-	c.FixHostIfNeeded()
+	c.fixHostIfNeeded()
 	visitor, err := c.Credentials.Configure(ctx, c)
 	if err != nil {
 		return c.wrapDebug(fmt.Errorf("%s auth: %w", c.Credentials.Name(), err))
@@ -225,12 +230,12 @@ func (c *Config) authenticateIfNeeded(ctx context.Context) error {
 	}
 	c.auth = visitor
 	c.AuthType = c.Credentials.Name()
-	c.FixHostIfNeeded()
+	c.fixHostIfNeeded()
 	// TODO: error customization
 	return nil
 }
 
-func (c *Config) FixHostIfNeeded() error {
+func (c *Config) fixHostIfNeeded() error {
 	// Nothing to fix if the host isn't set.
 	if c.Host == "" {
 		return nil

--- a/internal/mlflow_test.go
+++ b/internal/mlflow_test.go
@@ -132,12 +132,11 @@ func deleteModel(t *testing.T, w *databricks.WorkspaceClient, ctx context.Contex
 
 func TestAccRegistryWebhooks(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	w.Config.FixHostIfNeeded()
 	created, err := w.ModelRegistry.CreateWebhook(ctx, ml.CreateRegistryWebhook{
 		Description: RandomName("comment "),
 		Events:      []ml.RegistryWebhookEvent{ml.RegistryWebhookEventModelVersionCreated},
 		HttpUrlSpec: &ml.HttpUrlSpec{
-			Url: w.Config.Host,
+			Url: w.Config.CanonicalHostName(),
 		},
 	})
 	require.NoError(t, err)

--- a/internal/mlflow_test.go
+++ b/internal/mlflow_test.go
@@ -132,7 +132,7 @@ func deleteModel(t *testing.T, w *databricks.WorkspaceClient, ctx context.Contex
 
 func TestAccRegistryWebhooks(t *testing.T) {
 	ctx, w := workspaceTest(t)
-
+	w.Config.FixHostIfNeeded()
 	created, err := w.ModelRegistry.CreateWebhook(ctx, ml.CreateRegistryWebhook{
 		Description: RandomName("comment "),
 		Events:      []ml.RegistryWebhookEvent{ml.RegistryWebhookEventModelVersionCreated},


### PR DESCRIPTION
## Changes
* Fix `TestAccClustersApiIntegration` acceptance test for mlflow on azure.

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

