### PR TITLE
Serialize params to request body on delete

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -324,6 +324,10 @@ func serializeQueryParamsToRequestBody(data any) ([]byte, error) {
 	m := make(map[string]any)
 	rv := reflect.ValueOf(data)
 	rt := reflect.TypeOf(data)
+	// If data is a map, just serialize it to JSON.
+	if rv.Kind() == reflect.Map {
+		return json.MarshalIndent(data, "", "  ")
+	}
 	for i := 0; i < rv.NumField(); i++ {
 		field := rv.Field(i)
 		tag := rt.Field(i).Tag.Get("url")
@@ -348,8 +352,8 @@ var requestInBodyOverrides = []struct {
 	urlRegexp  *regexp.Regexp
 	serializer serializer
 }{
-	{"DELETE", regexp.MustCompile("/api/2.1/unity-catalog/(metastores|catalogs)/[^/]+"), serializeQueryParamsToRequestBody},
-	{"DELETE", regexp.MustCompile("/api/2.1/unity-catalog/workspaces/[^/]+/(metastore|catalog)"), serializeQueryParamsToRequestBody},
+	{"DELETE", regexp.MustCompile("(/api/2.1)?/unity-catalog/(metastores|catalogs)/[^/]+"), serializeQueryParamsToRequestBody},
+	{"DELETE", regexp.MustCompile("(/api/2.1)?/unity-catalog/workspaces/[^/]+/(metastore|catalog)"), serializeQueryParamsToRequestBody},
 }
 
 func getRequestCustomSerializer(method string, requestURL *string) serializer {

--- a/client/client.go
+++ b/client/client.go
@@ -321,7 +321,7 @@ func makeQueryString(data interface{}) (string, error) {
 type serializer func(any) ([]byte, error)
 
 func serializeQueryParamsToRequestBody(data any) ([]byte, error) {
-	m := make(map[string]any)
+	m := map[string]any{}
 	rv := reflect.ValueOf(data)
 	rt := reflect.TypeOf(data)
 	// If data is a map, just serialize it to JSON.
@@ -335,7 +335,7 @@ func serializeQueryParamsToRequestBody(data any) ([]byte, error) {
 			continue
 		}
 		value := field.Interface()
-		if reflect.DeepEqual(value, reflect.Zero(field.Type()).Interface()) {
+		if field.IsZero() {
 			continue
 		}
 		key := strings.Split(tag, ",")[0]

--- a/client/client.go
+++ b/client/client.go
@@ -321,7 +321,7 @@ func makeRequestBody(method string, requestURL *string, data interface{}) ([]byt
 	if data == nil && (method == "DELETE" || method == "GET") {
 		return requestBody, nil
 	}
-	if method == "GET" || method == "DELETE" {
+	if method == "GET" {
 		qs, err := makeQueryString(data)
 		if err != nil {
 			return nil, err

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -143,11 +143,10 @@ func TestUcAccCatalogs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		deleteCatalogRequest := catalog.DeleteCatalogRequest{
+		err := w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{
 			Name:  created.Name,
 			Force: true,
-		}
-		err := w.Catalogs.Delete(ctx, deleteCatalogRequest)
+		})
 		require.NoError(t, err)
 	})
 
@@ -173,11 +172,10 @@ func TestUcAccSchemas(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		deleteCatalogRequest := catalog.DeleteCatalogRequest{
+		err := w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{
 			Name:  newCatalog.Name,
 			Force: true,
-		}
-		err := w.Catalogs.Delete(ctx, deleteCatalogRequest)
+		})
 		require.NoError(t, err)
 	})
 

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -92,7 +92,6 @@ func TestUcAccExternalLocations(t *testing.T) {
 }
 
 func TestUcAccMetastores(t *testing.T) {
-	t.Skip("metastore force delete doesn't work yet")
 	ctx, w := ucwsTest(t)
 	created, err := w.Metastores.Create(ctx, catalog.CreateMetastore{
 		Name:        RandomName("go-sdk-"),
@@ -122,7 +121,6 @@ func TestUcAccMetastores(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// TODO: Fix once APP-1331 is implemented
 	err = w.Metastores.Unassign(ctx, catalog.UnassignRequest{
 		MetastoreId: created.MetastoreId,
 		WorkspaceId: GetEnvInt64OrSkipTest(t, "TEST_WORKSPACE_ID"),
@@ -138,7 +136,6 @@ func TestUcAccMetastores(t *testing.T) {
 }
 
 func TestUcAccCatalogs(t *testing.T) {
-	t.Skip("needs force delete")
 	ctx, w := ucwsTest(t)
 
 	created, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
@@ -146,11 +143,18 @@ func TestUcAccCatalogs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		err := w.Catalogs.DeleteByName(ctx, created.Name)
+		deleteCatalogRequest := catalog.DeleteCatalogRequest{
+			Name:  created.Name,
+			Force: true,
+		}
+		err := w.Catalogs.Delete(ctx, deleteCatalogRequest)
 		require.NoError(t, err)
 	})
 
-	_, err = w.Catalogs.Update(ctx, catalog.UpdateCatalog{})
+	_, err = w.Catalogs.Update(ctx, catalog.UpdateCatalog{
+		Name:    created.Name,
+		Comment: "updated",
+	})
 	require.NoError(t, err)
 
 	_, err = w.Catalogs.GetByName(ctx, created.Name)
@@ -162,7 +166,6 @@ func TestUcAccCatalogs(t *testing.T) {
 }
 
 func TestUcAccSchemas(t *testing.T) {
-	t.Skip("needs force delete")
 	ctx, w := ucwsTest(t)
 
 	newCatalog, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
@@ -170,8 +173,11 @@ func TestUcAccSchemas(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		// TODO: force delete
-		err := w.Catalogs.DeleteByName(ctx, newCatalog.Name)
+		deleteCatalogRequest := catalog.DeleteCatalogRequest{
+			Name:  newCatalog.Name,
+			Force: true,
+		}
+		err := w.Catalogs.Delete(ctx, deleteCatalogRequest)
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
## Changes
This change was introduced in https://github.com/databricks/databricks-sdk-go/commit/0dc1944411cd611ef4a92bc6a10eac379500dc55#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L324, but it causes metastore deletion to fail.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [x] TestUcAccMetastores, TestUcAccCatalogs, and TestUcAccSchemas all pass after this change.
- [x] TestUcAccMetastoreAssignment and TestUcAccCreateRecipientDb2DbAws from terraform-provider-databricks are passing after this change.