### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Version changelog
 
+## 0.9.0
+
+ * Added more usage examples for `go doc` and Go Packages ([#389](https://github.com/databricks/databricks-sdk-go/pull/389)).
+ * Make u2m authentication work with new CLI ([#394](https://github.com/databricks/databricks-sdk-go/pull/394)).
+ * Update from OpenAPI spec (19 may) ([#390](https://github.com/databricks/databricks-sdk-go/pull/390)).
+
+Dependency updates:
+
+ * Bump github.com/stretchr/testify from 1.8.2 to 1.8.3 ([#393](https://github.com/databricks/databricks-sdk-go/pull/393)).
+ * Bump google.golang.org/api from 0.122.0 to 0.123.0 ([#392](https://github.com/databricks/databricks-sdk-go/pull/392)).
+
 ## 0.8.1
 
  * Added `in` codegen function ([#387](https://github.com/databricks/databricks-sdk-go/pull/387)).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Databricks SDK for Go
 
 **Stability**: [Experimental](https://docs.databricks.com/release-notes/release-types.html)
+| See documentation at [Go Packages](https://pkg.go.dev/github.com/databricks/databricks-sdk-go)
+| See also the [Terraform Provider](https://github.com/databricks/terraform-provider-databricks)
+| See also the [SDK for Python](https://github.com/databricks/databricks-sdk-py) 
+| See also the [SDK for Java](https://github.com/databricks/databricks-sdk-java) 
 
 The Databricks SDK for Go includes functionality to accelerate development with [Go](https://go.dev) for the Databricks Lakehouse. It covers all public [Databricks REST API](https://docs.databricks.com/dev-tools/api/index.html) operations. The SDK's internal HTTP client is robust and handles failures on different levels by performing intelligent retries.
 
@@ -38,7 +42,7 @@ The Databricks SDK for Go includes functionality to accelerate development with 
 
     go 1.18
 
-    require github.com/databricks/databricks-sdk-go v0.7.0
+    require github.com/databricks/databricks-sdk-go v0.9.0
 
     // Indirect dependencies will go here.
     ```

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -189,14 +189,22 @@ func (m *Method) Pagination() *Pagination {
 			Bind:      m.Response.Field(m.pagination.Token.Response),
 		}
 	}
+	offset := m.Request.Field(m.pagination.Offset)
+	limit := m.Request.Field(m.pagination.Limit)
 	results := m.Response.Field(m.pagination.Results)
+	if results == nil {
+		panic(fmt.Errorf("invalid results field '%v': %s",
+			m.pagination.Results, m.operation.OperationId))
+	}
+	entity := results.Entity.ArrayValue
+	increment := m.pagination.Increment
 	return &Pagination{
 		Results:   results,
 		Token:     token,
-		Entity:    results.Entity.ArrayValue,
-		Offset:    m.Request.Field(m.pagination.Offset),
-		Limit:     m.Request.Field(m.pagination.Limit),
-		Increment: m.pagination.Increment,
+		Entity:    entity,
+		Offset:    offset,
+		Limit:     limit,
+		Increment: increment,
 	}
 }
 

--- a/service/catalog/api.go
+++ b/service/catalog/api.go
@@ -1765,7 +1765,7 @@ func (a *WorkspaceBindingsAPI) Impl() WorkspaceBindingsService {
 //
 // Gets workspace bindings of the catalog. The caller must be a metastore admin
 // or an owner of the catalog.
-func (a *WorkspaceBindingsAPI) Get(ctx context.Context, request GetWorkspaceBindingRequest) (*WorkspaceIds, error) {
+func (a *WorkspaceBindingsAPI) Get(ctx context.Context, request GetWorkspaceBindingRequest) (*CurrentWorkspaceBindings, error) {
 	return a.impl.Get(ctx, request)
 }
 
@@ -1773,7 +1773,7 @@ func (a *WorkspaceBindingsAPI) Get(ctx context.Context, request GetWorkspaceBind
 //
 // Gets workspace bindings of the catalog. The caller must be a metastore admin
 // or an owner of the catalog.
-func (a *WorkspaceBindingsAPI) GetByName(ctx context.Context, name string) (*WorkspaceIds, error) {
+func (a *WorkspaceBindingsAPI) GetByName(ctx context.Context, name string) (*CurrentWorkspaceBindings, error) {
 	return a.impl.Get(ctx, GetWorkspaceBindingRequest{
 		Name: name,
 	})
@@ -1783,6 +1783,6 @@ func (a *WorkspaceBindingsAPI) GetByName(ctx context.Context, name string) (*Wor
 //
 // Updates workspace bindings of the catalog. The caller must be a metastore
 // admin or an owner of the catalog.
-func (a *WorkspaceBindingsAPI) Update(ctx context.Context, request UpdateWorkspaceBindings) (*WorkspaceIds, error) {
+func (a *WorkspaceBindingsAPI) Update(ctx context.Context, request UpdateWorkspaceBindings) (*CurrentWorkspaceBindings, error) {
 	return a.impl.Update(ctx, request)
 }

--- a/service/catalog/catalogs_usage_test.go
+++ b/service/catalog/catalogs_usage_test.go
@@ -40,6 +40,33 @@ func ExampleCatalogsAPI_Create_catalogs() {
 
 }
 
+func ExampleCatalogsAPI_Create_catalogWorkspaceBindings() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	created, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
+
+	// cleanup
+
+	err = w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{
+		Name:  created.Name,
+		Force: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+}
+
 func ExampleCatalogsAPI_Create_schemas() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
@@ -132,6 +159,41 @@ func ExampleCatalogsAPI_Update_catalogs() {
 	_, err = w.Catalogs.Update(ctx, catalog.UpdateCatalog{
 		Name:    created.Name,
 		Comment: "updated",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// cleanup
+
+	err = w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{
+		Name:  created.Name,
+		Force: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+func ExampleCatalogsAPI_Update_catalogWorkspaceBindings() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	created, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
+
+	_, err = w.Catalogs.Update(ctx, catalog.UpdateCatalog{
+		Name:          created.Name,
+		IsolationMode: catalog.IsolationModeIsolated,
 	})
 	if err != nil {
 		panic(err)

--- a/service/catalog/impl.go
+++ b/service/catalog/impl.go
@@ -527,16 +527,16 @@ type workspaceBindingsImpl struct {
 	client *client.DatabricksClient
 }
 
-func (a *workspaceBindingsImpl) Get(ctx context.Context, request GetWorkspaceBindingRequest) (*WorkspaceIds, error) {
-	var workspaceIds WorkspaceIds
+func (a *workspaceBindingsImpl) Get(ctx context.Context, request GetWorkspaceBindingRequest) (*CurrentWorkspaceBindings, error) {
+	var currentWorkspaceBindings CurrentWorkspaceBindings
 	path := fmt.Sprintf("/api/2.1/unity-catalog/workspace-bindings/catalogs/%v", request.Name)
-	err := a.client.Do(ctx, http.MethodGet, path, request, &workspaceIds)
-	return &workspaceIds, err
+	err := a.client.Do(ctx, http.MethodGet, path, request, &currentWorkspaceBindings)
+	return &currentWorkspaceBindings, err
 }
 
-func (a *workspaceBindingsImpl) Update(ctx context.Context, request UpdateWorkspaceBindings) (*WorkspaceIds, error) {
-	var workspaceIds WorkspaceIds
+func (a *workspaceBindingsImpl) Update(ctx context.Context, request UpdateWorkspaceBindings) (*CurrentWorkspaceBindings, error) {
+	var currentWorkspaceBindings CurrentWorkspaceBindings
 	path := fmt.Sprintf("/api/2.1/unity-catalog/workspace-bindings/catalogs/%v", request.Name)
-	err := a.client.Do(ctx, http.MethodPatch, path, request, &workspaceIds)
-	return &workspaceIds, err
+	err := a.client.Do(ctx, http.MethodPatch, path, request, &currentWorkspaceBindings)
+	return &currentWorkspaceBindings, err
 }

--- a/service/catalog/interface.go
+++ b/service/catalog/interface.go
@@ -724,11 +724,11 @@ type WorkspaceBindingsService interface {
 	//
 	// Gets workspace bindings of the catalog. The caller must be a metastore
 	// admin or an owner of the catalog.
-	Get(ctx context.Context, request GetWorkspaceBindingRequest) (*WorkspaceIds, error)
+	Get(ctx context.Context, request GetWorkspaceBindingRequest) (*CurrentWorkspaceBindings, error)
 
 	// Update catalog workspace bindings.
 	//
 	// Updates workspace bindings of the catalog. The caller must be a metastore
 	// admin or an owner of the catalog.
-	Update(ctx context.Context, request UpdateWorkspaceBindings) (*WorkspaceIds, error)
+	Update(ctx context.Context, request UpdateWorkspaceBindings) (*CurrentWorkspaceBindings, error)
 }

--- a/service/catalog/model.go
+++ b/service/catalog/model.go
@@ -477,6 +477,12 @@ type CreateVolumeRequestContent struct {
 	VolumeType VolumeType `json:"volume_type"`
 }
 
+// Currently assigned workspaces
+type CurrentWorkspaceBindings struct {
+	// A list of workspace IDs.
+	Workspaces []int64 `json:"workspaces,omitempty"`
+}
+
 // Data source format
 type DataSourceFormat string
 
@@ -2000,11 +2006,11 @@ type UpdateVolumeRequestContent struct {
 
 type UpdateWorkspaceBindings struct {
 	// A list of workspace IDs.
-	AssignWorkspaces *WorkspaceIds `json:"assign_workspaces,omitempty"`
+	AssignWorkspaces []int64 `json:"assign_workspaces,omitempty"`
 	// The name of the catalog.
 	Name string `json:"-" url:"-"`
 	// A list of workspace IDs.
-	UnassignWorkspaces *WorkspaceIds `json:"unassign_workspaces,omitempty"`
+	UnassignWorkspaces []int64 `json:"unassign_workspaces,omitempty"`
 }
 
 type ValidateStorageCredential struct {
@@ -2158,9 +2164,4 @@ func (vt *VolumeType) Set(v string) error {
 // Type always returns VolumeType to satisfy [pflag.Value] interface
 func (vt *VolumeType) Type() string {
 	return "VolumeType"
-}
-
-// A list of workspace IDs.
-type WorkspaceIds struct {
-	Workspaces []int `json:"workspaces,omitempty"`
 }

--- a/service/catalog/workspace_bindings_usage_test.go
+++ b/service/catalog/workspace_bindings_usage_test.go
@@ -1,0 +1,92 @@
+// Code generated from Databricks SDK for Go integration tests by openapi.roll.TestRegenerateExamples. DO NOT EDIT.
+
+package catalog_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/logger"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+)
+
+func ExampleWorkspaceBindingsAPI_Get_catalogWorkspaceBindings() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	created, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
+
+	bindings, err := w.WorkspaceBindings.GetByName(ctx, created.Name)
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", bindings)
+
+	// cleanup
+
+	err = w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{
+		Name:  created.Name,
+		Force: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+func ExampleWorkspaceBindingsAPI_Update_catalogWorkspaceBindings() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	thisWorkspaceId := func(v string) int64 {
+		i, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("`%s` is not int64: %s", v, err))
+		}
+		return i
+	}(os.Getenv("THIS_WORKSPACE_ID"))
+
+	created, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
+
+	_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
+		Name:             created.Name,
+		AssignWorkspaces: []int64{thisWorkspaceId},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// cleanup
+
+	err = w.Catalogs.Delete(ctx, catalog.DeleteCatalogRequest{
+		Name:  created.Name,
+		Force: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+}

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -58,23 +58,6 @@ func ExampleModelRegistryAPI_CreateComment_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_models() {
-	ctx := context.Background()
-	w, err := databricks.NewWorkspaceClient()
-	if err != nil {
-		panic(err)
-	}
-
-	created, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
-		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", created)
-
-}
-
 func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
@@ -106,6 +89,23 @@ func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", model)
+
+}
+
+func ExampleModelRegistryAPI_CreateModel_models() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	created, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
 
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version of the SDK, updated manually before every tag
-const Version = "0.8.1"
+const Version = "0.9.0"


### PR DESCRIPTION
 * Added more usage examples for `go doc` and Go Packages ([#389](https://github.com/databricks/databricks-sdk-go/pull/389)).
 * Make OAuth work with new CLI ([#394](https://github.com/databricks/databricks-sdk-go/pull/394)).
 * Update from OpenAPI spec ([#390](https://github.com/databricks/databricks-sdk-go/pull/390)).

Dependency updates:

 * Bump github.com/stretchr/testify from 1.8.2 to 1.8.3 ([#393](https://github.com/databricks/databricks-sdk-go/pull/393)).
 * Bump google.golang.org/api from 0.122.0 to 0.123.0 ([#392](https://github.com/databricks/databricks-sdk-go/pull/392)).
