### PR TITLE
Fixed typo in delete a transition

### DIFF
--- a/service/ml/api.go
+++ b/service/ml/api.go
@@ -471,7 +471,7 @@ func (a *ModelRegistryAPI) DeleteModelVersionTag(ctx context.Context, request De
 	return a.impl.DeleteModelVersionTag(ctx, request)
 }
 
-// Delete a ransition request.
+// Delete a transition request.
 //
 // Cancels a model version stage transition request.
 func (a *ModelRegistryAPI) DeleteTransitionRequest(ctx context.Context, request DeleteTransitionRequestRequest) error {

--- a/service/ml/interface.go
+++ b/service/ml/interface.go
@@ -287,7 +287,7 @@ type ModelRegistryService interface {
 	// Deletes a model version tag.
 	DeleteModelVersionTag(ctx context.Context, request DeleteModelVersionTagRequest) error
 
-	// Delete a ransition request.
+	// Delete a transition request.
 	//
 	// Cancels a model version stage transition request.
 	DeleteTransitionRequest(ctx context.Context, request DeleteTransitionRequestRequest) error

--- a/service/ml/model.go
+++ b/service/ml/model.go
@@ -448,7 +448,7 @@ type DeleteTag struct {
 	RunId string `json:"run_id"`
 }
 
-// Delete a ransition request
+// Delete a transition request
 type DeleteTransitionRequestRequest struct {
 	// User-provided comment on the action.
 	Comment string `json:"-" url:"comment,omitempty"`


### PR DESCRIPTION
## Changes
Updated a typo in the repo


- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

