### PR TITLE
Fix cleanup logic in SQL warehouse integration test

### DIFF
--- a/internal/warehouses_test.go
+++ b/internal/warehouses_test.go
@@ -20,7 +20,7 @@ func TestAccSqlWarehouses(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_, err = w.Warehouses.DeleteByIdAndWait(ctx, created.Id)
+		err = w.Warehouses.DeleteById(ctx, created.Id)
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
## Changes

This was changed in #389 without testing.

The function `w.Warehouses.DeleteByIdAndWait` always fails because upon deletion there is nothing left to GET and it returns a 404 error. For the sake of test cleanup, we can issue the delete and move on without waiting.

## Tests

Ran TestAccSqlWarehouses manually to confirm this fixes the issue.