### PR TITLE
Do not use cached entities in code generation

### DIFF
--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -253,11 +253,6 @@ func (pkg *Package) definedEntity(name string, s *openapi.Schema) *Entity {
 		return pkg.define(entity)
 	}
 
-	component := pkg.localComponent(&s.Node)
-	if s.IsRef() && pkg.types[component] != nil {
-		// entity is defined, return from cache
-		return pkg.types[component]
-	}
 	e := pkg.schemaToEntity(s, []string{name}, true)
 	if e == nil {
 		// gets here when responses are objects with no properties
@@ -269,8 +264,7 @@ func (pkg *Package) definedEntity(name string, s *openapi.Schema) *Entity {
 	if e.Name == "" {
 		e.Named = Named{name, s.Description}
 	}
-	pkg.define(e)
-	return pkg.types[e.Name]
+	return pkg.define(e)
 }
 
 func (pkg *Package) define(entity *Entity) *Entity {


### PR DESCRIPTION
## Changes
Code generator stores the defined types (entities) in `pkg.types` field. This field is primarily used for keeping the list of all observed types while generating code.

But if we use the entity stored in this map and modify it in-place, for example, add that some field is required, it will change the entity stored.

If later one we use this "cached" version of entity, it will contain modified configuration which can lead to unexpected results, for example, `User` entity in `Users.create` operation will have `ID` field as required even though based on OpenAPI definition it is not.

Thus, it's better not to use cached entities.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied

