### PR TITLE
Introduce waiters as top-level methods

### DIFF
--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -40,7 +40,7 @@ func (a *{{.PascalName}}API) Impl() {{.PascalName}}Service {
 }
 
 {{range .Waits}}
-// {{.PascalName}} calls [{{.Method.Service.Name}}API.{{.Method.PascalName}}] and waits to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
+// {{.PascalName}} repeatedly calls [{{.Method.Service.Name}}API.{{.Poll.PascalName}}] and waits to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
 func (a *{{.Method.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{range .Binding}}, {{.PollField.CamelName}} {{template "type" .PollField.Entity}}{{end}},
 	timeout time.Duration, callback func(*{{.Poll.Response.PascalName}})) (*{{.Poll.Response.PascalName}}, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -82,8 +82,8 @@ func (a *{{.Method.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{
 
 // {{.PascalName}} is a wrapper that calls [{{.Method.Service.Name}}API.{{.PascalName}}] and waits to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state.
 type {{.PascalName}}[R any] struct {
-	Response *R
-
+	Response *R{{range .Binding}}
+	{{.PollField.PascalName}} {{template "type" .PollField.Entity}} `json:"{{.PollField.Name}}"`{{end}}
 	poll     func(time.Duration, func(*{{.Poll.Response.PascalName}})) (*{{.Poll.Response.PascalName}}, error)
 	callback func(*{{.Poll.Response.PascalName}})
 	timeout  time.Duration
@@ -117,7 +117,8 @@ func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Re
 	}
 	return &{{.Wait.PascalName}}{{with .Response}}[{{.PascalName}}]{{else}}[any]{{end}}{
 		{{with .Response}}Response: {{.CamelName}},
-		{{- end}}
+		{{- end}}{{range .Wait.Binding}}
+		{{.PollField.PascalName}}: {{.Bind.Of.CamelName}}.{{.Bind.PascalName}},{{end}}
 		poll: func(timeout time.Duration, callback func(*{{.Wait.Poll.Response.PascalName}})) (*{{.Wait.Poll.Response.PascalName}}, error) {
 			return a.{{.Wait.PascalName}}(ctx{{range .Wait.Binding}}, {{.Bind.Of.CamelName}}.{{.Bind.PascalName}}{{end}}, timeout, callback)
 		},

--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -39,64 +39,119 @@ func (a *{{.PascalName}}API) Impl() {{.PascalName}}Service {
 	return a.impl
 }
 
-{{range .Methods}}{{if not .Pagination}}{{.Comment "// " 80}}
-func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Request}}, request {{.Request.PascalName}}{{end}}) {{if .Response}}({{if .Response.ArrayValue}}[]{{.Response.ArrayValue.PascalName}}{{else}}*{{template "type" .Response}}{{end}}, error){{else}}error{{end}} {
-	return a.impl.{{.PascalName}}(ctx{{if .Request}}, request{{end}})
-}
-{{end}}
-
-{{if .Wait}}
-// Calls [{{.Service.Name}}API.{{.PascalName}}] and waits to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
-// 
-// You can override the default timeout of {{.Wait.Timeout}} minutes by calling adding 
-// retries.Timeout[{{.Wait.Poll.Response.PascalName}}](60*time.Minute) functional option.
-func (a *{{.Service.Name}}API) {{.PascalName}}AndWait(ctx context.Context{{if .Request}}, {{.Request.CamelName}} {{.Request.PascalName}}{{end}}, options ...retries.Option[{{.Wait.Poll.Response.PascalName}}]) (*{{.Wait.Poll.Response.PascalName}}, error) {
+{{range .Waits}}
+// {{.PascalName}} calls [{{.Method.Service.Name}}API.{{.Method.PascalName}}] and waits to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
+func (a *{{.Method.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{range .Binding}}, {{.PollField.CamelName}} {{template "type" .PollField.Entity}}{{end}},
+	timeout time.Duration, callback func(*{{.Poll.Response.PascalName}})) (*{{.Poll.Response.PascalName}}, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	{{if .Wait.ForceBindRequest}}_, {{else if .Response}}{{.Response.CamelName}}, {{end}}err := a.{{.PascalName}}(ctx{{if .Request}}, {{.Request.CamelName}}{{end}})
-	if err != nil {
-		return nil, err
-	}
-	i := retries.Info[{{.Wait.Poll.Response.PascalName}}]{Timeout: {{.Wait.Timeout}}*time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[{{.Wait.Poll.Response.PascalName}}](ctx, i.Timeout, func() (*{{.Wait.Poll.Response.PascalName}}, *retries.Err) {
-		{{.Wait.Poll.Response.CamelName}}, err := a.{{.Wait.Poll.PascalName}}(ctx, {{.Wait.Poll.Request.PascalName}}{ {{range .Wait.Binding}}
-			{{.PollField.PascalName}}: {{.Bind.Of.CamelName}}.{{.Bind.PascalName}},{{end}}
+	return retries.Poll[{{.Poll.Response.PascalName}}](ctx, timeout, func() (*{{.Poll.Response.PascalName}}, *retries.Err) {
+		{{.Poll.Response.CamelName}}, err := a.{{.Poll.PascalName}}(ctx, {{.Poll.Request.PascalName}}{ {{range .Binding}}
+			{{.PollField.PascalName}}: {{.PollField.CamelName}},{{end}}
 		})
 		if err != nil {
 			return nil, retries.Halt(err)
 		}
-		for _, o := range options {
-			o(&retries.Info[{{.Wait.Poll.Response.PascalName}}]{
-				Info: {{.Wait.Poll.Response.CamelName}},
-				Timeout: i.Timeout,
-			})
+		if callback != nil {
+			callback({{.Poll.Response.CamelName}})
 		}
-		status := {{.Wait.Poll.Response.CamelName}}{{range .Wait.StatusPath}}.{{.PascalName}}{{end}}
-		{{if .Wait.MessagePath -}}
-		{{if .Wait.ComplexMessagePath -}}
+		status := {{.Poll.Response.CamelName}}{{range .StatusPath}}.{{.PascalName}}{{end}}
+		{{if .MessagePath -}}
+		{{if .ComplexMessagePath -}}
 		statusMessage := fmt.Sprintf("current status: %s", status)
-		if ({{.Wait.Poll.Response.CamelName}}.{{.Wait.MessagePathHead.PascalName}} != nil) {
-			statusMessage = {{.Wait.Poll.Response.CamelName}}{{range .Wait.MessagePath}}.{{.PascalName}}{{end}}
+		if ({{.Poll.Response.CamelName}}.{{.MessagePathHead.PascalName}} != nil) {
+			statusMessage = {{.Poll.Response.CamelName}}{{range .MessagePath}}.{{.PascalName}}{{end}}
 		}
 		{{- else -}}
-		statusMessage := {{.Wait.Poll.Response.CamelName}}{{range .Wait.MessagePath}}.{{.PascalName}}{{end}}
+		statusMessage := {{.Poll.Response.CamelName}}{{range .MessagePath}}.{{.PascalName}}{{end}}
 		{{- end}}
 		{{- else -}}
 		statusMessage := fmt.Sprintf("current status: %s", status)
 		{{- end}}
 		switch status {
-		case {{range $i, $e := .Wait.Success}}{{if $i}}, {{end}}{{$e.Entity.PascalName}}{{$e.PascalName}}{{end}}: // target state
-			return {{.Wait.Poll.Response.CamelName}}, nil
-		{{if .Wait.Failure}}case {{range $i, $e := .Wait.Failure}}{{if $i}}, {{end}}{{$e.Entity.PascalName}}{{$e.PascalName}}{{end}}:
-			err := fmt.Errorf("failed to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}%s{{end}}, got %s: %s",
-				{{range $i, $e := .Wait.Success}}{{if $i}}, {{end}}{{$e.Entity.PascalName}}{{$e.PascalName}}{{end}}, status, statusMessage)
+		case {{range $i, $e := .Success}}{{if $i}}, {{end}}{{$e.Entity.PascalName}}{{$e.PascalName}}{{end}}: // target state
+			return {{.Poll.Response.CamelName}}, nil
+		{{if .Failure}}case {{range $i, $e := .Failure}}{{if $i}}, {{end}}{{$e.Entity.PascalName}}{{$e.PascalName}}{{end}}:
+			err := fmt.Errorf("failed to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}%s{{end}}, got %s: %s",
+				{{range $i, $e := .Success}}{{if $i}}, {{end}}{{$e.Entity.PascalName}}{{$e.PascalName}}{{end}}, status, statusMessage)
 			return nil, retries.Halt(err)
 		{{end}}default:
 			return nil, retries.Continues(statusMessage)
 		}
 	})
+}
+
+// {{.PascalName}} is a wrapper that calls [{{.Method.Service.Name}}API.{{.PascalName}}] and waits to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state.
+type {{.PascalName}}[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*{{.Poll.Response.PascalName}})) (*{{.Poll.Response.PascalName}}, error)
+	callback func(*{{.Poll.Response.PascalName}})
+	timeout  time.Duration
+}
+
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *{{.PascalName}}[R]) OnProgress(callback func(*{{.Poll.Response.PascalName}})) *{{.PascalName}}[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the {{.Poll.Response.PascalName}} with the default timeout of {{.Timeout}} minutes.
+func (w *{{.PascalName}}[R]) Get() (*{{.Poll.Response.PascalName}}, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the {{.Poll.Response.PascalName}} with custom timeout.
+func (w *{{.PascalName}}[R]) GetWithTimeout(timeout time.Duration) (*{{.Poll.Response.PascalName}}, error) {
+	return w.poll(timeout, w.callback)
+}
+{{end}}
+
+{{range .Methods}}
+{{- $hasWaiter := and .Wait (and (not .IsCrudRead) (not (eq .SnakeName "get_run"))) -}}
+{{if not .Pagination}}{{.Comment "// " 80}}
+func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Request}}, {{if $hasWaiter}}{{.Request.CamelName}}{{else}}request{{end}} {{.Request.PascalName}}{{end}}) {{if $hasWaiter}}(*{{.Wait.PascalName}}{{with .Response}}[{{.PascalName}}]{{else}}[any]{{end}}, error){{else}}{{if .Response}}({{if .Response.ArrayValue}}[]{{.Response.ArrayValue.PascalName}}{{else}}*{{template "type" .Response}}{{end}}, error){{else}}error{{end}}{{end}} {
+	{{if $hasWaiter -}}
+	{{if .Response}}{{.Response.CamelName}}, {{end}}err := a.impl.{{.PascalName}}(ctx{{if .Request}}, {{.Request.CamelName}}{{end}})
+	if err != nil {
+		return nil, err
+	}
+	return &{{.Wait.PascalName}}{{with .Response}}[{{.PascalName}}]{{else}}[any]{{end}}{
+		{{with .Response}}Response: {{.CamelName}},
+		{{- end}}
+		poll: func(timeout time.Duration, callback func(*{{.Wait.Poll.Response.PascalName}})) (*{{.Wait.Poll.Response.PascalName}}, error) {
+			return a.{{.Wait.PascalName}}(ctx{{range .Wait.Binding}}, {{.Bind.Of.CamelName}}.{{.Bind.PascalName}}{{end}}, timeout, callback)
+		},
+		timeout: {{.Wait.Timeout}}*time.Minute,
+		callback: nil,
+	}, nil
+	{{- else -}}
+	return a.impl.{{.PascalName}}(ctx{{if .Request}}, request{{end}})
+	{{- end}}
+}
+{{end}}
+
+{{if $hasWaiter}}
+// Calls [{{.Service.Name}}API.{{.PascalName}}] and waits to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
+// 
+// You can override the default timeout of {{.Wait.Timeout}} minutes by calling adding 
+// retries.Timeout[{{.Wait.Poll.Response.PascalName}}](60*time.Minute) functional option.
+//
+// Deprecated: use [{{.Service.Name}}API.{{.PascalName}}].Get() or [{{.Service.Name}}API.{{.Wait.PascalName}}]
+func (a *{{.Service.Name}}API) {{.PascalName}}AndWait(ctx context.Context{{if .Request}}, {{.Request.CamelName}} {{.Request.PascalName}}{{end}}, options ...retries.Option[{{.Wait.Poll.Response.PascalName}}]) (*{{.Wait.Poll.Response.PascalName}}, error) {
+	wait, err := a.{{.PascalName}}(ctx{{if .Request}}, {{.Request.CamelName}}{{end}})
+	if err != nil {
+		return nil, err
+	}
+	wait.timeout = {{.Wait.Timeout}}*time.Minute
+	wait.callback = func(info *{{.Wait.Poll.Response.PascalName}}) {
+		for _, o := range options {
+			o(&retries.Info[{{.Wait.Poll.Response.PascalName}}]{
+				Info: info,
+				Timeout: wait.timeout,
+			})
+		}
+	}
+	return wait.Get()
 }
 {{end}}{{if .Pagination}}
 {{.Comment "// " 80}}
@@ -225,7 +280,7 @@ func (a *{{.Service.Name}}API) {{.Shortcut.PascalName}}(ctx context.Context{{ran
 		{{.PascalName}}: {{.CamelName}},{{end}}
 	})
 }
-{{end}}{{if and .Shortcut .Wait}}
+{{end}}{{if and .Shortcut $hasWaiter}}
 func (a *{{.Service.Name}}API) {{.Shortcut.PascalName}}AndWait(ctx context.Context{{range .Shortcut.Params}}, {{.CamelName}} {{template "type" .Entity}}{{end}}, options ...retries.Option[{{.Wait.Poll.Response.PascalName}}]) (*{{.Wait.Poll.Response.PascalName}}, error) {
 	return a.{{.PascalName}}AndWait(ctx, {{.Request.PascalName}}{
 		{{- range .Shortcut.Params}}

--- a/internal/jobs_test.go
+++ b/internal/jobs_test.go
@@ -89,13 +89,13 @@ func TestAccJobsApiFullIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	cancelledRun, err := w.Jobs.CancelRunAndWait(ctx, jobs.CancelRun{
-		RunId: runNowResponse.RunId,
+		RunId: runNowResponse.Response.RunId,
 	})
 	require.NoError(t, err)
 
 	repairedRun, err := w.Jobs.RepairRunAndWait(ctx, jobs.RepairRun{
 		RerunTasks: []string{cancelledRun.Tasks[0].TaskKey},
-		RunId:      runNowResponse.RunId,
+		RunId:      runNowResponse.Response.RunId,
 	})
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(repairedRun.Tasks), 1)

--- a/internal/warehouses_test.go
+++ b/internal/warehouses_test.go
@@ -24,7 +24,7 @@ func TestAccSqlWarehouses(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	err = w.Warehouses.Edit(ctx, sql.EditWarehouseRequest{
+	_, err = w.Warehouses.Edit(ctx, sql.EditWarehouseRequest{
 		Id:             created.Id,
 		Name:           RandomName("go-sdk-updated-"),
 		ClusterSize:    "2X-Small",

--- a/service/compute/api.go
+++ b/service/compute/api.go
@@ -264,11 +264,11 @@ func (a *ClustersAPI) WaitGetClusterRunning(ctx context.Context, clusterId strin
 
 // WaitGetClusterRunning is a wrapper that calls [ClustersAPI.WaitGetClusterRunning] and waits to reach RUNNING state.
 type WaitGetClusterRunning[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*ClusterInfo)) (*ClusterInfo, error)
-	callback func(*ClusterInfo)
-	timeout  time.Duration
+	Response  *R
+	ClusterId string `json:"cluster_id"`
+	poll      func(time.Duration, func(*ClusterInfo)) (*ClusterInfo, error)
+	callback  func(*ClusterInfo)
+	timeout   time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -318,11 +318,11 @@ func (a *ClustersAPI) WaitGetClusterTerminated(ctx context.Context, clusterId st
 
 // WaitGetClusterTerminated is a wrapper that calls [ClustersAPI.WaitGetClusterTerminated] and waits to reach TERMINATED state.
 type WaitGetClusterTerminated[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*ClusterInfo)) (*ClusterInfo, error)
-	callback func(*ClusterInfo)
-	timeout  time.Duration
+	Response  *R
+	ClusterId string `json:"cluster_id"`
+	poll      func(time.Duration, func(*ClusterInfo)) (*ClusterInfo, error)
+	callback  func(*ClusterInfo)
+	timeout   time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -370,7 +370,8 @@ func (a *ClustersAPI) Create(ctx context.Context, createCluster CreateCluster) (
 		return nil, err
 	}
 	return &WaitGetClusterRunning[CreateClusterResponse]{
-		Response: createClusterResponse,
+		Response:  createClusterResponse,
+		ClusterId: createClusterResponse.ClusterId,
 		poll: func(timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 			return a.WaitGetClusterRunning(ctx, createClusterResponse.ClusterId, timeout, callback)
 		},
@@ -415,6 +416,7 @@ func (a *ClustersAPI) Delete(ctx context.Context, deleteCluster DeleteCluster) (
 	}
 	return &WaitGetClusterTerminated[any]{
 
+		ClusterId: deleteCluster.ClusterId,
 		poll: func(timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 			return a.WaitGetClusterTerminated(ctx, deleteCluster.ClusterId, timeout, callback)
 		},
@@ -485,6 +487,7 @@ func (a *ClustersAPI) Edit(ctx context.Context, editCluster EditCluster) (*WaitG
 	}
 	return &WaitGetClusterRunning[any]{
 
+		ClusterId: editCluster.ClusterId,
 		poll: func(timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 			return a.WaitGetClusterRunning(ctx, editCluster.ClusterId, timeout, callback)
 		},
@@ -734,6 +737,7 @@ func (a *ClustersAPI) Resize(ctx context.Context, resizeCluster ResizeCluster) (
 	}
 	return &WaitGetClusterRunning[any]{
 
+		ClusterId: resizeCluster.ClusterId,
 		poll: func(timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 			return a.WaitGetClusterRunning(ctx, resizeCluster.ClusterId, timeout, callback)
 		},
@@ -776,6 +780,7 @@ func (a *ClustersAPI) Restart(ctx context.Context, restartCluster RestartCluster
 	}
 	return &WaitGetClusterRunning[any]{
 
+		ClusterId: restartCluster.ClusterId,
 		poll: func(timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 			return a.WaitGetClusterRunning(ctx, restartCluster.ClusterId, timeout, callback)
 		},
@@ -832,6 +837,7 @@ func (a *ClustersAPI) Start(ctx context.Context, startCluster StartCluster) (*Wa
 	}
 	return &WaitGetClusterRunning[any]{
 
+		ClusterId: startCluster.ClusterId,
 		poll: func(timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 			return a.WaitGetClusterRunning(ctx, startCluster.ClusterId, timeout, callback)
 		},
@@ -969,11 +975,13 @@ func (a *CommandExecutionAPI) WaitCommandStatusCommandExecutionCancelled(ctx con
 
 // WaitCommandStatusCommandExecutionCancelled is a wrapper that calls [CommandExecutionAPI.WaitCommandStatusCommandExecutionCancelled] and waits to reach Cancelled state.
 type WaitCommandStatusCommandExecutionCancelled[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*CommandStatusResponse)) (*CommandStatusResponse, error)
-	callback func(*CommandStatusResponse)
-	timeout  time.Duration
+	Response  *R
+	ClusterId string `json:"clusterId"`
+	CommandId string `json:"commandId"`
+	ContextId string `json:"contextId"`
+	poll      func(time.Duration, func(*CommandStatusResponse)) (*CommandStatusResponse, error)
+	callback  func(*CommandStatusResponse)
+	timeout   time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -1025,11 +1033,13 @@ func (a *CommandExecutionAPI) WaitCommandStatusCommandExecutionFinishedOrError(c
 
 // WaitCommandStatusCommandExecutionFinishedOrError is a wrapper that calls [CommandExecutionAPI.WaitCommandStatusCommandExecutionFinishedOrError] and waits to reach Finished or Error state.
 type WaitCommandStatusCommandExecutionFinishedOrError[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*CommandStatusResponse)) (*CommandStatusResponse, error)
-	callback func(*CommandStatusResponse)
-	timeout  time.Duration
+	Response  *R
+	ClusterId string `json:"clusterId"`
+	CommandId string `json:"commandId"`
+	ContextId string `json:"contextId"`
+	poll      func(time.Duration, func(*CommandStatusResponse)) (*CommandStatusResponse, error)
+	callback  func(*CommandStatusResponse)
+	timeout   time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -1080,11 +1090,12 @@ func (a *CommandExecutionAPI) WaitContextStatusCommandExecutionRunning(ctx conte
 
 // WaitContextStatusCommandExecutionRunning is a wrapper that calls [CommandExecutionAPI.WaitContextStatusCommandExecutionRunning] and waits to reach Running state.
 type WaitContextStatusCommandExecutionRunning[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*ContextStatusResponse)) (*ContextStatusResponse, error)
-	callback func(*ContextStatusResponse)
-	timeout  time.Duration
+	Response  *R
+	ClusterId string `json:"clusterId"`
+	ContextId string `json:"contextId"`
+	poll      func(time.Duration, func(*ContextStatusResponse)) (*ContextStatusResponse, error)
+	callback  func(*ContextStatusResponse)
+	timeout   time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -1115,6 +1126,9 @@ func (a *CommandExecutionAPI) Cancel(ctx context.Context, cancelCommand CancelCo
 	}
 	return &WaitCommandStatusCommandExecutionCancelled[any]{
 
+		ClusterId: cancelCommand.ClusterId,
+		CommandId: cancelCommand.CommandId,
+		ContextId: cancelCommand.ContextId,
 		poll: func(timeout time.Duration, callback func(*CommandStatusResponse)) (*CommandStatusResponse, error) {
 			return a.WaitCommandStatusCommandExecutionCancelled(ctx, cancelCommand.ClusterId, cancelCommand.CommandId, cancelCommand.ContextId, timeout, callback)
 		},
@@ -1174,7 +1188,9 @@ func (a *CommandExecutionAPI) Create(ctx context.Context, createContext CreateCo
 		return nil, err
 	}
 	return &WaitContextStatusCommandExecutionRunning[Created]{
-		Response: created,
+		Response:  created,
+		ClusterId: createContext.ClusterId,
+		ContextId: created.Id,
 		poll: func(timeout time.Duration, callback func(*ContextStatusResponse)) (*ContextStatusResponse, error) {
 			return a.WaitContextStatusCommandExecutionRunning(ctx, createContext.ClusterId, created.Id, timeout, callback)
 		},
@@ -1226,7 +1242,10 @@ func (a *CommandExecutionAPI) Execute(ctx context.Context, command Command) (*Wa
 		return nil, err
 	}
 	return &WaitCommandStatusCommandExecutionFinishedOrError[Created]{
-		Response: created,
+		Response:  created,
+		ClusterId: command.ClusterId,
+		CommandId: created.Id,
+		ContextId: command.ContextId,
 		poll: func(timeout time.Duration, callback func(*CommandStatusResponse)) (*CommandStatusResponse, error) {
 			return a.WaitCommandStatusCommandExecutionFinishedOrError(ctx, command.ClusterId, created.Id, command.ContextId, timeout, callback)
 		},

--- a/service/compute/api.go
+++ b/service/compute/api.go
@@ -233,7 +233,7 @@ func (a *ClustersAPI) Impl() ClustersService {
 	return a.impl
 }
 
-// WaitGetClusterRunning calls [ClustersAPI.Edit] and waits to reach RUNNING state
+// WaitGetClusterRunning repeatedly calls [ClustersAPI.Get] and waits to reach RUNNING state
 func (a *ClustersAPI) WaitGetClusterRunning(ctx context.Context, clusterId string,
 	timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -287,7 +287,7 @@ func (w *WaitGetClusterRunning[R]) GetWithTimeout(timeout time.Duration) (*Clust
 	return w.poll(timeout, w.callback)
 }
 
-// WaitGetClusterTerminated calls [ClustersAPI.Delete] and waits to reach TERMINATED state
+// WaitGetClusterTerminated repeatedly calls [ClustersAPI.Get] and waits to reach TERMINATED state
 func (a *ClustersAPI) WaitGetClusterTerminated(ctx context.Context, clusterId string,
 	timeout time.Duration, callback func(*ClusterInfo)) (*ClusterInfo, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -933,7 +933,7 @@ func (a *CommandExecutionAPI) Impl() CommandExecutionService {
 	return a.impl
 }
 
-// WaitCommandStatusCommandExecutionCancelled calls [CommandExecutionAPI.Cancel] and waits to reach Cancelled state
+// WaitCommandStatusCommandExecutionCancelled repeatedly calls [CommandExecutionAPI.CommandStatus] and waits to reach Cancelled state
 func (a *CommandExecutionAPI) WaitCommandStatusCommandExecutionCancelled(ctx context.Context, clusterId string, commandId string, contextId string,
 	timeout time.Duration, callback func(*CommandStatusResponse)) (*CommandStatusResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -992,7 +992,7 @@ func (w *WaitCommandStatusCommandExecutionCancelled[R]) GetWithTimeout(timeout t
 	return w.poll(timeout, w.callback)
 }
 
-// WaitCommandStatusCommandExecutionFinishedOrError calls [CommandExecutionAPI.Execute] and waits to reach Finished or Error state
+// WaitCommandStatusCommandExecutionFinishedOrError repeatedly calls [CommandExecutionAPI.CommandStatus] and waits to reach Finished or Error state
 func (a *CommandExecutionAPI) WaitCommandStatusCommandExecutionFinishedOrError(ctx context.Context, clusterId string, commandId string, contextId string,
 	timeout time.Duration, callback func(*CommandStatusResponse)) (*CommandStatusResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -1048,7 +1048,7 @@ func (w *WaitCommandStatusCommandExecutionFinishedOrError[R]) GetWithTimeout(tim
 	return w.poll(timeout, w.callback)
 }
 
-// WaitContextStatusCommandExecutionRunning calls [CommandExecutionAPI.Create] and waits to reach Running state
+// WaitContextStatusCommandExecutionRunning repeatedly calls [CommandExecutionAPI.ContextStatus] and waits to reach Running state
 func (a *CommandExecutionAPI) WaitContextStatusCommandExecutionRunning(ctx context.Context, clusterId string, contextId string,
 	timeout time.Duration, callback func(*ContextStatusResponse)) (*ContextStatusResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -564,7 +564,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -156,7 +156,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 
@@ -564,7 +564,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }
@@ -593,7 +593,7 @@ type User struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks user ID.
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Name *Name `json:"name,omitempty"`
 

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -92,7 +92,7 @@ func (a *JobsAPI) WaitGetRunJobTerminatedOrSkipped(ctx context.Context, runId in
 // WaitGetRunJobTerminatedOrSkipped is a wrapper that calls [JobsAPI.WaitGetRunJobTerminatedOrSkipped] and waits to reach TERMINATED or SKIPPED state.
 type WaitGetRunJobTerminatedOrSkipped[R any] struct {
 	Response *R
-
+	RunId    int64 `json:"run_id"`
 	poll     func(time.Duration, func(*Run)) (*Run, error)
 	callback func(*Run)
 	timeout  time.Duration
@@ -143,6 +143,7 @@ func (a *JobsAPI) CancelRun(ctx context.Context, cancelRun CancelRun) (*WaitGetR
 	}
 	return &WaitGetRunJobTerminatedOrSkipped[any]{
 
+		RunId: cancelRun.RunId,
 		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
 			return a.WaitGetRunJobTerminatedOrSkipped(ctx, cancelRun.RunId, timeout, callback)
 		},
@@ -436,6 +437,7 @@ func (a *JobsAPI) RepairRun(ctx context.Context, repairRun RepairRun) (*WaitGetR
 	}
 	return &WaitGetRunJobTerminatedOrSkipped[RepairRunResponse]{
 		Response: repairRunResponse,
+		RunId:    repairRun.RunId,
 		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
 			return a.WaitGetRunJobTerminatedOrSkipped(ctx, repairRun.RunId, timeout, callback)
 		},
@@ -485,6 +487,7 @@ func (a *JobsAPI) RunNow(ctx context.Context, runNow RunNow) (*WaitGetRunJobTerm
 	}
 	return &WaitGetRunJobTerminatedOrSkipped[RunNowResponse]{
 		Response: runNowResponse,
+		RunId:    runNowResponse.RunId,
 		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
 			return a.WaitGetRunJobTerminatedOrSkipped(ctx, runNowResponse.RunId, timeout, callback)
 		},
@@ -529,6 +532,7 @@ func (a *JobsAPI) Submit(ctx context.Context, submitRun SubmitRun) (*WaitGetRunJ
 	}
 	return &WaitGetRunJobTerminatedOrSkipped[SubmitRunResponse]{
 		Response: submitRunResponse,
+		RunId:    submitRunResponse.RunId,
 		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
 			return a.WaitGetRunJobTerminatedOrSkipped(ctx, submitRunResponse.RunId, timeout, callback)
 		},

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -57,6 +57,63 @@ func (a *JobsAPI) Impl() JobsService {
 	return a.impl
 }
 
+// WaitGetRunJobTerminatedOrSkipped calls [JobsAPI.Submit] and waits to reach TERMINATED or SKIPPED state
+func (a *JobsAPI) WaitGetRunJobTerminatedOrSkipped(ctx context.Context, runId int64,
+	timeout time.Duration, callback func(*Run)) (*Run, error) {
+	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
+	return retries.Poll[Run](ctx, timeout, func() (*Run, *retries.Err) {
+		run, err := a.GetRun(ctx, GetRunRequest{
+			RunId: runId,
+		})
+		if err != nil {
+			return nil, retries.Halt(err)
+		}
+		if callback != nil {
+			callback(run)
+		}
+		status := run.State.LifeCycleState
+		statusMessage := fmt.Sprintf("current status: %s", status)
+		if run.State != nil {
+			statusMessage = run.State.StateMessage
+		}
+		switch status {
+		case RunLifeCycleStateTerminated, RunLifeCycleStateSkipped: // target state
+			return run, nil
+		case RunLifeCycleStateInternalError:
+			err := fmt.Errorf("failed to reach %s or %s, got %s: %s",
+				RunLifeCycleStateTerminated, RunLifeCycleStateSkipped, status, statusMessage)
+			return nil, retries.Halt(err)
+		default:
+			return nil, retries.Continues(statusMessage)
+		}
+	})
+}
+
+// WaitGetRunJobTerminatedOrSkipped is a wrapper that calls [JobsAPI.WaitGetRunJobTerminatedOrSkipped] and waits to reach TERMINATED or SKIPPED state.
+type WaitGetRunJobTerminatedOrSkipped[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*Run)) (*Run, error)
+	callback func(*Run)
+	timeout  time.Duration
+}
+
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *WaitGetRunJobTerminatedOrSkipped[R]) OnProgress(callback func(*Run)) *WaitGetRunJobTerminatedOrSkipped[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the Run with the default timeout of 20 minutes.
+func (w *WaitGetRunJobTerminatedOrSkipped[R]) Get() (*Run, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the Run with custom timeout.
+func (w *WaitGetRunJobTerminatedOrSkipped[R]) GetWithTimeout(timeout time.Duration) (*Run, error) {
+	return w.poll(timeout, w.callback)
+}
+
 // Cancel all runs of a job.
 //
 // Cancels all active runs of a job. The runs are canceled asynchronously, so it
@@ -79,53 +136,42 @@ func (a *JobsAPI) CancelAllRunsByJobId(ctx context.Context, jobId int64) error {
 //
 // Cancels a job run. The run is canceled asynchronously, so it may still be
 // running when this request completes.
-func (a *JobsAPI) CancelRun(ctx context.Context, request CancelRun) error {
-	return a.impl.CancelRun(ctx, request)
+func (a *JobsAPI) CancelRun(ctx context.Context, cancelRun CancelRun) (*WaitGetRunJobTerminatedOrSkipped[any], error) {
+	err := a.impl.CancelRun(ctx, cancelRun)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetRunJobTerminatedOrSkipped[any]{
+
+		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
+			return a.WaitGetRunJobTerminatedOrSkipped(ctx, cancelRun.RunId, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [JobsAPI.CancelRun] and waits to reach TERMINATED or SKIPPED state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[Run](60*time.Minute) functional option.
+//
+// Deprecated: use [JobsAPI.CancelRun].Get() or [JobsAPI.WaitGetRunJobTerminatedOrSkipped]
 func (a *JobsAPI) CancelRunAndWait(ctx context.Context, cancelRun CancelRun, options ...retries.Option[Run]) (*Run, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.CancelRun(ctx, cancelRun)
+	wait, err := a.CancelRun(ctx, cancelRun)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[Run]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[Run](ctx, i.Timeout, func() (*Run, *retries.Err) {
-		run, err := a.GetRun(ctx, GetRunRequest{
-			RunId: cancelRun.RunId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *Run) {
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    run,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := run.State.LifeCycleState
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if run.State != nil {
-			statusMessage = run.State.StateMessage
-		}
-		switch status {
-		case RunLifeCycleStateTerminated, RunLifeCycleStateSkipped: // target state
-			return run, nil
-		case RunLifeCycleStateInternalError:
-			err := fmt.Errorf("failed to reach %s or %s, got %s: %s",
-				RunLifeCycleStateTerminated, RunLifeCycleStateSkipped, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Cancel a job run.
@@ -211,51 +257,6 @@ func (a *JobsAPI) GetByJobId(ctx context.Context, jobId int64) (*Job, error) {
 // Retrieve the metadata of a run.
 func (a *JobsAPI) GetRun(ctx context.Context, request GetRunRequest) (*Run, error) {
 	return a.impl.GetRun(ctx, request)
-}
-
-// Calls [JobsAPI.GetRun] and waits to reach TERMINATED or SKIPPED state
-//
-// You can override the default timeout of 20 minutes by calling adding
-// retries.Timeout[Run](60*time.Minute) functional option.
-func (a *JobsAPI) GetRunAndWait(ctx context.Context, getRunRequest GetRunRequest, options ...retries.Option[Run]) (*Run, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	run, err := a.GetRun(ctx, getRunRequest)
-	if err != nil {
-		return nil, err
-	}
-	i := retries.Info[Run]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[Run](ctx, i.Timeout, func() (*Run, *retries.Err) {
-		run, err := a.GetRun(ctx, GetRunRequest{
-			RunId: run.RunId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
-		for _, o := range options {
-			o(&retries.Info[Run]{
-				Info:    run,
-				Timeout: i.Timeout,
-			})
-		}
-		status := run.State.LifeCycleState
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if run.State != nil {
-			statusMessage = run.State.StateMessage
-		}
-		switch status {
-		case RunLifeCycleStateTerminated, RunLifeCycleStateSkipped: // target state
-			return run, nil
-		case RunLifeCycleStateInternalError:
-			err := fmt.Errorf("failed to reach %s or %s, got %s: %s",
-				RunLifeCycleStateTerminated, RunLifeCycleStateSkipped, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
 }
 
 // Get the output for a single run.
@@ -428,53 +429,42 @@ func (a *JobsAPI) ListRunsAll(ctx context.Context, request ListRunsRequest) ([]B
 // Re-run one or more tasks. Tasks are re-run as part of the original job run.
 // They use the current job and task settings, and can be viewed in the history
 // for the original job run.
-func (a *JobsAPI) RepairRun(ctx context.Context, request RepairRun) (*RepairRunResponse, error) {
-	return a.impl.RepairRun(ctx, request)
+func (a *JobsAPI) RepairRun(ctx context.Context, repairRun RepairRun) (*WaitGetRunJobTerminatedOrSkipped[RepairRunResponse], error) {
+	repairRunResponse, err := a.impl.RepairRun(ctx, repairRun)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetRunJobTerminatedOrSkipped[RepairRunResponse]{
+		Response: repairRunResponse,
+		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
+			return a.WaitGetRunJobTerminatedOrSkipped(ctx, repairRun.RunId, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [JobsAPI.RepairRun] and waits to reach TERMINATED or SKIPPED state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[Run](60*time.Minute) functional option.
+//
+// Deprecated: use [JobsAPI.RepairRun].Get() or [JobsAPI.WaitGetRunJobTerminatedOrSkipped]
 func (a *JobsAPI) RepairRunAndWait(ctx context.Context, repairRun RepairRun, options ...retries.Option[Run]) (*Run, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	_, err := a.RepairRun(ctx, repairRun)
+	wait, err := a.RepairRun(ctx, repairRun)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[Run]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[Run](ctx, i.Timeout, func() (*Run, *retries.Err) {
-		run, err := a.GetRun(ctx, GetRunRequest{
-			RunId: repairRun.RunId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *Run) {
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    run,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := run.State.LifeCycleState
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if run.State != nil {
-			statusMessage = run.State.StateMessage
-		}
-		switch status {
-		case RunLifeCycleStateTerminated, RunLifeCycleStateSkipped: // target state
-			return run, nil
-		case RunLifeCycleStateInternalError:
-			err := fmt.Errorf("failed to reach %s or %s, got %s: %s",
-				RunLifeCycleStateTerminated, RunLifeCycleStateSkipped, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Overwrites all settings for a job.
@@ -488,53 +478,42 @@ func (a *JobsAPI) Reset(ctx context.Context, request ResetJob) error {
 // Trigger a new job run.
 //
 // Run a job and return the `run_id` of the triggered run.
-func (a *JobsAPI) RunNow(ctx context.Context, request RunNow) (*RunNowResponse, error) {
-	return a.impl.RunNow(ctx, request)
+func (a *JobsAPI) RunNow(ctx context.Context, runNow RunNow) (*WaitGetRunJobTerminatedOrSkipped[RunNowResponse], error) {
+	runNowResponse, err := a.impl.RunNow(ctx, runNow)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetRunJobTerminatedOrSkipped[RunNowResponse]{
+		Response: runNowResponse,
+		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
+			return a.WaitGetRunJobTerminatedOrSkipped(ctx, runNowResponse.RunId, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [JobsAPI.RunNow] and waits to reach TERMINATED or SKIPPED state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[Run](60*time.Minute) functional option.
+//
+// Deprecated: use [JobsAPI.RunNow].Get() or [JobsAPI.WaitGetRunJobTerminatedOrSkipped]
 func (a *JobsAPI) RunNowAndWait(ctx context.Context, runNow RunNow, options ...retries.Option[Run]) (*Run, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	runNowResponse, err := a.RunNow(ctx, runNow)
+	wait, err := a.RunNow(ctx, runNow)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[Run]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[Run](ctx, i.Timeout, func() (*Run, *retries.Err) {
-		run, err := a.GetRun(ctx, GetRunRequest{
-			RunId: runNowResponse.RunId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *Run) {
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    run,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := run.State.LifeCycleState
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if run.State != nil {
-			statusMessage = run.State.StateMessage
-		}
-		switch status {
-		case RunLifeCycleStateTerminated, RunLifeCycleStateSkipped: // target state
-			return run, nil
-		case RunLifeCycleStateInternalError:
-			err := fmt.Errorf("failed to reach %s or %s, got %s: %s",
-				RunLifeCycleStateTerminated, RunLifeCycleStateSkipped, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Create and trigger a one-time run.
@@ -543,53 +522,42 @@ func (a *JobsAPI) RunNowAndWait(ctx context.Context, runNow RunNow, options ...r
 // without creating a job. Runs submitted using this endpoint don’t display in
 // the UI. Use the `jobs/runs/get` API to check the run state after the job is
 // submitted.
-func (a *JobsAPI) Submit(ctx context.Context, request SubmitRun) (*SubmitRunResponse, error) {
-	return a.impl.Submit(ctx, request)
+func (a *JobsAPI) Submit(ctx context.Context, submitRun SubmitRun) (*WaitGetRunJobTerminatedOrSkipped[SubmitRunResponse], error) {
+	submitRunResponse, err := a.impl.Submit(ctx, submitRun)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetRunJobTerminatedOrSkipped[SubmitRunResponse]{
+		Response: submitRunResponse,
+		poll: func(timeout time.Duration, callback func(*Run)) (*Run, error) {
+			return a.WaitGetRunJobTerminatedOrSkipped(ctx, submitRunResponse.RunId, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [JobsAPI.Submit] and waits to reach TERMINATED or SKIPPED state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[Run](60*time.Minute) functional option.
+//
+// Deprecated: use [JobsAPI.Submit].Get() or [JobsAPI.WaitGetRunJobTerminatedOrSkipped]
 func (a *JobsAPI) SubmitAndWait(ctx context.Context, submitRun SubmitRun, options ...retries.Option[Run]) (*Run, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	submitRunResponse, err := a.Submit(ctx, submitRun)
+	wait, err := a.Submit(ctx, submitRun)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[Run]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[Run](ctx, i.Timeout, func() (*Run, *retries.Err) {
-		run, err := a.GetRun(ctx, GetRunRequest{
-			RunId: submitRunResponse.RunId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *Run) {
 		for _, o := range options {
 			o(&retries.Info[Run]{
-				Info:    run,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := run.State.LifeCycleState
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if run.State != nil {
-			statusMessage = run.State.StateMessage
-		}
-		switch status {
-		case RunLifeCycleStateTerminated, RunLifeCycleStateSkipped: // target state
-			return run, nil
-		case RunLifeCycleStateInternalError:
-			err := fmt.Errorf("failed to reach %s or %s, got %s: %s",
-				RunLifeCycleStateTerminated, RunLifeCycleStateSkipped, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Partially update a job.

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -57,7 +57,7 @@ func (a *JobsAPI) Impl() JobsService {
 	return a.impl
 }
 
-// WaitGetRunJobTerminatedOrSkipped calls [JobsAPI.Submit] and waits to reach TERMINATED or SKIPPED state
+// WaitGetRunJobTerminatedOrSkipped repeatedly calls [JobsAPI.GetRun] and waits to reach TERMINATED or SKIPPED state
 func (a *JobsAPI) WaitGetRunJobTerminatedOrSkipped(ctx context.Context, runId int64,
 	timeout time.Duration, callback func(*Run)) (*Run, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/service/jobs/jobs_usage_test.go
+++ b/service/jobs/jobs_usage_test.go
@@ -120,7 +120,7 @@ func ExampleJobsAPI_CancelRun_jobsApiFullIntegration() {
 	logger.Infof(ctx, "found %v", runNowResponse)
 
 	cancelledRun, err := w.Jobs.CancelRunAndWait(ctx, jobs.CancelRun{
-		RunId: runNowResponse.RunId,
+		RunId: runNowResponse.Response.RunId,
 	})
 	if err != nil {
 		panic(err)
@@ -430,7 +430,7 @@ func ExampleJobsAPI_RepairRun_jobsApiFullIntegration() {
 	logger.Infof(ctx, "found %v", runNowResponse)
 
 	cancelledRun, err := w.Jobs.CancelRunAndWait(ctx, jobs.CancelRun{
-		RunId: runNowResponse.RunId,
+		RunId: runNowResponse.Response.RunId,
 	})
 	if err != nil {
 		panic(err)
@@ -439,7 +439,7 @@ func ExampleJobsAPI_RepairRun_jobsApiFullIntegration() {
 
 	repairedRun, err := w.Jobs.RepairRunAndWait(ctx, jobs.RepairRun{
 		RerunTasks: []string{cancelledRun.Tasks[0].TaskKey},
-		RunId:      runNowResponse.RunId,
+		RunId:      runNowResponse.Response.RunId,
 	})
 	if err != nil {
 		panic(err)

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -58,20 +58,20 @@ func ExampleModelRegistryAPI_CreateComment_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_models() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
 		panic(err)
 	}
 
-	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+	created, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
 		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
 	})
 	if err != nil {
 		panic(err)
 	}
-	logger.Infof(ctx, "found %v", model)
+	logger.Infof(ctx, "found %v", created)
 
 }
 
@@ -92,24 +92,7 @@ func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_models() {
-	ctx := context.Background()
-	w, err := databricks.NewWorkspaceClient()
-	if err != nil {
-		panic(err)
-	}
-
-	created, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
-		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", created)
-
-}
-
-func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
@@ -123,15 +106,6 @@ func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", model)
-
-	created, err := w.ModelRegistry.CreateModelVersion(ctx, ml.CreateModelVersionRequest{
-		Name:   model.RegisteredModel.Name,
-		Source: "dbfs:/tmp",
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", created)
 
 }
 
@@ -158,6 +132,32 @@ func ExampleModelRegistryAPI_CreateModelVersion_modelVersionComments() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", mv)
+
+}
+
+func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", model)
+
+	created, err := w.ModelRegistry.CreateModelVersion(ctx, ml.CreateModelVersionRequest{
+		Name:   model.RegisteredModel.Name,
+		Source: "dbfs:/tmp",
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
 
 }
 

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -53,6 +53,114 @@ func (a *PipelinesAPI) Impl() PipelinesService {
 	return a.impl
 }
 
+// WaitGetPipelineIdle calls [PipelinesAPI.Stop] and waits to reach IDLE state
+func (a *PipelinesAPI) WaitGetPipelineIdle(ctx context.Context, pipelineId string,
+	timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
+	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
+	return retries.Poll[GetPipelineResponse](ctx, timeout, func() (*GetPipelineResponse, *retries.Err) {
+		getPipelineResponse, err := a.Get(ctx, GetPipelineRequest{
+			PipelineId: pipelineId,
+		})
+		if err != nil {
+			return nil, retries.Halt(err)
+		}
+		if callback != nil {
+			callback(getPipelineResponse)
+		}
+		status := getPipelineResponse.State
+		statusMessage := getPipelineResponse.Cause
+		switch status {
+		case PipelineStateIdle: // target state
+			return getPipelineResponse, nil
+		case PipelineStateFailed:
+			err := fmt.Errorf("failed to reach %s, got %s: %s",
+				PipelineStateIdle, status, statusMessage)
+			return nil, retries.Halt(err)
+		default:
+			return nil, retries.Continues(statusMessage)
+		}
+	})
+}
+
+// WaitGetPipelineIdle is a wrapper that calls [PipelinesAPI.WaitGetPipelineIdle] and waits to reach IDLE state.
+type WaitGetPipelineIdle[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*GetPipelineResponse)) (*GetPipelineResponse, error)
+	callback func(*GetPipelineResponse)
+	timeout  time.Duration
+}
+
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *WaitGetPipelineIdle[R]) OnProgress(callback func(*GetPipelineResponse)) *WaitGetPipelineIdle[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the GetPipelineResponse with the default timeout of 20 minutes.
+func (w *WaitGetPipelineIdle[R]) Get() (*GetPipelineResponse, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the GetPipelineResponse with custom timeout.
+func (w *WaitGetPipelineIdle[R]) GetWithTimeout(timeout time.Duration) (*GetPipelineResponse, error) {
+	return w.poll(timeout, w.callback)
+}
+
+// WaitGetPipelineRunning calls [PipelinesAPI.Reset] and waits to reach RUNNING state
+func (a *PipelinesAPI) WaitGetPipelineRunning(ctx context.Context, pipelineId string,
+	timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
+	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
+	return retries.Poll[GetPipelineResponse](ctx, timeout, func() (*GetPipelineResponse, *retries.Err) {
+		getPipelineResponse, err := a.Get(ctx, GetPipelineRequest{
+			PipelineId: pipelineId,
+		})
+		if err != nil {
+			return nil, retries.Halt(err)
+		}
+		if callback != nil {
+			callback(getPipelineResponse)
+		}
+		status := getPipelineResponse.State
+		statusMessage := getPipelineResponse.Cause
+		switch status {
+		case PipelineStateRunning: // target state
+			return getPipelineResponse, nil
+		case PipelineStateFailed:
+			err := fmt.Errorf("failed to reach %s, got %s: %s",
+				PipelineStateRunning, status, statusMessage)
+			return nil, retries.Halt(err)
+		default:
+			return nil, retries.Continues(statusMessage)
+		}
+	})
+}
+
+// WaitGetPipelineRunning is a wrapper that calls [PipelinesAPI.WaitGetPipelineRunning] and waits to reach RUNNING state.
+type WaitGetPipelineRunning[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*GetPipelineResponse)) (*GetPipelineResponse, error)
+	callback func(*GetPipelineResponse)
+	timeout  time.Duration
+}
+
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *WaitGetPipelineRunning[R]) OnProgress(callback func(*GetPipelineResponse)) *WaitGetPipelineRunning[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the GetPipelineResponse with the default timeout of 20 minutes.
+func (w *WaitGetPipelineRunning[R]) Get() (*GetPipelineResponse, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the GetPipelineResponse with custom timeout.
+func (w *WaitGetPipelineRunning[R]) GetWithTimeout(timeout time.Duration) (*GetPipelineResponse, error) {
+	return w.poll(timeout, w.callback)
+}
+
 // Create a pipeline.
 //
 // Creates a new data processing pipeline based on the requested configuration.
@@ -82,59 +190,11 @@ func (a *PipelinesAPI) Get(ctx context.Context, request GetPipelineRequest) (*Ge
 	return a.impl.Get(ctx, request)
 }
 
-// Calls [PipelinesAPI.Get] and waits to reach RUNNING state
-//
-// You can override the default timeout of 20 minutes by calling adding
-// retries.Timeout[GetPipelineResponse](60*time.Minute) functional option.
-func (a *PipelinesAPI) GetAndWait(ctx context.Context, getPipelineRequest GetPipelineRequest, options ...retries.Option[GetPipelineResponse]) (*GetPipelineResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	getPipelineResponse, err := a.Get(ctx, getPipelineRequest)
-	if err != nil {
-		return nil, err
-	}
-	i := retries.Info[GetPipelineResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetPipelineResponse](ctx, i.Timeout, func() (*GetPipelineResponse, *retries.Err) {
-		getPipelineResponse, err := a.Get(ctx, GetPipelineRequest{
-			PipelineId: getPipelineResponse.PipelineId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
-		for _, o := range options {
-			o(&retries.Info[GetPipelineResponse]{
-				Info:    getPipelineResponse,
-				Timeout: i.Timeout,
-			})
-		}
-		status := getPipelineResponse.State
-		statusMessage := getPipelineResponse.Cause
-		switch status {
-		case PipelineStateRunning: // target state
-			return getPipelineResponse, nil
-		case PipelineStateFailed:
-			err := fmt.Errorf("failed to reach %s, got %s: %s",
-				PipelineStateRunning, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
-}
-
 // Get a pipeline.
 func (a *PipelinesAPI) GetByPipelineId(ctx context.Context, pipelineId string) (*GetPipelineResponse, error) {
 	return a.impl.Get(ctx, GetPipelineRequest{
 		PipelineId: pipelineId,
 	})
-}
-
-func (a *PipelinesAPI) GetByPipelineIdAndWait(ctx context.Context, pipelineId string, options ...retries.Option[GetPipelineResponse]) (*GetPipelineResponse, error) {
-	return a.GetAndWait(ctx, GetPipelineRequest{
-		PipelineId: pipelineId,
-	}, options...)
 }
 
 // Get a pipeline update.
@@ -289,50 +349,42 @@ func (a *PipelinesAPI) ListUpdatesByPipelineId(ctx context.Context, pipelineId s
 // Reset a pipeline.
 //
 // Resets a pipeline.
-func (a *PipelinesAPI) Reset(ctx context.Context, request ResetRequest) error {
-	return a.impl.Reset(ctx, request)
+func (a *PipelinesAPI) Reset(ctx context.Context, resetRequest ResetRequest) (*WaitGetPipelineRunning[any], error) {
+	err := a.impl.Reset(ctx, resetRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetPipelineRunning[any]{
+
+		poll: func(timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
+			return a.WaitGetPipelineRunning(ctx, resetRequest.PipelineId, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [PipelinesAPI.Reset] and waits to reach RUNNING state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[GetPipelineResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [PipelinesAPI.Reset].Get() or [PipelinesAPI.WaitGetPipelineRunning]
 func (a *PipelinesAPI) ResetAndWait(ctx context.Context, resetRequest ResetRequest, options ...retries.Option[GetPipelineResponse]) (*GetPipelineResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.Reset(ctx, resetRequest)
+	wait, err := a.Reset(ctx, resetRequest)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[GetPipelineResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetPipelineResponse](ctx, i.Timeout, func() (*GetPipelineResponse, *retries.Err) {
-		getPipelineResponse, err := a.Get(ctx, GetPipelineRequest{
-			PipelineId: resetRequest.PipelineId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetPipelineResponse) {
 		for _, o := range options {
 			o(&retries.Info[GetPipelineResponse]{
-				Info:    getPipelineResponse,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := getPipelineResponse.State
-		statusMessage := getPipelineResponse.Cause
-		switch status {
-		case PipelineStateRunning: // target state
-			return getPipelineResponse, nil
-		case PipelineStateFailed:
-			err := fmt.Errorf("failed to reach %s, got %s: %s",
-				PipelineStateRunning, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Queue a pipeline update.
@@ -345,50 +397,42 @@ func (a *PipelinesAPI) StartUpdate(ctx context.Context, request StartUpdate) (*S
 // Stop a pipeline.
 //
 // Stops a pipeline.
-func (a *PipelinesAPI) Stop(ctx context.Context, request StopRequest) error {
-	return a.impl.Stop(ctx, request)
+func (a *PipelinesAPI) Stop(ctx context.Context, stopRequest StopRequest) (*WaitGetPipelineIdle[any], error) {
+	err := a.impl.Stop(ctx, stopRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetPipelineIdle[any]{
+
+		poll: func(timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
+			return a.WaitGetPipelineIdle(ctx, stopRequest.PipelineId, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [PipelinesAPI.Stop] and waits to reach IDLE state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[GetPipelineResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [PipelinesAPI.Stop].Get() or [PipelinesAPI.WaitGetPipelineIdle]
 func (a *PipelinesAPI) StopAndWait(ctx context.Context, stopRequest StopRequest, options ...retries.Option[GetPipelineResponse]) (*GetPipelineResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.Stop(ctx, stopRequest)
+	wait, err := a.Stop(ctx, stopRequest)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[GetPipelineResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetPipelineResponse](ctx, i.Timeout, func() (*GetPipelineResponse, *retries.Err) {
-		getPipelineResponse, err := a.Get(ctx, GetPipelineRequest{
-			PipelineId: stopRequest.PipelineId,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetPipelineResponse) {
 		for _, o := range options {
 			o(&retries.Info[GetPipelineResponse]{
-				Info:    getPipelineResponse,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := getPipelineResponse.State
-		statusMessage := getPipelineResponse.Cause
-		switch status {
-		case PipelineStateIdle: // target state
-			return getPipelineResponse, nil
-		case PipelineStateFailed:
-			err := fmt.Errorf("failed to reach %s, got %s: %s",
-				PipelineStateIdle, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Edit a pipeline.

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -53,7 +53,7 @@ func (a *PipelinesAPI) Impl() PipelinesService {
 	return a.impl
 }
 
-// WaitGetPipelineIdle calls [PipelinesAPI.Stop] and waits to reach IDLE state
+// WaitGetPipelineIdle repeatedly calls [PipelinesAPI.Get] and waits to reach IDLE state
 func (a *PipelinesAPI) WaitGetPipelineIdle(ctx context.Context, pipelineId string,
 	timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -107,7 +107,7 @@ func (w *WaitGetPipelineIdle[R]) GetWithTimeout(timeout time.Duration) (*GetPipe
 	return w.poll(timeout, w.callback)
 }
 
-// WaitGetPipelineRunning calls [PipelinesAPI.Reset] and waits to reach RUNNING state
+// WaitGetPipelineRunning repeatedly calls [PipelinesAPI.Get] and waits to reach RUNNING state
 func (a *PipelinesAPI) WaitGetPipelineRunning(ctx context.Context, pipelineId string,
 	timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -84,11 +84,11 @@ func (a *PipelinesAPI) WaitGetPipelineIdle(ctx context.Context, pipelineId strin
 
 // WaitGetPipelineIdle is a wrapper that calls [PipelinesAPI.WaitGetPipelineIdle] and waits to reach IDLE state.
 type WaitGetPipelineIdle[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*GetPipelineResponse)) (*GetPipelineResponse, error)
-	callback func(*GetPipelineResponse)
-	timeout  time.Duration
+	Response   *R
+	PipelineId string `json:"pipeline_id"`
+	poll       func(time.Duration, func(*GetPipelineResponse)) (*GetPipelineResponse, error)
+	callback   func(*GetPipelineResponse)
+	timeout    time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -138,11 +138,11 @@ func (a *PipelinesAPI) WaitGetPipelineRunning(ctx context.Context, pipelineId st
 
 // WaitGetPipelineRunning is a wrapper that calls [PipelinesAPI.WaitGetPipelineRunning] and waits to reach RUNNING state.
 type WaitGetPipelineRunning[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*GetPipelineResponse)) (*GetPipelineResponse, error)
-	callback func(*GetPipelineResponse)
-	timeout  time.Duration
+	Response   *R
+	PipelineId string `json:"pipeline_id"`
+	poll       func(time.Duration, func(*GetPipelineResponse)) (*GetPipelineResponse, error)
+	callback   func(*GetPipelineResponse)
+	timeout    time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -356,6 +356,7 @@ func (a *PipelinesAPI) Reset(ctx context.Context, resetRequest ResetRequest) (*W
 	}
 	return &WaitGetPipelineRunning[any]{
 
+		PipelineId: resetRequest.PipelineId,
 		poll: func(timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
 			return a.WaitGetPipelineRunning(ctx, resetRequest.PipelineId, timeout, callback)
 		},
@@ -404,6 +405,7 @@ func (a *PipelinesAPI) Stop(ctx context.Context, stopRequest StopRequest) (*Wait
 	}
 	return &WaitGetPipelineIdle[any]{
 
+		PipelineId: stopRequest.PipelineId,
 		poll: func(timeout time.Duration, callback func(*GetPipelineResponse)) (*GetPipelineResponse, error) {
 			return a.WaitGetPipelineIdle(ctx, stopRequest.PipelineId, timeout, callback)
 		},

--- a/service/provisioning/api.go
+++ b/service/provisioning/api.go
@@ -997,7 +997,7 @@ func (a *WorkspacesAPI) Impl() WorkspacesService {
 	return a.impl
 }
 
-// WaitGetWorkspaceRunning calls [WorkspacesAPI.Update] and waits to reach RUNNING state
+// WaitGetWorkspaceRunning repeatedly calls [WorkspacesAPI.Get] and waits to reach RUNNING state
 func (a *WorkspacesAPI) WaitGetWorkspaceRunning(ctx context.Context, workspaceId int64,
 	timeout time.Duration, callback func(*Workspace)) (*Workspace, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/service/provisioning/api.go
+++ b/service/provisioning/api.go
@@ -1028,11 +1028,11 @@ func (a *WorkspacesAPI) WaitGetWorkspaceRunning(ctx context.Context, workspaceId
 
 // WaitGetWorkspaceRunning is a wrapper that calls [WorkspacesAPI.WaitGetWorkspaceRunning] and waits to reach RUNNING state.
 type WaitGetWorkspaceRunning[R any] struct {
-	Response *R
-
-	poll     func(time.Duration, func(*Workspace)) (*Workspace, error)
-	callback func(*Workspace)
-	timeout  time.Duration
+	Response    *R
+	WorkspaceId int64 `json:"workspace_id"`
+	poll        func(time.Duration, func(*Workspace)) (*Workspace, error)
+	callback    func(*Workspace)
+	timeout     time.Duration
 }
 
 // OnProgress invokes a callback every time it polls for the status update.
@@ -1068,7 +1068,8 @@ func (a *WorkspacesAPI) Create(ctx context.Context, createWorkspaceRequest Creat
 		return nil, err
 	}
 	return &WaitGetWorkspaceRunning[Workspace]{
-		Response: workspace,
+		Response:    workspace,
+		WorkspaceId: workspace.WorkspaceId,
 		poll: func(timeout time.Duration, callback func(*Workspace)) (*Workspace, error) {
 			return a.WaitGetWorkspaceRunning(ctx, workspace.WorkspaceId, timeout, callback)
 		},
@@ -1357,6 +1358,7 @@ func (a *WorkspacesAPI) Update(ctx context.Context, updateWorkspaceRequest Updat
 	}
 	return &WaitGetWorkspaceRunning[any]{
 
+		WorkspaceId: updateWorkspaceRequest.WorkspaceId,
 		poll: func(timeout time.Duration, callback func(*Workspace)) (*Workspace, error) {
 			return a.WaitGetWorkspaceRunning(ctx, updateWorkspaceRequest.WorkspaceId, timeout, callback)
 		},

--- a/service/serving/api.go
+++ b/service/serving/api.go
@@ -84,7 +84,7 @@ func (a *ServingEndpointsAPI) WaitGetServingEndpointNotUpdating(ctx context.Cont
 // WaitGetServingEndpointNotUpdating is a wrapper that calls [ServingEndpointsAPI.WaitGetServingEndpointNotUpdating] and waits to reach NOT_UPDATING state.
 type WaitGetServingEndpointNotUpdating[R any] struct {
 	Response *R
-
+	Name     string `json:"name"`
 	poll     func(time.Duration, func(*ServingEndpointDetailed)) (*ServingEndpointDetailed, error)
 	callback func(*ServingEndpointDetailed)
 	timeout  time.Duration
@@ -133,6 +133,7 @@ func (a *ServingEndpointsAPI) Create(ctx context.Context, createServingEndpoint 
 	}
 	return &WaitGetServingEndpointNotUpdating[ServingEndpointDetailed]{
 		Response: servingEndpointDetailed,
+		Name:     servingEndpointDetailed.Name,
 		poll: func(timeout time.Duration, callback func(*ServingEndpointDetailed)) (*ServingEndpointDetailed, error) {
 			return a.WaitGetServingEndpointNotUpdating(ctx, servingEndpointDetailed.Name, timeout, callback)
 		},
@@ -254,6 +255,7 @@ func (a *ServingEndpointsAPI) UpdateConfig(ctx context.Context, endpointCoreConf
 	}
 	return &WaitGetServingEndpointNotUpdating[ServingEndpointDetailed]{
 		Response: servingEndpointDetailed,
+		Name:     servingEndpointDetailed.Name,
 		poll: func(timeout time.Duration, callback func(*ServingEndpointDetailed)) (*ServingEndpointDetailed, error) {
 			return a.WaitGetServingEndpointNotUpdating(ctx, servingEndpointDetailed.Name, timeout, callback)
 		},

--- a/service/serving/api.go
+++ b/service/serving/api.go
@@ -52,7 +52,7 @@ func (a *ServingEndpointsAPI) Impl() ServingEndpointsService {
 	return a.impl
 }
 
-// WaitGetServingEndpointNotUpdating calls [ServingEndpointsAPI.Create] and waits to reach NOT_UPDATING state
+// WaitGetServingEndpointNotUpdating repeatedly calls [ServingEndpointsAPI.Get] and waits to reach NOT_UPDATING state
 func (a *ServingEndpointsAPI) WaitGetServingEndpointNotUpdating(ctx context.Context, name string,
 	timeout time.Duration, callback func(*ServingEndpointDetailed)) (*ServingEndpointDetailed, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -1097,7 +1097,7 @@ func (a *WarehousesAPI) WaitGetWarehouseDeleted(ctx context.Context, id string,
 // WaitGetWarehouseDeleted is a wrapper that calls [WarehousesAPI.WaitGetWarehouseDeleted] and waits to reach DELETED state.
 type WaitGetWarehouseDeleted[R any] struct {
 	Response *R
-
+	Id       string `json:"id"`
 	poll     func(time.Duration, func(*GetWarehouseResponse)) (*GetWarehouseResponse, error)
 	callback func(*GetWarehouseResponse)
 	timeout  time.Duration
@@ -1154,7 +1154,7 @@ func (a *WarehousesAPI) WaitGetWarehouseRunning(ctx context.Context, id string,
 // WaitGetWarehouseRunning is a wrapper that calls [WarehousesAPI.WaitGetWarehouseRunning] and waits to reach RUNNING state.
 type WaitGetWarehouseRunning[R any] struct {
 	Response *R
-
+	Id       string `json:"id"`
 	poll     func(time.Duration, func(*GetWarehouseResponse)) (*GetWarehouseResponse, error)
 	callback func(*GetWarehouseResponse)
 	timeout  time.Duration
@@ -1207,7 +1207,7 @@ func (a *WarehousesAPI) WaitGetWarehouseStopped(ctx context.Context, id string,
 // WaitGetWarehouseStopped is a wrapper that calls [WarehousesAPI.WaitGetWarehouseStopped] and waits to reach STOPPED state.
 type WaitGetWarehouseStopped[R any] struct {
 	Response *R
-
+	Id       string `json:"id"`
 	poll     func(time.Duration, func(*GetWarehouseResponse)) (*GetWarehouseResponse, error)
 	callback func(*GetWarehouseResponse)
 	timeout  time.Duration
@@ -1239,6 +1239,7 @@ func (a *WarehousesAPI) Create(ctx context.Context, createWarehouseRequest Creat
 	}
 	return &WaitGetWarehouseRunning[CreateWarehouseResponse]{
 		Response: createWarehouseResponse,
+		Id:       createWarehouseResponse.Id,
 		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 			return a.WaitGetWarehouseRunning(ctx, createWarehouseResponse.Id, timeout, callback)
 		},
@@ -1280,6 +1281,7 @@ func (a *WarehousesAPI) Delete(ctx context.Context, deleteWarehouseRequest Delet
 	}
 	return &WaitGetWarehouseDeleted[any]{
 
+		Id: deleteWarehouseRequest.Id,
 		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 			return a.WaitGetWarehouseDeleted(ctx, deleteWarehouseRequest.Id, timeout, callback)
 		},
@@ -1336,6 +1338,7 @@ func (a *WarehousesAPI) Edit(ctx context.Context, editWarehouseRequest EditWareh
 	}
 	return &WaitGetWarehouseRunning[any]{
 
+		Id: editWarehouseRequest.Id,
 		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 			return a.WaitGetWarehouseRunning(ctx, editWarehouseRequest.Id, timeout, callback)
 		},
@@ -1475,6 +1478,7 @@ func (a *WarehousesAPI) Start(ctx context.Context, startRequest StartRequest) (*
 	}
 	return &WaitGetWarehouseRunning[any]{
 
+		Id: startRequest.Id,
 		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 			return a.WaitGetWarehouseRunning(ctx, startRequest.Id, timeout, callback)
 		},
@@ -1516,6 +1520,7 @@ func (a *WarehousesAPI) Stop(ctx context.Context, stopRequest StopRequest) (*Wai
 	}
 	return &WaitGetWarehouseStopped[any]{
 
+		Id: stopRequest.Id,
 		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 			return a.WaitGetWarehouseStopped(ctx, stopRequest.Id, timeout, callback)
 		},

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -1066,7 +1066,7 @@ func (a *WarehousesAPI) Impl() WarehousesService {
 	return a.impl
 }
 
-// WaitGetWarehouseDeleted calls [WarehousesAPI.Delete] and waits to reach DELETED state
+// WaitGetWarehouseDeleted repeatedly calls [WarehousesAPI.Get] and waits to reach DELETED state
 func (a *WarehousesAPI) WaitGetWarehouseDeleted(ctx context.Context, id string,
 	timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -1119,7 +1119,7 @@ func (w *WaitGetWarehouseDeleted[R]) GetWithTimeout(timeout time.Duration) (*Get
 	return w.poll(timeout, w.callback)
 }
 
-// WaitGetWarehouseRunning calls [WarehousesAPI.Get] and waits to reach RUNNING state
+// WaitGetWarehouseRunning repeatedly calls [WarehousesAPI.Get] and waits to reach RUNNING state
 func (a *WarehousesAPI) WaitGetWarehouseRunning(ctx context.Context, id string,
 	timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
@@ -1176,7 +1176,7 @@ func (w *WaitGetWarehouseRunning[R]) GetWithTimeout(timeout time.Duration) (*Get
 	return w.poll(timeout, w.callback)
 }
 
-// WaitGetWarehouseStopped calls [WarehousesAPI.Stop] and waits to reach STOPPED state
+// WaitGetWarehouseStopped repeatedly calls [WarehousesAPI.Get] and waits to reach STOPPED state
 func (a *WarehousesAPI) WaitGetWarehouseStopped(ctx context.Context, id string,
 	timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -1066,39 +1066,72 @@ func (a *WarehousesAPI) Impl() WarehousesService {
 	return a.impl
 }
 
-// Create a warehouse.
-//
-// Creates a new SQL warehouse.
-func (a *WarehousesAPI) Create(ctx context.Context, request CreateWarehouseRequest) (*CreateWarehouseResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Calls [WarehousesAPI.Create] and waits to reach RUNNING state
-//
-// You can override the default timeout of 20 minutes by calling adding
-// retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
-func (a *WarehousesAPI) CreateAndWait(ctx context.Context, createWarehouseRequest CreateWarehouseRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
+// WaitGetWarehouseDeleted calls [WarehousesAPI.Delete] and waits to reach DELETED state
+func (a *WarehousesAPI) WaitGetWarehouseDeleted(ctx context.Context, id string,
+	timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	createWarehouseResponse, err := a.Create(ctx, createWarehouseRequest)
-	if err != nil {
-		return nil, err
-	}
-	i := retries.Info[GetWarehouseResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetWarehouseResponse](ctx, i.Timeout, func() (*GetWarehouseResponse, *retries.Err) {
+	return retries.Poll[GetWarehouseResponse](ctx, timeout, func() (*GetWarehouseResponse, *retries.Err) {
 		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
-			Id: createWarehouseResponse.Id,
+			Id: id,
 		})
 		if err != nil {
 			return nil, retries.Halt(err)
 		}
-		for _, o := range options {
-			o(&retries.Info[GetWarehouseResponse]{
-				Info:    getWarehouseResponse,
-				Timeout: i.Timeout,
-			})
+		if callback != nil {
+			callback(getWarehouseResponse)
+		}
+		status := getWarehouseResponse.State
+		statusMessage := fmt.Sprintf("current status: %s", status)
+		if getWarehouseResponse.Health != nil {
+			statusMessage = getWarehouseResponse.Health.Summary
+		}
+		switch status {
+		case StateDeleted: // target state
+			return getWarehouseResponse, nil
+		default:
+			return nil, retries.Continues(statusMessage)
+		}
+	})
+}
+
+// WaitGetWarehouseDeleted is a wrapper that calls [WarehousesAPI.WaitGetWarehouseDeleted] and waits to reach DELETED state.
+type WaitGetWarehouseDeleted[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*GetWarehouseResponse)) (*GetWarehouseResponse, error)
+	callback func(*GetWarehouseResponse)
+	timeout  time.Duration
+}
+
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *WaitGetWarehouseDeleted[R]) OnProgress(callback func(*GetWarehouseResponse)) *WaitGetWarehouseDeleted[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the GetWarehouseResponse with the default timeout of 20 minutes.
+func (w *WaitGetWarehouseDeleted[R]) Get() (*GetWarehouseResponse, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the GetWarehouseResponse with custom timeout.
+func (w *WaitGetWarehouseDeleted[R]) GetWithTimeout(timeout time.Duration) (*GetWarehouseResponse, error) {
+	return w.poll(timeout, w.callback)
+}
+
+// WaitGetWarehouseRunning calls [WarehousesAPI.Get] and waits to reach RUNNING state
+func (a *WarehousesAPI) WaitGetWarehouseRunning(ctx context.Context, id string,
+	timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
+	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
+	return retries.Poll[GetWarehouseResponse](ctx, timeout, func() (*GetWarehouseResponse, *retries.Err) {
+		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
+			Id: id,
+		})
+		if err != nil {
+			return nil, retries.Halt(err)
+		}
+		if callback != nil {
+			callback(getWarehouseResponse)
 		}
 		status := getWarehouseResponse.State
 		statusMessage := fmt.Sprintf("current status: %s", status)
@@ -1118,39 +1151,44 @@ func (a *WarehousesAPI) CreateAndWait(ctx context.Context, createWarehouseReques
 	})
 }
 
-// Delete a warehouse.
-//
-// Deletes a SQL warehouse.
-func (a *WarehousesAPI) Delete(ctx context.Context, request DeleteWarehouseRequest) error {
-	return a.impl.Delete(ctx, request)
+// WaitGetWarehouseRunning is a wrapper that calls [WarehousesAPI.WaitGetWarehouseRunning] and waits to reach RUNNING state.
+type WaitGetWarehouseRunning[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*GetWarehouseResponse)) (*GetWarehouseResponse, error)
+	callback func(*GetWarehouseResponse)
+	timeout  time.Duration
 }
 
-// Calls [WarehousesAPI.Delete] and waits to reach DELETED state
-//
-// You can override the default timeout of 20 minutes by calling adding
-// retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
-func (a *WarehousesAPI) DeleteAndWait(ctx context.Context, deleteWarehouseRequest DeleteWarehouseRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *WaitGetWarehouseRunning[R]) OnProgress(callback func(*GetWarehouseResponse)) *WaitGetWarehouseRunning[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the GetWarehouseResponse with the default timeout of 20 minutes.
+func (w *WaitGetWarehouseRunning[R]) Get() (*GetWarehouseResponse, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the GetWarehouseResponse with custom timeout.
+func (w *WaitGetWarehouseRunning[R]) GetWithTimeout(timeout time.Duration) (*GetWarehouseResponse, error) {
+	return w.poll(timeout, w.callback)
+}
+
+// WaitGetWarehouseStopped calls [WarehousesAPI.Stop] and waits to reach STOPPED state
+func (a *WarehousesAPI) WaitGetWarehouseStopped(ctx context.Context, id string,
+	timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
 	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.Delete(ctx, deleteWarehouseRequest)
-	if err != nil {
-		return nil, err
-	}
-	i := retries.Info[GetWarehouseResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetWarehouseResponse](ctx, i.Timeout, func() (*GetWarehouseResponse, *retries.Err) {
+	return retries.Poll[GetWarehouseResponse](ctx, timeout, func() (*GetWarehouseResponse, *retries.Err) {
 		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
-			Id: deleteWarehouseRequest.Id,
+			Id: id,
 		})
 		if err != nil {
 			return nil, retries.Halt(err)
 		}
-		for _, o := range options {
-			o(&retries.Info[GetWarehouseResponse]{
-				Info:    getWarehouseResponse,
-				Timeout: i.Timeout,
-			})
+		if callback != nil {
+			callback(getWarehouseResponse)
 		}
 		status := getWarehouseResponse.State
 		statusMessage := fmt.Sprintf("current status: %s", status)
@@ -1158,12 +1196,119 @@ func (a *WarehousesAPI) DeleteAndWait(ctx context.Context, deleteWarehouseReques
 			statusMessage = getWarehouseResponse.Health.Summary
 		}
 		switch status {
-		case StateDeleted: // target state
+		case StateStopped: // target state
 			return getWarehouseResponse, nil
 		default:
 			return nil, retries.Continues(statusMessage)
 		}
 	})
+}
+
+// WaitGetWarehouseStopped is a wrapper that calls [WarehousesAPI.WaitGetWarehouseStopped] and waits to reach STOPPED state.
+type WaitGetWarehouseStopped[R any] struct {
+	Response *R
+
+	poll     func(time.Duration, func(*GetWarehouseResponse)) (*GetWarehouseResponse, error)
+	callback func(*GetWarehouseResponse)
+	timeout  time.Duration
+}
+
+// OnProgress invokes a callback every time it polls for the status update.
+func (w *WaitGetWarehouseStopped[R]) OnProgress(callback func(*GetWarehouseResponse)) *WaitGetWarehouseStopped[R] {
+	w.callback = callback
+	return w
+}
+
+// Get the GetWarehouseResponse with the default timeout of 20 minutes.
+func (w *WaitGetWarehouseStopped[R]) Get() (*GetWarehouseResponse, error) {
+	return w.poll(w.timeout, w.callback)
+}
+
+// Get the GetWarehouseResponse with custom timeout.
+func (w *WaitGetWarehouseStopped[R]) GetWithTimeout(timeout time.Duration) (*GetWarehouseResponse, error) {
+	return w.poll(timeout, w.callback)
+}
+
+// Create a warehouse.
+//
+// Creates a new SQL warehouse.
+func (a *WarehousesAPI) Create(ctx context.Context, createWarehouseRequest CreateWarehouseRequest) (*WaitGetWarehouseRunning[CreateWarehouseResponse], error) {
+	createWarehouseResponse, err := a.impl.Create(ctx, createWarehouseRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetWarehouseRunning[CreateWarehouseResponse]{
+		Response: createWarehouseResponse,
+		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
+			return a.WaitGetWarehouseRunning(ctx, createWarehouseResponse.Id, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
+}
+
+// Calls [WarehousesAPI.Create] and waits to reach RUNNING state
+//
+// You can override the default timeout of 20 minutes by calling adding
+// retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [WarehousesAPI.Create].Get() or [WarehousesAPI.WaitGetWarehouseRunning]
+func (a *WarehousesAPI) CreateAndWait(ctx context.Context, createWarehouseRequest CreateWarehouseRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
+	wait, err := a.Create(ctx, createWarehouseRequest)
+	if err != nil {
+		return nil, err
+	}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetWarehouseResponse) {
+		for _, o := range options {
+			o(&retries.Info[GetWarehouseResponse]{
+				Info:    info,
+				Timeout: wait.timeout,
+			})
+		}
+	}
+	return wait.Get()
+}
+
+// Delete a warehouse.
+//
+// Deletes a SQL warehouse.
+func (a *WarehousesAPI) Delete(ctx context.Context, deleteWarehouseRequest DeleteWarehouseRequest) (*WaitGetWarehouseDeleted[any], error) {
+	err := a.impl.Delete(ctx, deleteWarehouseRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetWarehouseDeleted[any]{
+
+		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
+			return a.WaitGetWarehouseDeleted(ctx, deleteWarehouseRequest.Id, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
+}
+
+// Calls [WarehousesAPI.Delete] and waits to reach DELETED state
+//
+// You can override the default timeout of 20 minutes by calling adding
+// retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [WarehousesAPI.Delete].Get() or [WarehousesAPI.WaitGetWarehouseDeleted]
+func (a *WarehousesAPI) DeleteAndWait(ctx context.Context, deleteWarehouseRequest DeleteWarehouseRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
+	wait, err := a.Delete(ctx, deleteWarehouseRequest)
+	if err != nil {
+		return nil, err
+	}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetWarehouseResponse) {
+		for _, o := range options {
+			o(&retries.Info[GetWarehouseResponse]{
+				Info:    info,
+				Timeout: wait.timeout,
+			})
+		}
+	}
+	return wait.Get()
 }
 
 // Delete a warehouse.
@@ -1184,53 +1329,42 @@ func (a *WarehousesAPI) DeleteByIdAndWait(ctx context.Context, id string, option
 // Update a warehouse.
 //
 // Updates the configuration for a SQL warehouse.
-func (a *WarehousesAPI) Edit(ctx context.Context, request EditWarehouseRequest) error {
-	return a.impl.Edit(ctx, request)
+func (a *WarehousesAPI) Edit(ctx context.Context, editWarehouseRequest EditWarehouseRequest) (*WaitGetWarehouseRunning[any], error) {
+	err := a.impl.Edit(ctx, editWarehouseRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetWarehouseRunning[any]{
+
+		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
+			return a.WaitGetWarehouseRunning(ctx, editWarehouseRequest.Id, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [WarehousesAPI.Edit] and waits to reach RUNNING state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [WarehousesAPI.Edit].Get() or [WarehousesAPI.WaitGetWarehouseRunning]
 func (a *WarehousesAPI) EditAndWait(ctx context.Context, editWarehouseRequest EditWarehouseRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.Edit(ctx, editWarehouseRequest)
+	wait, err := a.Edit(ctx, editWarehouseRequest)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[GetWarehouseResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetWarehouseResponse](ctx, i.Timeout, func() (*GetWarehouseResponse, *retries.Err) {
-		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
-			Id: editWarehouseRequest.Id,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetWarehouseResponse) {
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    getWarehouseResponse,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := getWarehouseResponse.State
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if getWarehouseResponse.Health != nil {
-			statusMessage = getWarehouseResponse.Health.Summary
-		}
-		switch status {
-		case StateRunning: // target state
-			return getWarehouseResponse, nil
-		case StateStopped, StateDeleted:
-			err := fmt.Errorf("failed to reach %s, got %s: %s",
-				StateRunning, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Get warehouse info.
@@ -1240,51 +1374,6 @@ func (a *WarehousesAPI) Get(ctx context.Context, request GetWarehouseRequest) (*
 	return a.impl.Get(ctx, request)
 }
 
-// Calls [WarehousesAPI.Get] and waits to reach RUNNING state
-//
-// You can override the default timeout of 20 minutes by calling adding
-// retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
-func (a *WarehousesAPI) GetAndWait(ctx context.Context, getWarehouseRequest GetWarehouseRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	getWarehouseResponse, err := a.Get(ctx, getWarehouseRequest)
-	if err != nil {
-		return nil, err
-	}
-	i := retries.Info[GetWarehouseResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetWarehouseResponse](ctx, i.Timeout, func() (*GetWarehouseResponse, *retries.Err) {
-		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
-			Id: getWarehouseResponse.Id,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
-		for _, o := range options {
-			o(&retries.Info[GetWarehouseResponse]{
-				Info:    getWarehouseResponse,
-				Timeout: i.Timeout,
-			})
-		}
-		status := getWarehouseResponse.State
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if getWarehouseResponse.Health != nil {
-			statusMessage = getWarehouseResponse.Health.Summary
-		}
-		switch status {
-		case StateRunning: // target state
-			return getWarehouseResponse, nil
-		case StateStopped, StateDeleted:
-			err := fmt.Errorf("failed to reach %s, got %s: %s",
-				StateRunning, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
-}
-
 // Get warehouse info.
 //
 // Gets the information for a single SQL warehouse.
@@ -1292,12 +1381,6 @@ func (a *WarehousesAPI) GetById(ctx context.Context, id string) (*GetWarehouseRe
 	return a.impl.Get(ctx, GetWarehouseRequest{
 		Id: id,
 	})
-}
-
-func (a *WarehousesAPI) GetByIdAndWait(ctx context.Context, id string, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
-	return a.GetAndWait(ctx, GetWarehouseRequest{
-		Id: id,
-	}, options...)
 }
 
 // Get the workspace configuration.
@@ -1385,99 +1468,81 @@ func (a *WarehousesAPI) SetWorkspaceWarehouseConfig(ctx context.Context, request
 // Start a warehouse.
 //
 // Starts a SQL warehouse.
-func (a *WarehousesAPI) Start(ctx context.Context, request StartRequest) error {
-	return a.impl.Start(ctx, request)
+func (a *WarehousesAPI) Start(ctx context.Context, startRequest StartRequest) (*WaitGetWarehouseRunning[any], error) {
+	err := a.impl.Start(ctx, startRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetWarehouseRunning[any]{
+
+		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
+			return a.WaitGetWarehouseRunning(ctx, startRequest.Id, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [WarehousesAPI.Start] and waits to reach RUNNING state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [WarehousesAPI.Start].Get() or [WarehousesAPI.WaitGetWarehouseRunning]
 func (a *WarehousesAPI) StartAndWait(ctx context.Context, startRequest StartRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.Start(ctx, startRequest)
+	wait, err := a.Start(ctx, startRequest)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[GetWarehouseResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetWarehouseResponse](ctx, i.Timeout, func() (*GetWarehouseResponse, *retries.Err) {
-		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
-			Id: startRequest.Id,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetWarehouseResponse) {
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    getWarehouseResponse,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := getWarehouseResponse.State
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if getWarehouseResponse.Health != nil {
-			statusMessage = getWarehouseResponse.Health.Summary
-		}
-		switch status {
-		case StateRunning: // target state
-			return getWarehouseResponse, nil
-		case StateStopped, StateDeleted:
-			err := fmt.Errorf("failed to reach %s, got %s: %s",
-				StateRunning, status, statusMessage)
-			return nil, retries.Halt(err)
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }
 
 // Stop a warehouse.
 //
 // Stops a SQL warehouse.
-func (a *WarehousesAPI) Stop(ctx context.Context, request StopRequest) error {
-	return a.impl.Stop(ctx, request)
+func (a *WarehousesAPI) Stop(ctx context.Context, stopRequest StopRequest) (*WaitGetWarehouseStopped[any], error) {
+	err := a.impl.Stop(ctx, stopRequest)
+	if err != nil {
+		return nil, err
+	}
+	return &WaitGetWarehouseStopped[any]{
+
+		poll: func(timeout time.Duration, callback func(*GetWarehouseResponse)) (*GetWarehouseResponse, error) {
+			return a.WaitGetWarehouseStopped(ctx, stopRequest.Id, timeout, callback)
+		},
+		timeout:  20 * time.Minute,
+		callback: nil,
+	}, nil
 }
 
 // Calls [WarehousesAPI.Stop] and waits to reach STOPPED state
 //
 // You can override the default timeout of 20 minutes by calling adding
 // retries.Timeout[GetWarehouseResponse](60*time.Minute) functional option.
+//
+// Deprecated: use [WarehousesAPI.Stop].Get() or [WarehousesAPI.WaitGetWarehouseStopped]
 func (a *WarehousesAPI) StopAndWait(ctx context.Context, stopRequest StopRequest, options ...retries.Option[GetWarehouseResponse]) (*GetWarehouseResponse, error) {
-	ctx = useragent.InContext(ctx, "sdk-feature", "long-running")
-	err := a.Stop(ctx, stopRequest)
+	wait, err := a.Stop(ctx, stopRequest)
 	if err != nil {
 		return nil, err
 	}
-	i := retries.Info[GetWarehouseResponse]{Timeout: 20 * time.Minute}
-	for _, o := range options {
-		o(&i)
-	}
-	return retries.Poll[GetWarehouseResponse](ctx, i.Timeout, func() (*GetWarehouseResponse, *retries.Err) {
-		getWarehouseResponse, err := a.Get(ctx, GetWarehouseRequest{
-			Id: stopRequest.Id,
-		})
-		if err != nil {
-			return nil, retries.Halt(err)
-		}
+	wait.timeout = 20 * time.Minute
+	wait.callback = func(info *GetWarehouseResponse) {
 		for _, o := range options {
 			o(&retries.Info[GetWarehouseResponse]{
-				Info:    getWarehouseResponse,
-				Timeout: i.Timeout,
+				Info:    info,
+				Timeout: wait.timeout,
 			})
 		}
-		status := getWarehouseResponse.State
-		statusMessage := fmt.Sprintf("current status: %s", status)
-		if getWarehouseResponse.Health != nil {
-			statusMessage = getWarehouseResponse.Health.Summary
-		}
-		switch status {
-		case StateStopped: // target state
-			return getWarehouseResponse, nil
-		default:
-			return nil, retries.Continues(statusMessage)
-		}
-	})
+	}
+	return wait.Get()
 }

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -120,7 +120,6 @@ type ChannelInfo struct {
 	Name ChannelName `json:"name,omitempty"`
 }
 
-// Name of the channel
 type ChannelName string
 
 const ChannelNameChannelNameCurrent ChannelName = `CHANNEL_NAME_CURRENT`

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -120,6 +120,7 @@ type ChannelInfo struct {
 	Name ChannelName `json:"name,omitempty"`
 }
 
+// Name of the channel
 type ChannelName string
 
 const ChannelNameChannelNameCurrent ChannelName = `CHANNEL_NAME_CURRENT`

--- a/service/sql/warehouses_usage_test.go
+++ b/service/sql/warehouses_usage_test.go
@@ -33,7 +33,7 @@ func ExampleWarehousesAPI_Create_sqlWarehouses() {
 
 	// cleanup
 
-	_, err = w.Warehouses.DeleteByIdAndWait(ctx, created.Id)
+	err = w.Warehouses.DeleteById(ctx, created.Id)
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +58,7 @@ func ExampleWarehousesAPI_Edit_sqlWarehouses() {
 	}
 	logger.Infof(ctx, "found %v", created)
 
-	err = w.Warehouses.Edit(ctx, sql.EditWarehouseRequest{
+	_, err = w.Warehouses.Edit(ctx, sql.EditWarehouseRequest{
 		Id:             created.Id,
 		Name:           fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
 		ClusterSize:    "2X-Small",
@@ -71,7 +71,7 @@ func ExampleWarehousesAPI_Edit_sqlWarehouses() {
 
 	// cleanup
 
-	_, err = w.Warehouses.DeleteByIdAndWait(ctx, created.Id)
+	err = w.Warehouses.DeleteById(ctx, created.Id)
 	if err != nil {
 		panic(err)
 	}
@@ -104,7 +104,7 @@ func ExampleWarehousesAPI_Get_sqlWarehouses() {
 
 	// cleanup
 
-	_, err = w.Warehouses.DeleteByIdAndWait(ctx, created.Id)
+	err = w.Warehouses.DeleteById(ctx, created.Id)
 	if err != nil {
 		panic(err)
 	}

--- a/service/workspace/workspace_usage_test.go
+++ b/service/workspace/workspace_usage_test.go
@@ -32,7 +32,7 @@ func ExampleWorkspaceAPI_Export_workspaceIntegration() {
 
 	exportResponse, err := w.Workspace.Export(ctx, workspace.ExportRequest{
 		DirectDownload: false,
-		Format:         "SOURCE",
+		Format:         workspace.ExportFormatSource,
 		Path:           notebook,
 	})
 	if err != nil {
@@ -193,8 +193,8 @@ func ExampleWorkspaceAPI_Import_workspaceIntegration() {
 
 	err = w.Workspace.Import(ctx, workspace.Import{
 		Path:      notebook,
-		Format:    "SOURCE",
-		Language:  "PYTHON",
+		Format:    workspace.ExportFormatSource,
+		Language:  workspace.LanguagePython,
 		Content:   base64.StdEncoding.EncodeToString([]byte(("# Databricks notebook source\nprint('hello from job')"))),
 		Overwrite: true,
 	})


### PR DESCRIPTION
## Changes

* Deprecated `*AndWait` methods, will be removed in further releases. This PR keeps backwards compatibility for these methods.
* Introduced dedicated wait-for-state polling methods. This PR breaks compatibility for these methods and increases coherence with other SDKs
* `*API` clients with long-running semantics now always return an instance, that allows to optionally start polling

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

