### PR TITLE
Revert "Do not use cached entities in code generation (#403)"

### DIFF
--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -253,6 +253,11 @@ func (pkg *Package) definedEntity(name string, s *openapi.Schema) *Entity {
 		return pkg.define(entity)
 	}
 
+	component := pkg.localComponent(&s.Node)
+	if s.IsRef() && pkg.types[component] != nil {
+		// entity is defined, return from cache
+		return pkg.types[component]
+	}
 	e := pkg.schemaToEntity(s, []string{name}, true)
 	if e == nil {
 		// gets here when responses are objects with no properties
@@ -264,7 +269,8 @@ func (pkg *Package) definedEntity(name string, s *openapi.Schema) *Entity {
 	if e.Name == "" {
 		e.Named = Named{name, s.Description}
 	}
-	return pkg.define(e)
+	pkg.define(e)
+	return pkg.types[e.Name]
 }
 
 func (pkg *Package) define(entity *Entity) *Entity {


### PR DESCRIPTION
This reverts commit 0af0ffcfe4e6ea977347ab107d16e5b2de9e7e41, otherwise, we miss the path parameters in the requests and break all SDKs
![image](https://github.com/databricks/databricks-sdk-go/assets/259697/8c6b17a2-7576-4090-9276-050b11604c9e)