### PR TITLE
Added type update when entity fields are updated

### DIFF
--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -173,6 +173,7 @@ func (svc *Service) newRequest(params []openapi.Parameter, op *openapi.Operation
 			}
 		}
 	}
+	svc.Package.updateType(request)
 	if request.Name == "" {
 		// when there was a merge of params with a request or new entity was made
 		signularServiceName := svc.Singular().PascalName()


### PR DESCRIPTION
## Changes
Added type update when entity fields are updated.

it also removes the caching, so every time we define an entity a new one is returned.

Keeping the cache would make the logic too complex, in particular
Case 1.
When we get the entity from cache but changing its fields, like [here](https://github.com/databricks/databricks-sdk-go/blob/main/openapi/code/service.go#L161), we can check if this field does not exist and the entity is from cache and create a new entity as a copy but with different name. The issue with that is
1. What if the field is removed and not added? We won't be able to detect this
2. New very similarly looking structuring will be created, which can cause confusion
3. The logic becomes a bit too complex

Case 2.
Let's say we process request which has no / less / different required fields but uses the same request entity as the one that requires. As an example, some create and update resource requests which uses the same request body but create does not require ID field. 
When we get the entity which has required fields from cache we would need to see if required fields are different, again create a copy of request entity with different name and use it instead.
Again, it will make the logic more complex because we conditionally need to use new (non-cached) entity.

Thus, it is easier not to use cache at all.


## Tests
[x] Made sure SDK is generated correctly
[x] Made sure CLI is generated correctly

