### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ The Databricks SDK for Go includes functionality to accelerate development with 
       "context"
 
       "github.com/databricks/databricks-sdk-go"
-      "github.com/databricks/databricks-sdk-go/service/clusters"
+      "github.com/databricks/databricks-sdk-go/service/compute"
     )
 
     func main() {
       w := databricks.Must(databricks.NewWorkspaceClient())
-      all, err := w.Clusters.ListAll(context.Background(), clusters.List{})
+      all, err := w.Clusters.ListAll(context.Background(), compute.ListClustersRequest{})
       if err != nil {
         panic(err)
       }


### PR DESCRIPTION
## Changes
Fix example for the fact that `clusters` module no longer exists.

## Tests
I ran the example.