### PR TITLE
Allow enum types to be set to empty string

### DIFF
--- a/.codegen/model.go.tmpl
+++ b/.codegen/model.go.tmpl
@@ -34,6 +34,10 @@ func ({{.AbbrName}} *{{.PascalName}}) Set(v string) error {
     case {{range $i, $e := .Enum }}{{if $i}}, {{end}}`{{.Content}}`{{end}}:
         *{{.AbbrName}} = {{.PascalName}}(v)
         return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*{{.AbbrName}} = {{.PascalName}}(``)
+		return nil
     default:
         return fmt.Errorf(`value "%s" is not one of {{range $i, $e := .Enum }}{{if $i}}, {{end}}"{{.Content}}"{{end}}`, v)
     }

--- a/service/billing/model.go
+++ b/service/billing/model.go
@@ -211,6 +211,10 @@ func (ds *DeliveryStatus) Set(v string) error {
 	case `CREATED`, `NOT_FOUND`, `SUCCEEDED`, `SYSTEM_FAILURE`, `USER_FAILURE`:
 		*ds = DeliveryStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ds = DeliveryStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CREATED", "NOT_FOUND", "SUCCEEDED", "SYSTEM_FAILURE", "USER_FAILURE"`, v)
 	}
@@ -278,6 +282,10 @@ func (ldcs *LogDeliveryConfigStatus) Set(v string) error {
 	switch v {
 	case `DISABLED`, `ENABLED`:
 		*ldcs = LogDeliveryConfigStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ldcs = LogDeliveryConfigStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DISABLED", "ENABLED"`, v)
@@ -416,6 +424,10 @@ func (lt *LogType) Set(v string) error {
 	case `AUDIT_LOGS`, `BILLABLE_USAGE`:
 		*lt = LogType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lt = LogType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "AUDIT_LOGS", "BILLABLE_USAGE"`, v)
 	}
@@ -452,6 +464,10 @@ func (of *OutputFormat) Set(v string) error {
 	switch v {
 	case `CSV`, `JSON`:
 		*of = OutputFormat(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*of = OutputFormat(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CSV", "JSON"`, v)

--- a/service/catalog/model.go
+++ b/service/catalog/model.go
@@ -147,6 +147,10 @@ func (ct *CatalogType) Set(v string) error {
 	case `DELTASHARING_CATALOG`, `MANAGED_CATALOG`, `SYSTEM_CATALOG`:
 		*ct = CatalogType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ct = CatalogType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DELTASHARING_CATALOG", "MANAGED_CATALOG", "SYSTEM_CATALOG"`, v)
 	}
@@ -250,6 +254,10 @@ func (ctn *ColumnTypeName) Set(v string) error {
 	case `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TABLE_TYPE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `USER_DEFINED_TYPE`:
 		*ctn = ColumnTypeName(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ctn = ColumnTypeName(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TABLE_TYPE", "TIMESTAMP", "TIMESTAMP_NTZ", "USER_DEFINED_TYPE"`, v)
 	}
@@ -323,6 +331,10 @@ func (ct *ConnectionType) Set(v string) error {
 	switch v {
 	case `DATABRICKS`, `MYSQL`, `POSTGRESQL`, `REDSHIFT`, `SNOWFLAKE`, `SQLDW`, `SQLSERVER`:
 		*ct = ConnectionType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ct = ConnectionType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DATABRICKS", "MYSQL", "POSTGRESQL", "REDSHIFT", "SNOWFLAKE", "SQLDW", "SQLSERVER"`, v)
@@ -452,6 +464,10 @@ func (cfps *CreateFunctionParameterStyle) Set(v string) error {
 	case `S`:
 		*cfps = CreateFunctionParameterStyle(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cfps = CreateFunctionParameterStyle(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "S"`, v)
 	}
@@ -483,6 +499,10 @@ func (cfrb *CreateFunctionRoutineBody) Set(v string) error {
 	case `EXTERNAL`, `SQL`:
 		*cfrb = CreateFunctionRoutineBody(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cfrb = CreateFunctionRoutineBody(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EXTERNAL", "SQL"`, v)
 	}
@@ -508,6 +528,10 @@ func (cfst *CreateFunctionSecurityType) Set(v string) error {
 	switch v {
 	case `DEFINER`:
 		*cfst = CreateFunctionSecurityType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cfst = CreateFunctionSecurityType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DEFINER"`, v)
@@ -538,6 +562,10 @@ func (cfsda *CreateFunctionSqlDataAccess) Set(v string) error {
 	switch v {
 	case `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`:
 		*cfsda = CreateFunctionSqlDataAccess(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cfsda = CreateFunctionSqlDataAccess(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CONTAINS_SQL", "NO_SQL", "READS_SQL_DATA"`, v)
@@ -642,6 +670,10 @@ func (ct *CredentialType) Set(v string) error {
 	case `USERNAME_PASSWORD`:
 		*ct = CredentialType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ct = CredentialType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "USERNAME_PASSWORD"`, v)
 	}
@@ -689,6 +721,10 @@ func (dsf *DataSourceFormat) Set(v string) error {
 	switch v {
 	case `AVRO`, `CSV`, `DELTA`, `DELTASHARING`, `JSON`, `ORC`, `PARQUET`, `TEXT`, `UNITY_CATALOG`:
 		*dsf = DataSourceFormat(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*dsf = DataSourceFormat(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "AVRO", "CSV", "DELTA", "DELTASHARING", "JSON", "ORC", "PARQUET", "TEXT", "UNITY_CATALOG"`, v)
@@ -864,6 +900,10 @@ func (eamfift *EffectiveAutoMaintenanceFlagInheritedFromType) Set(v string) erro
 	case `CATALOG`, `SCHEMA`:
 		*eamfift = EffectiveAutoMaintenanceFlagInheritedFromType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*eamfift = EffectiveAutoMaintenanceFlagInheritedFromType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CATALOG", "SCHEMA"`, v)
 	}
@@ -921,6 +961,10 @@ func (eam *EnableAutoMaintenance) Set(v string) error {
 	switch v {
 	case `DISABLE`, `ENABLE`, `INHERIT`:
 		*eam = EnableAutoMaintenance(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*eam = EnableAutoMaintenance(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DISABLE", "ENABLE", "INHERIT"`, v)
@@ -1061,6 +1105,10 @@ func (fips *FunctionInfoParameterStyle) Set(v string) error {
 	case `S`:
 		*fips = FunctionInfoParameterStyle(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fips = FunctionInfoParameterStyle(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "S"`, v)
 	}
@@ -1092,6 +1140,10 @@ func (firb *FunctionInfoRoutineBody) Set(v string) error {
 	case `EXTERNAL`, `SQL`:
 		*firb = FunctionInfoRoutineBody(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*firb = FunctionInfoRoutineBody(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EXTERNAL", "SQL"`, v)
 	}
@@ -1117,6 +1169,10 @@ func (fist *FunctionInfoSecurityType) Set(v string) error {
 	switch v {
 	case `DEFINER`:
 		*fist = FunctionInfoSecurityType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fist = FunctionInfoSecurityType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DEFINER"`, v)
@@ -1147,6 +1203,10 @@ func (fisda *FunctionInfoSqlDataAccess) Set(v string) error {
 	switch v {
 	case `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`:
 		*fisda = FunctionInfoSqlDataAccess(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fisda = FunctionInfoSqlDataAccess(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CONTAINS_SQL", "NO_SQL", "READS_SQL_DATA"`, v)
@@ -1201,6 +1261,10 @@ func (fpm *FunctionParameterMode) Set(v string) error {
 	case `IN`:
 		*fpm = FunctionParameterMode(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fpm = FunctionParameterMode(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "IN"`, v)
 	}
@@ -1228,6 +1292,10 @@ func (fpt *FunctionParameterType) Set(v string) error {
 	switch v {
 	case `COLUMN`, `PARAM`:
 		*fpt = FunctionParameterType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fpt = FunctionParameterType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "COLUMN", "PARAM"`, v)
@@ -1372,6 +1440,10 @@ func (gmsrdss *GetMetastoreSummaryResponseDeltaSharingScope) Set(v string) error
 	case `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
 		*gmsrdss = GetMetastoreSummaryResponseDeltaSharingScope(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*gmsrdss = GetMetastoreSummaryResponseDeltaSharingScope(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "INTERNAL", "INTERNAL_AND_EXTERNAL"`, v)
 	}
@@ -1426,6 +1498,10 @@ func (im *IsolationMode) Set(v string) error {
 	switch v {
 	case `ISOLATED`, `OPEN`:
 		*im = IsolationMode(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*im = IsolationMode(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ISOLATED", "OPEN"`, v)
@@ -1639,6 +1715,10 @@ func (midss *MetastoreInfoDeltaSharingScope) Set(v string) error {
 	case `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
 		*midss = MetastoreInfoDeltaSharingScope(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*midss = MetastoreInfoDeltaSharingScope(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "INTERNAL", "INTERNAL_AND_EXTERNAL"`, v)
 	}
@@ -1753,6 +1833,10 @@ func (p *Privilege) Set(v string) error {
 	case `ALL_PRIVILEGES`, `CREATE`, `CREATE_CATALOG`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `CREATE_FUNCTION`, `CREATE_MANAGED_STORAGE`, `CREATE_MATERIALIZED_VIEW`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SCHEMA`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `CREATE_TABLE`, `CREATE_VIEW`, `EXECUTE`, `MODIFY`, `READ_FILES`, `READ_PRIVATE_FILES`, `REFRESH`, `SELECT`, `SET_SHARE_PERMISSION`, `USAGE`, `USE_CATALOG`, `USE_PROVIDER`, `USE_RECIPIENT`, `USE_SCHEMA`, `USE_SHARE`, `WRITE_FILES`, `WRITE_PRIVATE_FILES`:
 		*p = Privilege(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*p = Privilege(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ALL_PRIVILEGES", "CREATE", "CREATE_CATALOG", "CREATE_EXTERNAL_LOCATION", "CREATE_EXTERNAL_TABLE", "CREATE_FUNCTION", "CREATE_MANAGED_STORAGE", "CREATE_MATERIALIZED_VIEW", "CREATE_PROVIDER", "CREATE_RECIPIENT", "CREATE_SCHEMA", "CREATE_SHARE", "CREATE_STORAGE_CREDENTIAL", "CREATE_TABLE", "CREATE_VIEW", "EXECUTE", "MODIFY", "READ_FILES", "READ_PRIVATE_FILES", "REFRESH", "SELECT", "SET_SHARE_PERMISSION", "USAGE", "USE_CATALOG", "USE_PROVIDER", "USE_RECIPIENT", "USE_SCHEMA", "USE_SHARE", "WRITE_FILES", "WRITE_PRIVATE_FILES"`, v)
 	}
@@ -1852,6 +1936,10 @@ func (st *SecurableType) Set(v string) error {
 	case `CATALOG`, `EXTERNAL_LOCATION`, `FUNCTION`, `METASTORE`, `PROVIDER`, `RECIPIENT`, `SCHEMA`, `SHARE`, `STORAGE_CREDENTIAL`, `TABLE`:
 		*st = SecurableType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*st = SecurableType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CATALOG", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE"`, v)
 	}
@@ -1926,6 +2014,10 @@ func (ssis *SystemSchemaInfoState) Set(v string) error {
 	switch v {
 	case `DisableInitialized`, `EnableCompleted`, `EnableInitialized`, `Unavailable`:
 		*ssis = SystemSchemaInfoState(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ssis = SystemSchemaInfoState(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DisableInitialized", "EnableCompleted", "EnableInitialized", "Unavailable"`, v)
@@ -2067,6 +2159,10 @@ func (tt *TableType) Set(v string) error {
 	case `EXTERNAL`, `MANAGED`, `MATERIALIZED_VIEW`, `STREAMING_TABLE`, `VIEW`:
 		*tt = TableType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*tt = TableType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EXTERNAL", "MANAGED", "MATERIALIZED_VIEW", "STREAMING_TABLE", "VIEW"`, v)
 	}
@@ -2198,6 +2294,10 @@ func (umdss *UpdateMetastoreDeltaSharingScope) Set(v string) error {
 	switch v {
 	case `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
 		*umdss = UpdateMetastoreDeltaSharingScope(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*umdss = UpdateMetastoreDeltaSharingScope(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "INTERNAL", "INTERNAL_AND_EXTERNAL"`, v)
@@ -2333,6 +2433,10 @@ func (vro *ValidationResultOperation) Set(v string) error {
 	case `DELETE`, `LIST`, `READ`, `WRITE`:
 		*vro = ValidationResultOperation(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*vro = ValidationResultOperation(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DELETE", "LIST", "READ", "WRITE"`, v)
 	}
@@ -2362,6 +2466,10 @@ func (vrr *ValidationResultResult) Set(v string) error {
 	switch v {
 	case `FAIL`, `PASS`, `SKIP`:
 		*vrr = ValidationResultResult(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*vrr = ValidationResultResult(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FAIL", "PASS", "SKIP"`, v)
@@ -2420,6 +2528,10 @@ func (vt *VolumeType) Set(v string) error {
 	switch v {
 	case `EXTERNAL`, `MANAGED`:
 		*vt = VolumeType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*vt = VolumeType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EXTERNAL", "MANAGED"`, v)

--- a/service/compute/model.go
+++ b/service/compute/model.go
@@ -155,6 +155,10 @@ func (aa *AwsAvailability) Set(v string) error {
 	case `ON_DEMAND`, `SPOT`, `SPOT_WITH_FALLBACK`:
 		*aa = AwsAvailability(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*aa = AwsAvailability(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ON_DEMAND", "SPOT", "SPOT_WITH_FALLBACK"`, v)
 	}
@@ -212,6 +216,10 @@ func (aa *AzureAvailability) Set(v string) error {
 	switch v {
 	case `ON_DEMAND_AZURE`, `SPOT_AZURE`, `SPOT_WITH_FALLBACK_AZURE`:
 		*aa = AzureAvailability(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*aa = AzureAvailability(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ON_DEMAND_AZURE", "SPOT_AZURE", "SPOT_WITH_FALLBACK_AZURE"`, v)
@@ -390,6 +398,10 @@ func (cpns *CloudProviderNodeStatus) Set(v string) error {
 	switch v {
 	case `NotAvailableInRegion`, `NotEnabledOnSubscription`:
 		*cpns = CloudProviderNodeStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cpns = CloudProviderNodeStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "NotAvailableInRegion", "NotEnabledOnSubscription"`, v)
@@ -777,6 +789,10 @@ func (cs *ClusterSource) Set(v string) error {
 	case `API`, `JOB`, `MODELS`, `PIPELINE`, `PIPELINE_MAINTENANCE`, `SQL`, `UI`:
 		*cs = ClusterSource(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cs = ClusterSource(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "API", "JOB", "MODELS", "PIPELINE", "PIPELINE_MAINTENANCE", "SQL", "UI"`, v)
 	}
@@ -829,6 +845,10 @@ func (cs *CommandStatus) Set(v string) error {
 	case `Cancelled`, `Cancelling`, `Error`, `Finished`, `Queued`, `Running`:
 		*cs = CommandStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cs = CommandStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "Cancelled", "Cancelling", "Error", "Finished", "Queued", "Running"`, v)
 	}
@@ -874,6 +894,10 @@ func (cs *ContextStatus) Set(v string) error {
 	switch v {
 	case `Error`, `Pending`, `Running`:
 		*cs = ContextStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cs = ContextStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "Error", "Pending", "Running"`, v)
@@ -1164,6 +1188,10 @@ func (dpedet *DataPlaneEventDetailsEventType) Set(v string) error {
 	case `NODE_BLACKLISTED`, `NODE_EXCLUDED_DECOMMISSIONED`:
 		*dpedet = DataPlaneEventDetailsEventType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*dpedet = DataPlaneEventDetailsEventType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "NODE_BLACKLISTED", "NODE_EXCLUDED_DECOMMISSIONED"`, v)
 	}
@@ -1213,6 +1241,10 @@ func (dsm *DataSecurityMode) Set(v string) error {
 	switch v {
 	case `LEGACY_PASSTHROUGH`, `LEGACY_SINGLE_USER`, `LEGACY_TABLE_ACL`, `NONE`, `SINGLE_USER`, `USER_ISOLATION`:
 		*dsm = DataSecurityMode(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*dsm = DataSecurityMode(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_TABLE_ACL", "NONE", "SINGLE_USER", "USER_ISOLATION"`, v)
@@ -1314,6 +1346,10 @@ func (dtadvt *DiskTypeAzureDiskVolumeType) Set(v string) error {
 	case `PREMIUM_LRS`, `STANDARD_LRS`:
 		*dtadvt = DiskTypeAzureDiskVolumeType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*dtadvt = DiskTypeAzureDiskVolumeType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "PREMIUM_LRS", "STANDARD_LRS"`, v)
 	}
@@ -1340,6 +1376,10 @@ func (dtevt *DiskTypeEbsVolumeType) Set(v string) error {
 	switch v {
 	case `GENERAL_PURPOSE_SSD`, `THROUGHPUT_OPTIMIZED_HDD`:
 		*dtevt = DiskTypeEbsVolumeType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*dtevt = DiskTypeEbsVolumeType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"`, v)
@@ -1381,6 +1421,10 @@ func (evt *EbsVolumeType) Set(v string) error {
 	switch v {
 	case `GENERAL_PURPOSE_SSD`, `THROUGHPUT_OPTIMIZED_HDD`:
 		*evt = EbsVolumeType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*evt = EbsVolumeType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"`, v)
@@ -1681,6 +1725,10 @@ func (edc *EventDetailsCause) Set(v string) error {
 	case `AUTORECOVERY`, `AUTOSCALE`, `REPLACE_BAD_NODES`, `USER_REQUEST`:
 		*edc = EventDetailsCause(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*edc = EventDetailsCause(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "AUTORECOVERY", "AUTOSCALE", "REPLACE_BAD_NODES", "USER_REQUEST"`, v)
 	}
@@ -1754,6 +1802,10 @@ func (et *EventType) Set(v string) error {
 	case `AUTOSCALING_STATS_REPORT`, `CREATING`, `DBFS_DOWN`, `DID_NOT_EXPAND_DISK`, `DRIVER_HEALTHY`, `DRIVER_NOT_RESPONDING`, `DRIVER_UNAVAILABLE`, `EDITED`, `EXPANDED_DISK`, `FAILED_TO_EXPAND_DISK`, `INIT_SCRIPTS_FINISHED`, `INIT_SCRIPTS_STARTED`, `METASTORE_DOWN`, `NODE_BLACKLISTED`, `NODE_EXCLUDED_DECOMMISSIONED`, `NODES_LOST`, `PINNED`, `RESIZING`, `RESTARTING`, `RUNNING`, `SPARK_EXCEPTION`, `STARTING`, `TERMINATING`, `UNPINNED`, `UPSIZE_COMPLETED`:
 		*et = EventType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*et = EventType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "AUTOSCALING_STATS_REPORT", "CREATING", "DBFS_DOWN", "DID_NOT_EXPAND_DISK", "DRIVER_HEALTHY", "DRIVER_NOT_RESPONDING", "DRIVER_UNAVAILABLE", "EDITED", "EXPANDED_DISK", "FAILED_TO_EXPAND_DISK", "INIT_SCRIPTS_FINISHED", "INIT_SCRIPTS_STARTED", "METASTORE_DOWN", "NODE_BLACKLISTED", "NODE_EXCLUDED_DECOMMISSIONED", "NODES_LOST", "PINNED", "RESIZING", "RESTARTING", "RUNNING", "SPARK_EXCEPTION", "STARTING", "TERMINATING", "UNPINNED", "UPSIZE_COMPLETED"`, v)
 	}
@@ -1822,6 +1874,10 @@ func (fodoas *FleetOnDemandOptionAllocationStrategy) Set(v string) error {
 	case `CAPACITY_OPTIMIZED`, `DIVERSIFIED`, `LOWEST_PRICE`, `PRIORITIZED`:
 		*fodoas = FleetOnDemandOptionAllocationStrategy(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fodoas = FleetOnDemandOptionAllocationStrategy(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CAPACITY_OPTIMIZED", "DIVERSIFIED", "LOWEST_PRICE", "PRIORITIZED"`, v)
 	}
@@ -1868,6 +1924,10 @@ func (fsoas *FleetSpotOptionAllocationStrategy) Set(v string) error {
 	case `CAPACITY_OPTIMIZED`, `DIVERSIFIED`, `LOWEST_PRICE`, `PRIORITIZED`:
 		*fsoas = FleetSpotOptionAllocationStrategy(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*fsoas = FleetSpotOptionAllocationStrategy(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CAPACITY_OPTIMIZED", "DIVERSIFIED", "LOWEST_PRICE", "PRIORITIZED"`, v)
 	}
@@ -1913,6 +1973,10 @@ func (ga *GcpAvailability) Set(v string) error {
 	switch v {
 	case `ON_DEMAND_GCP`, `PREEMPTIBLE_GCP`, `PREEMPTIBLE_WITH_FALLBACK_GCP`:
 		*ga = GcpAvailability(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ga = GcpAvailability(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ON_DEMAND_GCP", "PREEMPTIBLE_GCP", "PREEMPTIBLE_WITH_FALLBACK_GCP"`, v)
@@ -1976,6 +2040,10 @@ func (geo *GetEventsOrder) Set(v string) error {
 	switch v {
 	case `ASC`, `DESC`:
 		*geo = GetEventsOrder(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*geo = GetEventsOrder(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ASC", "DESC"`, v)
@@ -2337,6 +2405,10 @@ func (ipaaa *InstancePoolAwsAttributesAvailability) Set(v string) error {
 	case `ON_DEMAND`, `SPOT`, `SPOT_WITH_FALLBACK`:
 		*ipaaa = InstancePoolAwsAttributesAvailability(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ipaaa = InstancePoolAwsAttributesAvailability(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ON_DEMAND", "SPOT", "SPOT_WITH_FALLBACK"`, v)
 	}
@@ -2381,6 +2453,10 @@ func (ipaaa *InstancePoolAzureAttributesAvailability) Set(v string) error {
 	case `ON_DEMAND_AZURE`, `SPOT_AZURE`, `SPOT_WITH_FALLBACK_AZURE`:
 		*ipaaa = InstancePoolAzureAttributesAvailability(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ipaaa = InstancePoolAzureAttributesAvailability(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ON_DEMAND_AZURE", "SPOT_AZURE", "SPOT_WITH_FALLBACK_AZURE"`, v)
 	}
@@ -2418,6 +2494,10 @@ func (ips *InstancePoolState) Set(v string) error {
 	switch v {
 	case `ACTIVE`, `DELETED`, `STOPPED`:
 		*ips = InstancePoolState(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ips = InstancePoolState(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ACTIVE", "DELETED", "STOPPED"`, v)
@@ -2489,6 +2569,10 @@ func (l *Language) Set(v string) error {
 	switch v {
 	case `python`, `scala`, `sql`:
 		*l = Language(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*l = Language(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "python", "scala", "sql"`, v)
@@ -2568,6 +2652,10 @@ func (lfss *LibraryFullStatusStatus) Set(v string) error {
 	switch v {
 	case `FAILED`, `INSTALLED`, `INSTALLING`, `PENDING`, `RESOLVING`, `SKIPPED`, `UNINSTALL_ON_RESTART`:
 		*lfss = LibraryFullStatusStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lfss = LibraryFullStatusStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FAILED", "INSTALLED", "INSTALLING", "PENDING", "RESOLVING", "SKIPPED", "UNINSTALL_ON_RESTART"`, v)
@@ -2671,6 +2759,10 @@ func (lsc *ListSortColumn) Set(v string) error {
 	case `POLICY_CREATION_TIME`, `POLICY_NAME`:
 		*lsc = ListSortColumn(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lsc = ListSortColumn(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "POLICY_CREATION_TIME", "POLICY_NAME"`, v)
 	}
@@ -2697,6 +2789,10 @@ func (lso *ListSortOrder) Set(v string) error {
 	switch v {
 	case `ASC`, `DESC`:
 		*lso = ListSortOrder(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lso = ListSortOrder(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ASC", "DESC"`, v)
@@ -2934,6 +3030,10 @@ func (rt *ResultType) Set(v string) error {
 	case `error`, `image`, `images`, `table`, `text`:
 		*rt = ResultType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rt = ResultType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "error", "image", "images", "table", "text"`, v)
 	}
@@ -2988,6 +3088,10 @@ func (re *RuntimeEngine) Set(v string) error {
 	switch v {
 	case `NULL`, `PHOTON`, `STANDARD`:
 		*re = RuntimeEngine(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*re = RuntimeEngine(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "NULL", "PHOTON", "STANDARD"`, v)
@@ -3110,6 +3214,10 @@ func (s *State) Set(v string) error {
 	switch v {
 	case `ERROR`, `PENDING`, `RESIZING`, `RESTARTING`, `RUNNING`, `TERMINATED`, `TERMINATING`, `UNKNOWN`:
 		*s = State(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*s = State(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ERROR", "PENDING", "RESIZING", "RESTARTING", "RUNNING", "TERMINATED", "TERMINATING", "UNKNOWN"`, v)
@@ -3303,6 +3411,10 @@ func (trc *TerminationReasonCode) Set(v string) error {
 	case `ABUSE_DETECTED`, `ATTACH_PROJECT_FAILURE`, `AWS_AUTHORIZATION_FAILURE`, `AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE`, `AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE`, `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE`, `AWS_REQUEST_LIMIT_EXCEEDED`, `AWS_UNSUPPORTED_FAILURE`, `AZURE_BYOK_KEY_PERMISSION_FAILURE`, `AZURE_EPHEMERAL_DISK_FAILURE`, `AZURE_INVALID_DEPLOYMENT_TEMPLATE`, `AZURE_OPERATION_NOT_ALLOWED_EXCEPTION`, `AZURE_QUOTA_EXCEEDED_EXCEPTION`, `AZURE_RESOURCE_MANAGER_THROTTLING`, `AZURE_RESOURCE_PROVIDER_THROTTLING`, `AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE`, `AZURE_VM_EXTENSION_FAILURE`, `AZURE_VNET_CONFIGURATION_FAILURE`, `BOOTSTRAP_TIMEOUT`, `BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION`, `CLOUD_PROVIDER_DISK_SETUP_FAILURE`, `CLOUD_PROVIDER_LAUNCH_FAILURE`, `CLOUD_PROVIDER_RESOURCE_STOCKOUT`, `CLOUD_PROVIDER_SHUTDOWN`, `COMMUNICATION_LOST`, `CONTAINER_LAUNCH_FAILURE`, `CONTROL_PLANE_REQUEST_FAILURE`, `DATABASE_CONNECTION_FAILURE`, `DBFS_COMPONENT_UNHEALTHY`, `DOCKER_IMAGE_PULL_FAILURE`, `DRIVER_UNREACHABLE`, `DRIVER_UNRESPONSIVE`, `EXECUTION_COMPONENT_UNHEALTHY`, `GCP_QUOTA_EXCEEDED`, `GCP_SERVICE_ACCOUNT_DELETED`, `GLOBAL_INIT_SCRIPT_FAILURE`, `HIVE_METASTORE_PROVISIONING_FAILURE`, `IMAGE_PULL_PERMISSION_DENIED`, `INACTIVITY`, `INIT_SCRIPT_FAILURE`, `INSTANCE_POOL_CLUSTER_FAILURE`, `INSTANCE_UNREACHABLE`, `INTERNAL_ERROR`, `INVALID_ARGUMENT`, `INVALID_SPARK_IMAGE`, `IP_EXHAUSTION_FAILURE`, `JOB_FINISHED`, `K8S_AUTOSCALING_FAILURE`, `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`, `METASTORE_COMPONENT_UNHEALTHY`, `NEPHOS_RESOURCE_MANAGEMENT`, `NETWORK_CONFIGURATION_FAILURE`, `NFS_MOUNT_FAILURE`, `NPIP_TUNNEL_SETUP_FAILURE`, `NPIP_TUNNEL_TOKEN_FAILURE`, `REQUEST_REJECTED`, `REQUEST_THROTTLED`, `SECRET_RESOLUTION_ERROR`, `SECURITY_DAEMON_REGISTRATION_EXCEPTION`, `SELF_BOOTSTRAP_FAILURE`, `SKIPPED_SLOW_NODES`, `SLOW_IMAGE_DOWNLOAD`, `SPARK_ERROR`, `SPARK_IMAGE_DOWNLOAD_FAILURE`, `SPARK_STARTUP_FAILURE`, `SPOT_INSTANCE_TERMINATION`, `STORAGE_DOWNLOAD_FAILURE`, `STS_CLIENT_SETUP_FAILURE`, `SUBNET_EXHAUSTED_FAILURE`, `TEMPORARILY_UNAVAILABLE`, `TRIAL_EXPIRED`, `UNEXPECTED_LAUNCH_FAILURE`, `UNKNOWN`, `UNSUPPORTED_INSTANCE_TYPE`, `UPDATE_INSTANCE_PROFILE_FAILURE`, `USER_REQUEST`, `WORKER_SETUP_FAILURE`, `WORKSPACE_CANCELLED_ERROR`, `WORKSPACE_CONFIGURATION_ERROR`:
 		*trc = TerminationReasonCode(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*trc = TerminationReasonCode(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ABUSE_DETECTED", "ATTACH_PROJECT_FAILURE", "AWS_AUTHORIZATION_FAILURE", "AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE", "AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE", "AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE", "AWS_REQUEST_LIMIT_EXCEEDED", "AWS_UNSUPPORTED_FAILURE", "AZURE_BYOK_KEY_PERMISSION_FAILURE", "AZURE_EPHEMERAL_DISK_FAILURE", "AZURE_INVALID_DEPLOYMENT_TEMPLATE", "AZURE_OPERATION_NOT_ALLOWED_EXCEPTION", "AZURE_QUOTA_EXCEEDED_EXCEPTION", "AZURE_RESOURCE_MANAGER_THROTTLING", "AZURE_RESOURCE_PROVIDER_THROTTLING", "AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE", "AZURE_VM_EXTENSION_FAILURE", "AZURE_VNET_CONFIGURATION_FAILURE", "BOOTSTRAP_TIMEOUT", "BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION", "CLOUD_PROVIDER_DISK_SETUP_FAILURE", "CLOUD_PROVIDER_LAUNCH_FAILURE", "CLOUD_PROVIDER_RESOURCE_STOCKOUT", "CLOUD_PROVIDER_SHUTDOWN", "COMMUNICATION_LOST", "CONTAINER_LAUNCH_FAILURE", "CONTROL_PLANE_REQUEST_FAILURE", "DATABASE_CONNECTION_FAILURE", "DBFS_COMPONENT_UNHEALTHY", "DOCKER_IMAGE_PULL_FAILURE", "DRIVER_UNREACHABLE", "DRIVER_UNRESPONSIVE", "EXECUTION_COMPONENT_UNHEALTHY", "GCP_QUOTA_EXCEEDED", "GCP_SERVICE_ACCOUNT_DELETED", "GLOBAL_INIT_SCRIPT_FAILURE", "HIVE_METASTORE_PROVISIONING_FAILURE", "IMAGE_PULL_PERMISSION_DENIED", "INACTIVITY", "INIT_SCRIPT_FAILURE", "INSTANCE_POOL_CLUSTER_FAILURE", "INSTANCE_UNREACHABLE", "INTERNAL_ERROR", "INVALID_ARGUMENT", "INVALID_SPARK_IMAGE", "IP_EXHAUSTION_FAILURE", "JOB_FINISHED", "K8S_AUTOSCALING_FAILURE", "K8S_DBR_CLUSTER_LAUNCH_TIMEOUT", "METASTORE_COMPONENT_UNHEALTHY", "NEPHOS_RESOURCE_MANAGEMENT", "NETWORK_CONFIGURATION_FAILURE", "NFS_MOUNT_FAILURE", "NPIP_TUNNEL_SETUP_FAILURE", "NPIP_TUNNEL_TOKEN_FAILURE", "REQUEST_REJECTED", "REQUEST_THROTTLED", "SECRET_RESOLUTION_ERROR", "SECURITY_DAEMON_REGISTRATION_EXCEPTION", "SELF_BOOTSTRAP_FAILURE", "SKIPPED_SLOW_NODES", "SLOW_IMAGE_DOWNLOAD", "SPARK_ERROR", "SPARK_IMAGE_DOWNLOAD_FAILURE", "SPARK_STARTUP_FAILURE", "SPOT_INSTANCE_TERMINATION", "STORAGE_DOWNLOAD_FAILURE", "STS_CLIENT_SETUP_FAILURE", "SUBNET_EXHAUSTED_FAILURE", "TEMPORARILY_UNAVAILABLE", "TRIAL_EXPIRED", "UNEXPECTED_LAUNCH_FAILURE", "UNKNOWN", "UNSUPPORTED_INSTANCE_TYPE", "UPDATE_INSTANCE_PROFILE_FAILURE", "USER_REQUEST", "WORKER_SETUP_FAILURE", "WORKSPACE_CANCELLED_ERROR", "WORKSPACE_CONFIGURATION_ERROR"`, v)
 	}
@@ -3334,6 +3446,10 @@ func (trt *TerminationReasonType) Set(v string) error {
 	switch v {
 	case `CLIENT_ERROR`, `CLOUD_FAILURE`, `SERVICE_FAULT`, `SUCCESS`:
 		*trt = TerminationReasonType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*trt = TerminationReasonType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLIENT_ERROR", "CLOUD_FAILURE", "SERVICE_FAULT", "SUCCESS"`, v)

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -357,6 +357,10 @@ func (lso *ListSortOrder) Set(v string) error {
 	case `ascending`, `descending`:
 		*lso = ListSortOrder(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lso = ListSortOrder(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ascending", "descending"`, v)
 	}
@@ -461,6 +465,10 @@ func (po *PatchOp) Set(v string) error {
 	case `add`, `remove`, `replace`:
 		*po = PatchOp(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*po = PatchOp(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "add", "remove", "replace"`, v)
 	}
@@ -536,6 +544,10 @@ func (pl *PermissionLevel) Set(v string) error {
 	switch v {
 	case `CAN_ATTACH_TO`, `CAN_BIND`, `CAN_EDIT`, `CAN_EDIT_METADATA`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_RUN`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`, `CAN_RESTART`, `CAN_RUN`, `CAN_USE`, `CAN_VIEW`, `CAN_VIEW_METADATA`, `IS_OWNER`:
 		*pl = PermissionLevel(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pl = PermissionLevel(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CAN_ATTACH_TO", "CAN_BIND", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"`, v)
@@ -688,6 +700,10 @@ func (wp *WorkspacePermission) Set(v string) error {
 	switch v {
 	case `ADMIN`, `UNKNOWN`, `USER`:
 		*wp = WorkspacePermission(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*wp = WorkspacePermission(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ADMIN", "UNKNOWN", "USER"`, v)

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -188,6 +188,10 @@ func (cps *ContinuousPauseStatus) Set(v string) error {
 	case `PAUSED`, `UNPAUSED`:
 		*cps = ContinuousPauseStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cps = ContinuousPauseStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "PAUSED", "UNPAUSED"`, v)
 	}
@@ -294,6 +298,10 @@ func (cjf *CreateJobFormat) Set(v string) error {
 	case `MULTI_TASK`, `SINGLE_TASK`:
 		*cjf = CreateJobFormat(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cjf = CreateJobFormat(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "MULTI_TASK", "SINGLE_TASK"`, v)
 	}
@@ -341,6 +349,10 @@ func (csps *CronSchedulePauseStatus) Set(v string) error {
 	switch v {
 	case `PAUSED`, `UNPAUSED`:
 		*csps = CronSchedulePauseStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*csps = CronSchedulePauseStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "PAUSED", "UNPAUSED"`, v)
@@ -517,6 +529,10 @@ func (gsgp *GitSourceGitProvider) Set(v string) error {
 	switch v {
 	case `awsCodeCommit`, `azureDevOpsServices`, `bitbucketCloud`, `bitbucketServer`, `gitHub`, `gitHubEnterprise`, `gitLab`, `gitLabEnterpriseEdition`:
 		*gsgp = GitSourceGitProvider(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*gsgp = GitSourceGitProvider(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "awsCodeCommit", "azureDevOpsServices", "bitbucketCloud", "bitbucketServer", "gitHub", "gitHubEnterprise", "gitLab", "gitLabEnterpriseEdition"`, v)
@@ -701,6 +717,10 @@ func (jsf *JobSettingsFormat) Set(v string) error {
 	switch v {
 	case `MULTI_TASK`, `SINGLE_TASK`:
 		*jsf = JobSettingsFormat(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*jsf = JobSettingsFormat(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "MULTI_TASK", "SINGLE_TASK"`, v)
@@ -919,6 +939,10 @@ func (lrrt *ListRunsRunType) Set(v string) error {
 	case `JOB_RUN`, `SUBMIT_RUN`, `WORKFLOW_RUN`:
 		*lrrt = ListRunsRunType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lrrt = ListRunsRunType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "JOB_RUN", "SUBMIT_RUN", "WORKFLOW_RUN"`, v)
 	}
@@ -987,6 +1011,10 @@ func (nts *NotebookTaskSource) Set(v string) error {
 	switch v {
 	case `GIT`, `WORKSPACE`:
 		*nts = NotebookTaskSource(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*nts = NotebookTaskSource(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "GIT", "WORKSPACE"`, v)
@@ -1062,6 +1090,10 @@ func (rhit *RepairHistoryItemType) Set(v string) error {
 	switch v {
 	case `ORIGINAL`, `REPAIR`:
 		*rhit = RepairHistoryItemType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rhit = RepairHistoryItemType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ORIGINAL", "REPAIR"`, v)
@@ -1327,6 +1359,10 @@ func (rlcs *RunLifeCycleState) Set(v string) error {
 	case `BLOCKED`, `INTERNAL_ERROR`, `PENDING`, `RUNNING`, `SKIPPED`, `TERMINATED`, `TERMINATING`, `WAITING_FOR_RETRY`:
 		*rlcs = RunLifeCycleState(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rlcs = RunLifeCycleState(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "BLOCKED", "INTERNAL_ERROR", "PENDING", "RUNNING", "SKIPPED", "TERMINATED", "TERMINATING", "WAITING_FOR_RETRY"`, v)
 	}
@@ -1591,6 +1627,10 @@ func (rrs *RunResultState) Set(v string) error {
 	case `CANCELED`, `FAILED`, `SUCCESS`, `TIMEDOUT`:
 		*rrs = RunResultState(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rrs = RunResultState(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCELED", "FAILED", "SUCCESS", "TIMEDOUT"`, v)
 	}
@@ -1779,6 +1819,10 @@ func (rt *RunType) Set(v string) error {
 	case `JOB_RUN`, `SUBMIT_RUN`, `WORKFLOW_RUN`:
 		*rt = RunType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rt = RunType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "JOB_RUN", "SUBMIT_RUN", "WORKFLOW_RUN"`, v)
 	}
@@ -1847,6 +1891,10 @@ func (spts *SparkPythonTaskSource) Set(v string) error {
 	case `GIT`, `WORKSPACE`:
 		*spts = SparkPythonTaskSource(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*spts = SparkPythonTaskSource(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "GIT", "WORKSPACE"`, v)
 	}
@@ -1909,6 +1957,10 @@ func (sas *SqlAlertState) Set(v string) error {
 	case `OK`, `TRIGGERED`, `UNKNOWN`:
 		*sas = SqlAlertState(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sas = SqlAlertState(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "OK", "TRIGGERED", "UNKNOWN"`, v)
 	}
@@ -1966,6 +2018,10 @@ func (sdwos *SqlDashboardWidgetOutputStatus) Set(v string) error {
 	switch v {
 	case `CANCELLED`, `FAILED`, `PENDING`, `RUNNING`, `SUCCESS`:
 		*sdwos = SqlDashboardWidgetOutputStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sdwos = SqlDashboardWidgetOutputStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCELLED", "FAILED", "PENDING", "RUNNING", "SUCCESS"`, v)
@@ -2189,6 +2245,10 @@ func (tsps *TriggerSettingsPauseStatus) Set(v string) error {
 	case `PAUSED`, `UNPAUSED`:
 		*tsps = TriggerSettingsPauseStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*tsps = TriggerSettingsPauseStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "PAUSED", "UNPAUSED"`, v)
 	}
@@ -2226,6 +2286,10 @@ func (tt *TriggerType) Set(v string) error {
 	switch v {
 	case `FILE_ARRIVAL`, `ONE_TIME`, `PERIODIC`, `RETRY`:
 		*tt = TriggerType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*tt = TriggerType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FILE_ARRIVAL", "ONE_TIME", "PERIODIC", "RETRY"`, v)
@@ -2283,6 +2347,10 @@ func (vt *ViewType) Set(v string) error {
 	case `DASHBOARD`, `NOTEBOOK`:
 		*vt = ViewType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*vt = ViewType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DASHBOARD", "NOTEBOOK"`, v)
 	}
@@ -2315,6 +2383,10 @@ func (vte *ViewsToExport) Set(v string) error {
 	switch v {
 	case `ALL`, `CODE`, `DASHBOARDS`:
 		*vte = ViewsToExport(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*vte = ViewsToExport(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ALL", "CODE", "DASHBOARDS"`, v)

--- a/service/ml/model.go
+++ b/service/ml/model.go
@@ -72,6 +72,10 @@ func (aa *ActivityAction) Set(v string) error {
 	case `APPROVE_TRANSITION_REQUEST`, `CANCEL_TRANSITION_REQUEST`, `REJECT_TRANSITION_REQUEST`:
 		*aa = ActivityAction(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*aa = ActivityAction(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "APPROVE_TRANSITION_REQUEST", "CANCEL_TRANSITION_REQUEST", "REJECT_TRANSITION_REQUEST"`, v)
 	}
@@ -116,6 +120,10 @@ func (at *ActivityType) Set(v string) error {
 	switch v {
 	case `APPLIED_TRANSITION`, `APPROVED_REQUEST`, `CANCELLED_REQUEST`, `NEW_COMMENT`, `REJECTED_REQUEST`, `REQUESTED_TRANSITION`, `SYSTEM_TRANSITION`:
 		*at = ActivityType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*at = ActivityType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "APPLIED_TRANSITION", "APPROVED_REQUEST", "CANCELLED_REQUEST", "NEW_COMMENT", "REJECTED_REQUEST", "REQUESTED_TRANSITION", "SYSTEM_TRANSITION"`, v)
@@ -173,6 +181,10 @@ func (caa *CommentActivityAction) Set(v string) error {
 	switch v {
 	case `DELETE_COMMENT`, `EDIT_COMMENT`:
 		*caa = CommentActivityAction(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*caa = CommentActivityAction(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DELETE_COMMENT", "EDIT_COMMENT"`, v)
@@ -492,6 +504,10 @@ func (dtrs *DeleteTransitionRequestStage) Set(v string) error {
 	switch v {
 	case `Archived`, `None`, `Production`, `Staging`:
 		*dtrs = DeleteTransitionRequestStage(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*dtrs = DeleteTransitionRequestStage(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "Archived", "None", "Production", "Staging"`, v)
@@ -1009,6 +1025,10 @@ func (mvs *ModelVersionStatus) Set(v string) error {
 	case `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
 		*mvs = ModelVersionStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*mvs = ModelVersionStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"`, v)
 	}
@@ -1057,6 +1077,10 @@ func (pl *PermissionLevel) Set(v string) error {
 	switch v {
 	case `CAN_EDIT`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`:
 		*pl = PermissionLevel(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pl = PermissionLevel(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CAN_EDIT", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_STAGING_VERSIONS", "CAN_READ"`, v)
@@ -1158,6 +1182,10 @@ func (rwe *RegistryWebhookEvent) Set(v string) error {
 	case `COMMENT_CREATED`, `MODEL_VERSION_CREATED`, `MODEL_VERSION_TAG_SET`, `MODEL_VERSION_TRANSITIONED_STAGE`, `MODEL_VERSION_TRANSITIONED_TO_ARCHIVED`, `MODEL_VERSION_TRANSITIONED_TO_PRODUCTION`, `MODEL_VERSION_TRANSITIONED_TO_STAGING`, `REGISTERED_MODEL_CREATED`, `TRANSITION_REQUEST_CREATED`, `TRANSITION_REQUEST_TO_ARCHIVED_CREATED`, `TRANSITION_REQUEST_TO_PRODUCTION_CREATED`, `TRANSITION_REQUEST_TO_STAGING_CREATED`:
 		*rwe = RegistryWebhookEvent(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rwe = RegistryWebhookEvent(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "COMMENT_CREATED", "MODEL_VERSION_CREATED", "MODEL_VERSION_TAG_SET", "MODEL_VERSION_TRANSITIONED_STAGE", "MODEL_VERSION_TRANSITIONED_TO_ARCHIVED", "MODEL_VERSION_TRANSITIONED_TO_PRODUCTION", "MODEL_VERSION_TRANSITIONED_TO_STAGING", "REGISTERED_MODEL_CREATED", "TRANSITION_REQUEST_CREATED", "TRANSITION_REQUEST_TO_ARCHIVED_CREATED", "TRANSITION_REQUEST_TO_PRODUCTION_CREATED", "TRANSITION_REQUEST_TO_STAGING_CREATED"`, v)
 	}
@@ -1191,6 +1219,10 @@ func (rws *RegistryWebhookStatus) Set(v string) error {
 	switch v {
 	case `ACTIVE`, `DISABLED`, `TEST_MODE`:
 		*rws = RegistryWebhookStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*rws = RegistryWebhookStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ACTIVE", "DISABLED", "TEST_MODE"`, v)
@@ -1316,6 +1348,10 @@ func (ris *RunInfoStatus) Set(v string) error {
 	case `FAILED`, `FINISHED`, `KILLED`, `RUNNING`, `SCHEDULED`:
 		*ris = RunInfoStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ris = RunInfoStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FAILED", "FINISHED", "KILLED", "RUNNING", "SCHEDULED"`, v)
 	}
@@ -1384,6 +1420,10 @@ func (sevt *SearchExperimentsViewType) Set(v string) error {
 	switch v {
 	case `ACTIVE_ONLY`, `ALL`, `DELETED_ONLY`:
 		*sevt = SearchExperimentsViewType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sevt = SearchExperimentsViewType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ACTIVE_ONLY", "ALL", "DELETED_ONLY"`, v)
@@ -1502,6 +1542,10 @@ func (srrvt *SearchRunsRunViewType) Set(v string) error {
 	case `ACTIVE_ONLY`, `ALL`, `DELETED_ONLY`:
 		*srrvt = SearchRunsRunViewType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*srrvt = SearchRunsRunViewType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ACTIVE_ONLY", "ALL", "DELETED_ONLY"`, v)
 	}
@@ -1595,6 +1639,10 @@ func (s *Stage) Set(v string) error {
 	case `Archived`, `None`, `Production`, `Staging`:
 		*s = Stage(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*s = Stage(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "Archived", "None", "Production", "Staging"`, v)
 	}
@@ -1628,6 +1676,10 @@ func (s *Status) Set(v string) error {
 	switch v {
 	case `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
 		*s = Status(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*s = Status(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FAILED_REGISTRATION", "PENDING_REGISTRATION", "READY"`, v)
@@ -1833,6 +1885,10 @@ func (urs *UpdateRunStatus) Set(v string) error {
 	switch v {
 	case `FAILED`, `FINISHED`, `KILLED`, `RUNNING`, `SCHEDULED`:
 		*urs = UpdateRunStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*urs = UpdateRunStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "FAILED", "FINISHED", "KILLED", "RUNNING", "SCHEDULED"`, v)

--- a/service/pipelines/model.go
+++ b/service/pipelines/model.go
@@ -161,6 +161,10 @@ func (el *EventLevel) Set(v string) error {
 	case `ERROR`, `INFO`, `METRICS`, `WARN`:
 		*el = EventLevel(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*el = EventLevel(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ERROR", "INFO", "METRICS", "WARN"`, v)
 	}
@@ -232,6 +236,10 @@ func (gprh *GetPipelineResponseHealth) Set(v string) error {
 	switch v {
 	case `HEALTHY`, `UNHEALTHY`:
 		*gprh = GetPipelineResponseHealth(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*gprh = GetPipelineResponseHealth(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "HEALTHY", "UNHEALTHY"`, v)
@@ -366,6 +374,10 @@ func (ml *MaturityLevel) Set(v string) error {
 	switch v {
 	case `DEPRECATED`, `EVOLVING`, `STABLE`:
 		*ml = MaturityLevel(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ml = MaturityLevel(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DEPRECATED", "EVOLVING", "STABLE"`, v)
@@ -619,6 +631,10 @@ func (ps *PipelineState) Set(v string) error {
 	case `DELETED`, `DEPLOYING`, `FAILED`, `IDLE`, `RECOVERING`, `RESETTING`, `RUNNING`, `STARTING`, `STOPPING`:
 		*ps = PipelineState(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ps = PipelineState(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DELETED", "DEPLOYING", "FAILED", "IDLE", "RECOVERING", "RESETTING", "RUNNING", "STARTING", "STOPPING"`, v)
 	}
@@ -729,6 +745,10 @@ func (suc *StartUpdateCause) Set(v string) error {
 	case `API_CALL`, `JOB_TASK`, `RETRY_ON_FAILURE`, `SCHEMA_CHANGE`, `SERVICE_UPGRADE`, `USER_ACTION`:
 		*suc = StartUpdateCause(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*suc = StartUpdateCause(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "API_CALL", "JOB_TASK", "RETRY_ON_FAILURE", "SCHEMA_CHANGE", "SERVICE_UPGRADE", "USER_ACTION"`, v)
 	}
@@ -804,6 +824,10 @@ func (uic *UpdateInfoCause) Set(v string) error {
 	case `API_CALL`, `JOB_TASK`, `RETRY_ON_FAILURE`, `SCHEMA_CHANGE`, `SERVICE_UPGRADE`, `USER_ACTION`:
 		*uic = UpdateInfoCause(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*uic = UpdateInfoCause(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "API_CALL", "JOB_TASK", "RETRY_ON_FAILURE", "SCHEMA_CHANGE", "SERVICE_UPGRADE", "USER_ACTION"`, v)
 	}
@@ -849,6 +873,10 @@ func (uis *UpdateInfoState) Set(v string) error {
 	switch v {
 	case `CANCELED`, `COMPLETED`, `CREATED`, `FAILED`, `INITIALIZING`, `QUEUED`, `RESETTING`, `RUNNING`, `SETTING_UP_TABLES`, `STOPPING`, `WAITING_FOR_RESOURCES`:
 		*uis = UpdateInfoState(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*uis = UpdateInfoState(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCELED", "COMPLETED", "CREATED", "FAILED", "INITIALIZING", "QUEUED", "RESETTING", "RUNNING", "SETTING_UP_TABLES", "STOPPING", "WAITING_FOR_RESOURCES"`, v)
@@ -902,6 +930,10 @@ func (usis *UpdateStateInfoState) Set(v string) error {
 	switch v {
 	case `CANCELED`, `COMPLETED`, `CREATED`, `FAILED`, `INITIALIZING`, `QUEUED`, `RESETTING`, `RUNNING`, `SETTING_UP_TABLES`, `STOPPING`, `WAITING_FOR_RESOURCES`:
 		*usis = UpdateStateInfoState(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*usis = UpdateStateInfoState(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCELED", "COMPLETED", "CREATED", "FAILED", "INITIALIZING", "QUEUED", "RESETTING", "RUNNING", "SETTING_UP_TABLES", "STOPPING", "WAITING_FOR_RESOURCES"`, v)

--- a/service/provisioning/model.go
+++ b/service/provisioning/model.go
@@ -294,6 +294,10 @@ func (euc *EndpointUseCase) Set(v string) error {
 	case `DATAPLANE_RELAY_ACCESS`, `WORKSPACE_ACCESS`:
 		*euc = EndpointUseCase(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*euc = EndpointUseCase(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DATAPLANE_RELAY_ACCESS", "WORKSPACE_ACCESS"`, v)
 	}
@@ -328,6 +332,10 @@ func (et *ErrorType) Set(v string) error {
 	switch v {
 	case `credentials`, `networkAcl`, `securityGroup`, `subnet`, `vpc`:
 		*et = ErrorType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*et = ErrorType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "credentials", "networkAcl", "securityGroup", "subnet", "vpc"`, v)
@@ -503,6 +511,10 @@ func (gcct *GkeConfigConnectivityType) Set(v string) error {
 	case `PRIVATE_NODE_PUBLIC_MASTER`, `PUBLIC_NODE_PUBLIC_MASTER`:
 		*gcct = GkeConfigConnectivityType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*gcct = GkeConfigConnectivityType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "PRIVATE_NODE_PUBLIC_MASTER", "PUBLIC_NODE_PUBLIC_MASTER"`, v)
 	}
@@ -533,6 +545,10 @@ func (kuc *KeyUseCase) Set(v string) error {
 	switch v {
 	case `MANAGED_SERVICES`, `STORAGE`:
 		*kuc = KeyUseCase(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*kuc = KeyUseCase(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "MANAGED_SERVICES", "STORAGE"`, v)
@@ -636,6 +652,10 @@ func (pt *PricingTier) Set(v string) error {
 	case `COMMUNITY_EDITION`, `DEDICATED`, `ENTERPRISE`, `PREMIUM`, `STANDARD`, `UNKNOWN`:
 		*pt = PricingTier(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pt = PricingTier(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "COMMUNITY_EDITION", "DEDICATED", "ENTERPRISE", "PREMIUM", "STANDARD", "UNKNOWN"`, v)
 	}
@@ -668,6 +688,10 @@ func (pal *PrivateAccessLevel) Set(v string) error {
 	switch v {
 	case `ACCOUNT`, `ENDPOINT`:
 		*pal = PrivateAccessLevel(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pal = PrivateAccessLevel(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ACCOUNT", "ENDPOINT"`, v)
@@ -860,6 +884,10 @@ func (vs *VpcStatus) Set(v string) error {
 	case `BROKEN`, `UNATTACHED`, `VALID`, `WARNED`:
 		*vs = VpcStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*vs = VpcStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "BROKEN", "UNATTACHED", "VALID", "WARNED"`, v)
 	}
@@ -887,6 +915,10 @@ func (wt *WarningType) Set(v string) error {
 	switch v {
 	case `securityGroup`, `subnet`:
 		*wt = WarningType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*wt = WarningType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "securityGroup", "subnet"`, v)
@@ -1012,6 +1044,10 @@ func (ws *WorkspaceStatus) Set(v string) error {
 	switch v {
 	case `BANNED`, `CANCELLING`, `FAILED`, `NOT_PROVISIONED`, `PROVISIONING`, `RUNNING`:
 		*ws = WorkspaceStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ws = WorkspaceStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "BANNED", "CANCELLING", "FAILED", "NOT_PROVISIONED", "PROVISIONING", "RUNNING"`, v)

--- a/service/serving/model.go
+++ b/service/serving/model.go
@@ -113,6 +113,10 @@ func (escu *EndpointStateConfigUpdate) Set(v string) error {
 	case `IN_PROGRESS`, `NOT_UPDATING`, `UPDATE_FAILED`:
 		*escu = EndpointStateConfigUpdate(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*escu = EndpointStateConfigUpdate(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "IN_PROGRESS", "NOT_UPDATING", "UPDATE_FAILED"`, v)
 	}
@@ -143,6 +147,10 @@ func (esr *EndpointStateReady) Set(v string) error {
 	switch v {
 	case `NOT_READY`, `READY`:
 		*esr = EndpointStateReady(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*esr = EndpointStateReady(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "NOT_READY", "READY"`, v)
@@ -313,6 +321,10 @@ func (smsd *ServedModelStateDeployment) Set(v string) error {
 	case `DEPLOYMENT_ABORTED`, `DEPLOYMENT_CREATING`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_READY`, `DEPLOYMENT_RECOVERING`:
 		*smsd = ServedModelStateDeployment(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*smsd = ServedModelStateDeployment(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DEPLOYMENT_ABORTED", "DEPLOYMENT_CREATING", "DEPLOYMENT_FAILED", "DEPLOYMENT_READY", "DEPLOYMENT_RECOVERING"`, v)
 	}
@@ -388,6 +400,10 @@ func (sedpl *ServingEndpointDetailedPermissionLevel) Set(v string) error {
 	switch v {
 	case `CAN_MANAGE`, `CAN_QUERY`, `CAN_VIEW`:
 		*sedpl = ServingEndpointDetailedPermissionLevel(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sedpl = ServingEndpointDetailedPermissionLevel(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CAN_MANAGE", "CAN_QUERY", "CAN_VIEW"`, v)

--- a/service/settings/model.go
+++ b/service/settings/model.go
@@ -159,6 +159,10 @@ func (lt *ListType) Set(v string) error {
 	case `ALLOW`, `BLOCK`:
 		*lt = ListType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lt = ListType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ALLOW", "BLOCK"`, v)
 	}
@@ -191,6 +195,10 @@ func (pcme *PersonalComputeMessageEnum) Set(v string) error {
 	switch v {
 	case `DELEGATE`, `ON`:
 		*pcme = PersonalComputeMessageEnum(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pcme = PersonalComputeMessageEnum(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DELEGATE", "ON"`, v)

--- a/service/sharing/model.go
+++ b/service/sharing/model.go
@@ -28,6 +28,10 @@ func (at *AuthenticationType) Set(v string) error {
 	case `DATABRICKS`, `TOKEN`:
 		*at = AuthenticationType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*at = AuthenticationType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DATABRICKS", "TOKEN"`, v)
 	}
@@ -212,6 +216,10 @@ func (pvo *PartitionValueOp) Set(v string) error {
 	case `EQUAL`, `LIKE`:
 		*pvo = PartitionValueOp(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pvo = PartitionValueOp(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EQUAL", "LIKE"`, v)
 	}
@@ -294,6 +302,10 @@ func (p *Privilege) Set(v string) error {
 	switch v {
 	case `ALL_PRIVILEGES`, `CREATE`, `CREATE_CATALOG`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `CREATE_FUNCTION`, `CREATE_MANAGED_STORAGE`, `CREATE_MATERIALIZED_VIEW`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SCHEMA`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `CREATE_TABLE`, `CREATE_VIEW`, `EXECUTE`, `MODIFY`, `READ_FILES`, `READ_PRIVATE_FILES`, `REFRESH`, `SELECT`, `SET_SHARE_PERMISSION`, `USAGE`, `USE_CATALOG`, `USE_PROVIDER`, `USE_RECIPIENT`, `USE_SCHEMA`, `USE_SHARE`, `WRITE_FILES`, `WRITE_PRIVATE_FILES`:
 		*p = Privilege(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*p = Privilege(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ALL_PRIVILEGES", "CREATE", "CREATE_CATALOG", "CREATE_EXTERNAL_LOCATION", "CREATE_EXTERNAL_TABLE", "CREATE_FUNCTION", "CREATE_MANAGED_STORAGE", "CREATE_MATERIALIZED_VIEW", "CREATE_PROVIDER", "CREATE_RECIPIENT", "CREATE_SCHEMA", "CREATE_SHARE", "CREATE_STORAGE_CREDENTIAL", "CREATE_TABLE", "CREATE_VIEW", "EXECUTE", "MODIFY", "READ_FILES", "READ_PRIVATE_FILES", "REFRESH", "SELECT", "SET_SHARE_PERMISSION", "USAGE", "USE_CATALOG", "USE_PROVIDER", "USE_RECIPIENT", "USE_SCHEMA", "USE_SHARE", "WRITE_FILES", "WRITE_PRIVATE_FILES"`, v)
@@ -554,6 +566,10 @@ func (sdos *SharedDataObjectStatus) Set(v string) error {
 	case `ACTIVE`, `PERMISSION_DENIED`:
 		*sdos = SharedDataObjectStatus(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sdos = SharedDataObjectStatus(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ACTIVE", "PERMISSION_DENIED"`, v)
 	}
@@ -590,6 +606,10 @@ func (sdoua *SharedDataObjectUpdateAction) Set(v string) error {
 	switch v {
 	case `ADD`, `REMOVE`, `UPDATE`:
 		*sdoua = SharedDataObjectUpdateAction(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sdoua = SharedDataObjectUpdateAction(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ADD", "REMOVE", "UPDATE"`, v)

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -91,6 +91,10 @@ func (as *AlertState) Set(v string) error {
 	case `ok`, `triggered`, `unknown`:
 		*as = AlertState(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*as = AlertState(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ok", "triggered", "unknown"`, v)
 	}
@@ -142,6 +146,10 @@ func (cn *ChannelName) Set(v string) error {
 	switch v {
 	case `CHANNEL_NAME_CURRENT`, `CHANNEL_NAME_CUSTOM`, `CHANNEL_NAME_PREVIEW`, `CHANNEL_NAME_PREVIOUS`, `CHANNEL_NAME_UNSPECIFIED`:
 		*cn = ChannelName(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cn = ChannelName(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS", "CHANNEL_NAME_UNSPECIFIED"`, v)
@@ -241,6 +249,10 @@ func (citn *ColumnInfoTypeName) Set(v string) error {
 	switch v {
 	case `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TIMESTAMP`, `USER_DEFINED_TYPE`:
 		*citn = ColumnInfoTypeName(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*citn = ColumnInfoTypeName(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ARRAY", "BINARY", "BOOLEAN", "BYTE", "CHAR", "DATE", "DECIMAL", "DOUBLE", "FLOAT", "INT", "INTERVAL", "LONG", "MAP", "NULL", "SHORT", "STRING", "STRUCT", "TIMESTAMP", "USER_DEFINED_TYPE"`, v)
@@ -367,6 +379,10 @@ func (cwrwt *CreateWarehouseRequestWarehouseType) Set(v string) error {
 	switch v {
 	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*cwrwt = CreateWarehouseRequestWarehouseType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*cwrwt = CreateWarehouseRequestWarehouseType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLASSIC", "PRO", "TYPE_UNSPECIFIED"`, v)
@@ -527,6 +543,10 @@ func (d *Disposition) Set(v string) error {
 	case `EXTERNAL_LINKS`, `INLINE`:
 		*d = Disposition(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*d = Disposition(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EXTERNAL_LINKS", "INLINE"`, v)
 	}
@@ -636,6 +656,10 @@ func (ewrwt *EditWarehouseRequestWarehouseType) Set(v string) error {
 	switch v {
 	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*ewrwt = EditWarehouseRequestWarehouseType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ewrwt = EditWarehouseRequestWarehouseType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLASSIC", "PRO", "TYPE_UNSPECIFIED"`, v)
@@ -766,6 +790,10 @@ func (eiwt *EndpointInfoWarehouseType) Set(v string) error {
 	switch v {
 	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*eiwt = EndpointInfoWarehouseType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*eiwt = EndpointInfoWarehouseType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLASSIC", "PRO", "TYPE_UNSPECIFIED"`, v)
@@ -992,6 +1020,10 @@ func (f *Format) Set(v string) error {
 	case `ARROW_STREAM`, `CSV`, `JSON_ARRAY`:
 		*f = Format(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*f = Format(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ARROW_STREAM", "CSV", "JSON_ARRAY"`, v)
 	}
@@ -1165,6 +1197,10 @@ func (gwrwt *GetWarehouseResponseWarehouseType) Set(v string) error {
 	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*gwrwt = GetWarehouseResponseWarehouseType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*gwrwt = GetWarehouseResponseWarehouseType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLASSIC", "PRO", "TYPE_UNSPECIFIED"`, v)
 	}
@@ -1223,6 +1259,10 @@ func (gwwcrsp *GetWorkspaceWarehouseConfigResponseSecurityPolicy) Set(v string) 
 	case `DATA_ACCESS_CONTROL`, `NONE`, `PASSTHROUGH`:
 		*gwwcrsp = GetWorkspaceWarehouseConfigResponseSecurityPolicy(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*gwwcrsp = GetWorkspaceWarehouseConfigResponseSecurityPolicy(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DATA_ACCESS_CONTROL", "NONE", "PASSTHROUGH"`, v)
 	}
@@ -1261,6 +1301,10 @@ func (lo *ListOrder) Set(v string) error {
 	switch v {
 	case `created_at`, `name`:
 		*lo = ListOrder(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*lo = ListOrder(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "created_at", "name"`, v)
@@ -1363,6 +1407,10 @@ func (ot *ObjectType) Set(v string) error {
 	case `alert`, `dashboard`, `data_source`, `query`:
 		*ot = ObjectType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ot = ObjectType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "alert", "dashboard", "data_source", "query"`, v)
 	}
@@ -1394,6 +1442,10 @@ func (otp *ObjectTypePlural) Set(v string) error {
 	switch v {
 	case `alerts`, `dashboards`, `data_sources`, `queries`:
 		*otp = ObjectTypePlural(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*otp = ObjectTypePlural(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "alerts", "dashboards", "data_sources", "queries"`, v)
@@ -1434,6 +1486,10 @@ func (oot *OwnableObjectType) Set(v string) error {
 	switch v {
 	case `alert`, `dashboard`, `query`:
 		*oot = OwnableObjectType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*oot = OwnableObjectType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "alert", "dashboard", "query"`, v)
@@ -1477,6 +1533,10 @@ func (pt *ParameterType) Set(v string) error {
 	case `datetime`, `number`, `text`:
 		*pt = ParameterType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pt = ParameterType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "datetime", "number", "text"`, v)
 	}
@@ -1509,6 +1569,10 @@ func (pl *PermissionLevel) Set(v string) error {
 	switch v {
 	case `CAN_MANAGE`, `CAN_RUN`, `CAN_VIEW`:
 		*pl = PermissionLevel(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*pl = PermissionLevel(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CAN_MANAGE", "CAN_RUN", "CAN_VIEW"`, v)
@@ -1545,6 +1609,10 @@ func (ps *PlansState) Set(v string) error {
 	switch v {
 	case `EMPTY`, `EXISTS`, `IGNORED_LARGE_PLANS_SIZE`, `IGNORED_SMALL_DURATION`, `IGNORED_SPARK_PLAN_TYPE`, `UNKNOWN`:
 		*ps = PlansState(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ps = PlansState(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "EMPTY", "EXISTS", "IGNORED_LARGE_PLANS_SIZE", "IGNORED_SMALL_DURATION", "IGNORED_SPARK_PLAN_TYPE", "UNKNOWN"`, v)
@@ -1852,6 +1920,10 @@ func (qst *QueryStatementType) Set(v string) error {
 	case `ALTER`, `ANALYZE`, `COPY`, `CREATE`, `DELETE`, `DESCRIBE`, `DROP`, `EXPLAIN`, `GRANT`, `INSERT`, `MERGE`, `OPTIMIZE`, `OTHER`, `REFRESH`, `REPLACE`, `REVOKE`, `SELECT`, `SET`, `SHOW`, `TRUNCATE`, `UPDATE`, `USE`:
 		*qst = QueryStatementType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*qst = QueryStatementType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ALTER", "ANALYZE", "COPY", "CREATE", "DELETE", "DESCRIBE", "DROP", "EXPLAIN", "GRANT", "INSERT", "MERGE", "OPTIMIZE", "OTHER", "REFRESH", "REPLACE", "REVOKE", "SELECT", "SET", "SHOW", "TRUNCATE", "UPDATE", "USE"`, v)
 	}
@@ -1890,6 +1962,10 @@ func (qs *QueryStatus) Set(v string) error {
 	switch v {
 	case `CANCELED`, `FAILED`, `FINISHED`, `QUEUED`, `RUNNING`:
 		*qs = QueryStatus(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*qs = QueryStatus(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCELED", "FAILED", "FINISHED", "QUEUED", "RUNNING"`, v)
@@ -2056,6 +2132,10 @@ func (sec *ServiceErrorCode) Set(v string) error {
 	case `ABORTED`, `ALREADY_EXISTS`, `BAD_REQUEST`, `CANCELLED`, `DEADLINE_EXCEEDED`, `INTERNAL_ERROR`, `IO_ERROR`, `NOT_FOUND`, `RESOURCE_EXHAUSTED`, `SERVICE_UNDER_MAINTENANCE`, `TEMPORARILY_UNAVAILABLE`, `UNAUTHENTICATED`, `UNKNOWN`, `WORKSPACE_TEMPORARILY_UNAVAILABLE`:
 		*sec = ServiceErrorCode(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sec = ServiceErrorCode(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ABORTED", "ALREADY_EXISTS", "BAD_REQUEST", "CANCELLED", "DEADLINE_EXCEEDED", "INTERNAL_ERROR", "IO_ERROR", "NOT_FOUND", "RESOURCE_EXHAUSTED", "SERVICE_UNDER_MAINTENANCE", "TEMPORARILY_UNAVAILABLE", "UNAUTHENTICATED", "UNKNOWN", "WORKSPACE_TEMPORARILY_UNAVAILABLE"`, v)
 	}
@@ -2132,6 +2212,10 @@ func (swwcrsp *SetWorkspaceWarehouseConfigRequestSecurityPolicy) Set(v string) e
 	case `DATA_ACCESS_CONTROL`, `NONE`, `PASSTHROUGH`:
 		*swwcrsp = SetWorkspaceWarehouseConfigRequestSecurityPolicy(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*swwcrsp = SetWorkspaceWarehouseConfigRequestSecurityPolicy(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DATA_ACCESS_CONTROL", "NONE", "PASSTHROUGH"`, v)
 	}
@@ -2161,6 +2245,10 @@ func (sip *SpotInstancePolicy) Set(v string) error {
 	switch v {
 	case `COST_OPTIMIZED`, `POLICY_UNSPECIFIED`, `RELIABILITY_OPTIMIZED`:
 		*sip = SpotInstancePolicy(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sip = SpotInstancePolicy(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "COST_OPTIMIZED", "POLICY_UNSPECIFIED", "RELIABILITY_OPTIMIZED"`, v)
@@ -2204,6 +2292,10 @@ func (s *State) Set(v string) error {
 	case `DELETED`, `DELETING`, `RUNNING`, `STARTING`, `STOPPED`, `STOPPING`:
 		*s = State(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*s = State(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DELETED", "DELETING", "RUNNING", "STARTING", "STOPPED", "STOPPING"`, v)
 	}
@@ -2244,6 +2336,10 @@ func (ss *StatementState) Set(v string) error {
 	switch v {
 	case `CANCELED`, `CLOSED`, `FAILED`, `PENDING`, `RUNNING`, `SUCCEEDED`:
 		*ss = StatementState(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ss = StatementState(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCELED", "CLOSED", "FAILED", "PENDING", "RUNNING", "SUCCEEDED"`, v)
@@ -2290,6 +2386,10 @@ func (s *Status) Set(v string) error {
 	case `DEGRADED`, `FAILED`, `HEALTHY`, `STATUS_UNSPECIFIED`:
 		*s = Status(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*s = Status(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DEGRADED", "FAILED", "HEALTHY", "STATUS_UNSPECIFIED"`, v)
 	}
@@ -2324,6 +2424,10 @@ func (sm *SuccessMessage) Set(v string) error {
 	switch v {
 	case `Success`:
 		*sm = SuccessMessage(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sm = SuccessMessage(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "Success"`, v)
@@ -2517,6 +2621,10 @@ func (trc *TerminationReasonCode) Set(v string) error {
 	case `ABUSE_DETECTED`, `ATTACH_PROJECT_FAILURE`, `AWS_AUTHORIZATION_FAILURE`, `AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE`, `AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE`, `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE`, `AWS_REQUEST_LIMIT_EXCEEDED`, `AWS_UNSUPPORTED_FAILURE`, `AZURE_BYOK_KEY_PERMISSION_FAILURE`, `AZURE_EPHEMERAL_DISK_FAILURE`, `AZURE_INVALID_DEPLOYMENT_TEMPLATE`, `AZURE_OPERATION_NOT_ALLOWED_EXCEPTION`, `AZURE_QUOTA_EXCEEDED_EXCEPTION`, `AZURE_RESOURCE_MANAGER_THROTTLING`, `AZURE_RESOURCE_PROVIDER_THROTTLING`, `AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE`, `AZURE_VM_EXTENSION_FAILURE`, `AZURE_VNET_CONFIGURATION_FAILURE`, `BOOTSTRAP_TIMEOUT`, `BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION`, `CLOUD_PROVIDER_DISK_SETUP_FAILURE`, `CLOUD_PROVIDER_LAUNCH_FAILURE`, `CLOUD_PROVIDER_RESOURCE_STOCKOUT`, `CLOUD_PROVIDER_SHUTDOWN`, `COMMUNICATION_LOST`, `CONTAINER_LAUNCH_FAILURE`, `CONTROL_PLANE_REQUEST_FAILURE`, `DATABASE_CONNECTION_FAILURE`, `DBFS_COMPONENT_UNHEALTHY`, `DOCKER_IMAGE_PULL_FAILURE`, `DRIVER_UNREACHABLE`, `DRIVER_UNRESPONSIVE`, `EXECUTION_COMPONENT_UNHEALTHY`, `GCP_QUOTA_EXCEEDED`, `GCP_SERVICE_ACCOUNT_DELETED`, `GLOBAL_INIT_SCRIPT_FAILURE`, `HIVE_METASTORE_PROVISIONING_FAILURE`, `IMAGE_PULL_PERMISSION_DENIED`, `INACTIVITY`, `INIT_SCRIPT_FAILURE`, `INSTANCE_POOL_CLUSTER_FAILURE`, `INSTANCE_UNREACHABLE`, `INTERNAL_ERROR`, `INVALID_ARGUMENT`, `INVALID_SPARK_IMAGE`, `IP_EXHAUSTION_FAILURE`, `JOB_FINISHED`, `K8S_AUTOSCALING_FAILURE`, `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`, `METASTORE_COMPONENT_UNHEALTHY`, `NEPHOS_RESOURCE_MANAGEMENT`, `NETWORK_CONFIGURATION_FAILURE`, `NFS_MOUNT_FAILURE`, `NPIP_TUNNEL_SETUP_FAILURE`, `NPIP_TUNNEL_TOKEN_FAILURE`, `REQUEST_REJECTED`, `REQUEST_THROTTLED`, `SECRET_RESOLUTION_ERROR`, `SECURITY_DAEMON_REGISTRATION_EXCEPTION`, `SELF_BOOTSTRAP_FAILURE`, `SKIPPED_SLOW_NODES`, `SLOW_IMAGE_DOWNLOAD`, `SPARK_ERROR`, `SPARK_IMAGE_DOWNLOAD_FAILURE`, `SPARK_STARTUP_FAILURE`, `SPOT_INSTANCE_TERMINATION`, `STORAGE_DOWNLOAD_FAILURE`, `STS_CLIENT_SETUP_FAILURE`, `SUBNET_EXHAUSTED_FAILURE`, `TEMPORARILY_UNAVAILABLE`, `TRIAL_EXPIRED`, `UNEXPECTED_LAUNCH_FAILURE`, `UNKNOWN`, `UNSUPPORTED_INSTANCE_TYPE`, `UPDATE_INSTANCE_PROFILE_FAILURE`, `USER_REQUEST`, `WORKER_SETUP_FAILURE`, `WORKSPACE_CANCELLED_ERROR`, `WORKSPACE_CONFIGURATION_ERROR`:
 		*trc = TerminationReasonCode(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*trc = TerminationReasonCode(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "ABUSE_DETECTED", "ATTACH_PROJECT_FAILURE", "AWS_AUTHORIZATION_FAILURE", "AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE", "AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE", "AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE", "AWS_REQUEST_LIMIT_EXCEEDED", "AWS_UNSUPPORTED_FAILURE", "AZURE_BYOK_KEY_PERMISSION_FAILURE", "AZURE_EPHEMERAL_DISK_FAILURE", "AZURE_INVALID_DEPLOYMENT_TEMPLATE", "AZURE_OPERATION_NOT_ALLOWED_EXCEPTION", "AZURE_QUOTA_EXCEEDED_EXCEPTION", "AZURE_RESOURCE_MANAGER_THROTTLING", "AZURE_RESOURCE_PROVIDER_THROTTLING", "AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE", "AZURE_VM_EXTENSION_FAILURE", "AZURE_VNET_CONFIGURATION_FAILURE", "BOOTSTRAP_TIMEOUT", "BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION", "CLOUD_PROVIDER_DISK_SETUP_FAILURE", "CLOUD_PROVIDER_LAUNCH_FAILURE", "CLOUD_PROVIDER_RESOURCE_STOCKOUT", "CLOUD_PROVIDER_SHUTDOWN", "COMMUNICATION_LOST", "CONTAINER_LAUNCH_FAILURE", "CONTROL_PLANE_REQUEST_FAILURE", "DATABASE_CONNECTION_FAILURE", "DBFS_COMPONENT_UNHEALTHY", "DOCKER_IMAGE_PULL_FAILURE", "DRIVER_UNREACHABLE", "DRIVER_UNRESPONSIVE", "EXECUTION_COMPONENT_UNHEALTHY", "GCP_QUOTA_EXCEEDED", "GCP_SERVICE_ACCOUNT_DELETED", "GLOBAL_INIT_SCRIPT_FAILURE", "HIVE_METASTORE_PROVISIONING_FAILURE", "IMAGE_PULL_PERMISSION_DENIED", "INACTIVITY", "INIT_SCRIPT_FAILURE", "INSTANCE_POOL_CLUSTER_FAILURE", "INSTANCE_UNREACHABLE", "INTERNAL_ERROR", "INVALID_ARGUMENT", "INVALID_SPARK_IMAGE", "IP_EXHAUSTION_FAILURE", "JOB_FINISHED", "K8S_AUTOSCALING_FAILURE", "K8S_DBR_CLUSTER_LAUNCH_TIMEOUT", "METASTORE_COMPONENT_UNHEALTHY", "NEPHOS_RESOURCE_MANAGEMENT", "NETWORK_CONFIGURATION_FAILURE", "NFS_MOUNT_FAILURE", "NPIP_TUNNEL_SETUP_FAILURE", "NPIP_TUNNEL_TOKEN_FAILURE", "REQUEST_REJECTED", "REQUEST_THROTTLED", "SECRET_RESOLUTION_ERROR", "SECURITY_DAEMON_REGISTRATION_EXCEPTION", "SELF_BOOTSTRAP_FAILURE", "SKIPPED_SLOW_NODES", "SLOW_IMAGE_DOWNLOAD", "SPARK_ERROR", "SPARK_IMAGE_DOWNLOAD_FAILURE", "SPARK_STARTUP_FAILURE", "SPOT_INSTANCE_TERMINATION", "STORAGE_DOWNLOAD_FAILURE", "STS_CLIENT_SETUP_FAILURE", "SUBNET_EXHAUSTED_FAILURE", "TEMPORARILY_UNAVAILABLE", "TRIAL_EXPIRED", "UNEXPECTED_LAUNCH_FAILURE", "UNKNOWN", "UNSUPPORTED_INSTANCE_TYPE", "UPDATE_INSTANCE_PROFILE_FAILURE", "USER_REQUEST", "WORKER_SETUP_FAILURE", "WORKSPACE_CANCELLED_ERROR", "WORKSPACE_CONFIGURATION_ERROR"`, v)
 	}
@@ -2548,6 +2656,10 @@ func (trt *TerminationReasonType) Set(v string) error {
 	switch v {
 	case `CLIENT_ERROR`, `CLOUD_FAILURE`, `SERVICE_FAULT`, `SUCCESS`:
 		*trt = TerminationReasonType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*trt = TerminationReasonType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLIENT_ERROR", "CLOUD_FAILURE", "SERVICE_FAULT", "SUCCESS"`, v)
@@ -2590,6 +2702,10 @@ func (ta *TimeoutAction) Set(v string) error {
 	switch v {
 	case `CANCEL`, `CONTINUE`:
 		*ta = TimeoutAction(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ta = TimeoutAction(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CANCEL", "CONTINUE"`, v)
@@ -2681,6 +2797,10 @@ func (wtpwt *WarehouseTypePairWarehouseType) Set(v string) error {
 	switch v {
 	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*wtpwt = WarehouseTypePairWarehouseType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*wtpwt = WarehouseTypePairWarehouseType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "CLASSIC", "PRO", "TYPE_UNSPECIFIED"`, v)

--- a/service/workspace/model.go
+++ b/service/workspace/model.go
@@ -32,6 +32,10 @@ func (ap *AclPermission) Set(v string) error {
 	case `MANAGE`, `READ`, `WRITE`:
 		*ap = AclPermission(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ap = AclPermission(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "MANAGE", "READ", "WRITE"`, v)
 	}
@@ -190,6 +194,10 @@ func (ef *ExportFormat) Set(v string) error {
 	case `AUTO`, `DBC`, `HTML`, `JUPYTER`, `R_MARKDOWN`, `SOURCE`:
 		*ef = ExportFormat(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ef = ExportFormat(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "AUTO", "DBC", "HTML", "JUPYTER", "R_MARKDOWN", "SOURCE"`, v)
 	}
@@ -298,6 +306,10 @@ func (l *Language) Set(v string) error {
 	switch v {
 	case `PYTHON`, `R`, `SCALA`, `SQL`:
 		*l = Language(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*l = Language(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "PYTHON", "R", "SCALA", "SQL"`, v)
@@ -416,6 +428,10 @@ func (ot *ObjectType) Set(v string) error {
 	case `DIRECTORY`, `FILE`, `LIBRARY`, `NOTEBOOK`, `REPO`:
 		*ot = ObjectType(v)
 		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*ot = ObjectType(``)
+		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "DIRECTORY", "FILE", "LIBRARY", "NOTEBOOK", "REPO"`, v)
 	}
@@ -483,6 +499,10 @@ func (sbt *ScopeBackendType) Set(v string) error {
 	switch v {
 	case `AZURE_KEYVAULT`, `DATABRICKS`:
 		*sbt = ScopeBackendType(v)
+		return nil
+	case ``:
+		// Enum type may be set to empty string to indicate unset value.
+		*sbt = ScopeBackendType(``)
 		return nil
 	default:
 		return fmt.Errorf(`value "%s" is not one of "AZURE_KEYVAULT", "DATABRICKS"`, v)


### PR DESCRIPTION
## Changes

The default value of these enum types is an empty string, which means that once set, they cannot be unset. With this change they can always be reverted back to their initial value. This is needed to set/unset flags in the CLI.

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

