### PR TITLE
Added ClusterID field for Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	// Databricks host (either of workspace endpoint or Accounts API endpoint)
 	Host string `name:"host" env:"DATABRICKS_HOST"`
 
+	ClusterId string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
+
 	// URL of the metadata service that provides authentication credentials.
 	MetadataServiceURL string `name:"metadata_service_url" env:"DATABRICKS_METADATA_SERVICE_URL" auth:"metadata-service,sensitive"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	// Databricks host (either of workspace endpoint or Accounts API endpoint)
 	Host string `name:"host" env:"DATABRICKS_HOST"`
 
-	ClusterId string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
+	ClusterID string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
 
 	// URL of the metadata service that provides authentication credentials.
 	MetadataServiceURL string `name:"metadata_service_url" env:"DATABRICKS_METADATA_SERVICE_URL" auth:"metadata-service,sensitive"`

--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,8 @@ type Config struct {
 	// Databricks host (either of workspace endpoint or Accounts API endpoint)
 	Host string `name:"host" env:"DATABRICKS_HOST"`
 
-	ClusterID string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
+	ClusterID   string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
+	WarehouseID string `name:"warehouse_id" env:"DATABRICKS_WAREHOUSE_ID"`
 
 	// URL of the metadata service that provides authentication credentials.
 	MetadataServiceURL string `name:"metadata_service_url" env:"DATABRICKS_METADATA_SERVICE_URL" auth:"metadata-service,sensitive"`


### PR DESCRIPTION
## Changes
As per https://docs.databricks.com/dev-tools/databricks-connect.html it's possible to provide cluster ID in Databricks configuration

This PR adds this field in Config struct

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] ~relevant integration tests applied~

