### PR TITLE
Support accounts-dod as account endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -158,7 +158,16 @@ func (c *Config) IsAws() bool {
 
 // IsAccountClient returns true if client is configured for Accounts API
 func (c *Config) IsAccountClient() bool {
-	return (c.AccountID != "" && c.isTesting) || strings.HasPrefix(c.Host, "https://accounts.")
+	accountsPrefixes := []string{
+		"https://accounts.",
+		"https://accounts-dod.",
+	}
+	for _, prefix := range accountsPrefixes {
+		if strings.HasPrefix(c.Host, prefix) {
+			return true
+		}
+	}
+	return c.AccountID != "" && c.isTesting
 }
 
 func (c *Config) EnsureResolved() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAccountClient_AwsAccount(t *testing.T) {
+	c := &Config{
+		Host:      "https://accounts.cloud.databricks.com",
+		AccountID: "123e4567-e89b-12d3-a456-426614174000",
+	}
+	assert.True(t, c.IsAccountClient())
+}
+
+func TestIsAccountClient_AwsDodAccount(t *testing.T) {
+	c := &Config{
+		Host:      "https://accounts-dod.cloud.databricks.us",
+		AccountID: "123e4567-e89b-12d3-a456-426614174000",
+	}
+	assert.True(t, c.IsAccountClient())
+}
+
+func TestIsAccountClient_AwsWorkspace(t *testing.T) {
+	c := &Config{
+		Host:      "https://my-workspace.cloud.databricks.us",
+		AccountID: "123e4567-e89b-12d3-a456-426614174000",
+	}
+	assert.False(t, c.IsAccountClient())
+}


### PR DESCRIPTION
## Changes
Modify IsAccountClient to return `true` for new accounts endpoints that are set up for the Department of Defense.

Resolves https://github.com/databricks/terraform-provider-databricks/issues/2433 once TF provider is updated to a version including this commit.

## Tests
- [x] Added a unit test to cover IsAccountClient().
- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

