### PR TITLE
Regenerate SDK according to OpenAPI spec c411c04c62262f1bdacc047356f1d2030f41e660

### DIFF
--- a/service/catalog/impl.go
+++ b/service/catalog/impl.go
@@ -484,7 +484,7 @@ func (a *systemSchemasImpl) Disable(ctx context.Context, request DisableRequest)
 
 func (a *systemSchemasImpl) Enable(ctx context.Context, request EnableRequest) error {
 	path := fmt.Sprintf("/api/2.1/unity-catalog/metastores/%v/systemschemas/%v", request.MetastoreId, request.SchemaName)
-	err := a.client.Do(ctx, http.MethodPost, path, request, nil)
+	err := a.client.Do(ctx, http.MethodPut, path, request, nil)
 	return err
 }
 

--- a/service/catalog/model.go
+++ b/service/catalog/model.go
@@ -1912,25 +1912,27 @@ type SecurablePropertiesMap map[string]string
 // The type of Unity Catalog securable
 type SecurableType string
 
-const SecurableTypeCatalog SecurableType = `CATALOG`
+const SecurableTypeCatalog SecurableType = `catalog`
 
-const SecurableTypeExternalLocation SecurableType = `EXTERNAL_LOCATION`
+const SecurableTypeExternalLocation SecurableType = `external_location`
 
-const SecurableTypeFunction SecurableType = `FUNCTION`
+const SecurableTypeFunction SecurableType = `function`
 
-const SecurableTypeMetastore SecurableType = `METASTORE`
+const SecurableTypeMetastore SecurableType = `metastore`
 
-const SecurableTypeProvider SecurableType = `PROVIDER`
+const SecurableTypePipeline SecurableType = `pipeline`
 
-const SecurableTypeRecipient SecurableType = `RECIPIENT`
+const SecurableTypeProvider SecurableType = `provider`
 
-const SecurableTypeSchema SecurableType = `SCHEMA`
+const SecurableTypeRecipient SecurableType = `recipient`
 
-const SecurableTypeShare SecurableType = `SHARE`
+const SecurableTypeSchema SecurableType = `schema`
 
-const SecurableTypeStorageCredential SecurableType = `STORAGE_CREDENTIAL`
+const SecurableTypeShare SecurableType = `share`
 
-const SecurableTypeTable SecurableType = `TABLE`
+const SecurableTypeStorageCredential SecurableType = `storage_credential`
+
+const SecurableTypeTable SecurableType = `table`
 
 // String representation for [fmt.Print]
 func (f *SecurableType) String() string {
@@ -1940,11 +1942,11 @@ func (f *SecurableType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SecurableType) Set(v string) error {
 	switch v {
-	case `CATALOG`, `EXTERNAL_LOCATION`, `FUNCTION`, `METASTORE`, `PROVIDER`, `RECIPIENT`, `SCHEMA`, `SHARE`, `STORAGE_CREDENTIAL`, `TABLE`:
+	case `catalog`, `external_location`, `function`, `metastore`, `pipeline`, `provider`, `recipient`, `schema`, `share`, `storage_credential`, `table`:
 		*f = SecurableType(v)
 		return nil
 	default:
-		return fmt.Errorf(`value "%s" is not one of "CATALOG", "EXTERNAL_LOCATION", "FUNCTION", "METASTORE", "PROVIDER", "RECIPIENT", "SCHEMA", "SHARE", "STORAGE_CREDENTIAL", "TABLE"`, v)
+		return fmt.Errorf(`value "%s" is not one of "catalog", "external_location", "function", "metastore", "pipeline", "provider", "recipient", "schema", "share", "storage_credential", "table"`, v)
 	}
 }
 

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -191,6 +191,8 @@ type Group struct {
 	Id string `json:"id,omitempty" url:"-"`
 
 	Members []ComplexValue `json:"members,omitempty"`
+	// Container for the group identifier. Workspace local versus account.
+	Meta *ResourceMeta `json:"meta,omitempty"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }
@@ -582,6 +584,12 @@ type PrincipalOutput struct {
 	UserName string `json:"user_name,omitempty"`
 }
 
+type ResourceMeta struct {
+	// Identifier for group type. Can be local workspace group
+	// (`WorkspaceGroup`) or account group (`Group`).
+	ResourceType string `json:"resourceType,omitempty"`
+}
+
 type RuleSetResponse struct {
 	// Identifies the version of the rule set returned.
 	Etag string `json:"etag,omitempty"`
@@ -652,7 +660,7 @@ type User struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks user ID.
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 
 	Name *Name `json:"name,omitempty"`
 

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -58,20 +58,20 @@ func ExampleModelRegistryAPI_CreateComment_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_models() {
+func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
 		panic(err)
 	}
 
-	created, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
 		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
 	})
 	if err != nil {
 		panic(err)
 	}
-	logger.Infof(ctx, "found %v", created)
+	logger.Infof(ctx, "found %v", model)
 
 }
 
@@ -92,20 +92,20 @@ func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
+func ExampleModelRegistryAPI_CreateModel_models() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
 		panic(err)
 	}
 
-	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+	created, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
 		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
 	})
 	if err != nil {
 		panic(err)
 	}
-	logger.Infof(ctx, "found %v", model)
+	logger.Infof(ctx, "found %v", created)
 
 }
 

--- a/service/serving/api.go
+++ b/service/serving/api.go
@@ -25,15 +25,15 @@ func NewServingEndpoints(client *client.DatabricksClient) *ServingEndpointsAPI {
 // serving endpoints.
 //
 // You can use a serving endpoint to serve models from the Databricks Model
-// Registry. Endpoints expose the underlying models as scalable REST API
-// endpoints using serverless compute. This means the endpoints and associated
-// compute resources are fully managed by Databricks and will not appear in your
-// cloud account. A serving endpoint can consist of one or more MLflow models
-// from the Databricks Model Registry, called served models. A serving endpoint
-// can have at most ten served models. You can configure traffic settings to
-// define how requests should be routed to your served models behind an
-// endpoint. Additionally, you can configure the scale of resources that should
-// be applied to each served model.
+// Registry or from Unity Catalog. Endpoints expose the underlying models as
+// scalable REST API endpoints using serverless compute. This means the
+// endpoints and associated compute resources are fully managed by Databricks
+// and will not appear in your cloud account. A serving endpoint can consist of
+// one or more MLflow models from the Databricks Model Registry, called served
+// models. A serving endpoint can have at most ten served models. You can
+// configure traffic settings to define how requests should be routed to your
+// served models behind an endpoint. Additionally, you can configure the scale
+// of resources that should be applied to each served model.
 type ServingEndpointsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ServingEndpointsService)

--- a/service/serving/interface.go
+++ b/service/serving/interface.go
@@ -10,15 +10,15 @@ import (
 // serving endpoints.
 //
 // You can use a serving endpoint to serve models from the Databricks Model
-// Registry. Endpoints expose the underlying models as scalable REST API
-// endpoints using serverless compute. This means the endpoints and associated
-// compute resources are fully managed by Databricks and will not appear in your
-// cloud account. A serving endpoint can consist of one or more MLflow models
-// from the Databricks Model Registry, called served models. A serving endpoint
-// can have at most ten served models. You can configure traffic settings to
-// define how requests should be routed to your served models behind an
-// endpoint. Additionally, you can configure the scale of resources that should
-// be applied to each served model.
+// Registry or from Unity Catalog. Endpoints expose the underlying models as
+// scalable REST API endpoints using serverless compute. This means the
+// endpoints and associated compute resources are fully managed by Databricks
+// and will not appear in your cloud account. A serving endpoint can consist of
+// one or more MLflow models from the Databricks Model Registry, called served
+// models. A serving endpoint can have at most ten served models. You can
+// configure traffic settings to define how requests should be routed to your
+// served models behind an endpoint. Additionally, you can configure the scale
+// of resources that should be applied to each served model.
 type ServingEndpointsService interface {
 
 	// Retrieve the logs associated with building the model's environment for a

--- a/service/serving/model.go
+++ b/service/serving/model.go
@@ -209,10 +209,13 @@ type ServedModelInput struct {
 	// variables that refer to Databricks secrets: `{"OPENAI_API_KEY":
 	// "{{secrets/my_scope/my_key}}", "DATABRICKS_TOKEN":
 	// "{{secrets/my_scope2/my_key2}}"}`
-	EnvironmentVars any `json:"environment_vars,omitempty"`
-	// The name of the model in Databricks Model Registry to be served.
+	EnvironmentVars map[string]string `json:"environment_vars,omitempty"`
+	// The name of the model in Databricks Model Registry to be served or if the
+	// model resides in Unity Catalog, the full name of model, in the form of
+	// __catalog_name__.__schema_name__.__model_name__.
 	ModelName string `json:"model_name"`
-	// The version of the model in Databricks Model Registry to be served.
+	// The version of the model in Databricks Model Registry or Unity Catalog to
+	// be served.
 	ModelVersion string `json:"model_version"`
 	// The name of a served model. It must be unique across an endpoint. If not
 	// specified, this field will default to <model-name>-<model-version>. A
@@ -243,10 +246,12 @@ type ServedModelOutput struct {
 	// variables that refer to Databricks secrets: `{"OPENAI_API_KEY":
 	// "{{secrets/my_scope/my_key}}", "DATABRICKS_TOKEN":
 	// "{{secrets/my_scope2/my_key2}}"}`
-	EnvironmentVars any `json:"environment_vars,omitempty"`
-	// The name of the model in Databricks Model Registry.
+	EnvironmentVars map[string]string `json:"environment_vars,omitempty"`
+	// The name of the model in Databricks Model Registry or the full name of
+	// the model in Unity Catalog.
 	ModelName string `json:"model_name,omitempty"`
-	// The version of the model in Databricks Model Registry.
+	// The version of the model in Databricks Model Registry or Unity Catalog to
+	// be served.
 	ModelVersion string `json:"model_version,omitempty"`
 	// The name of the served model.
 	Name string `json:"name,omitempty"`
@@ -266,9 +271,11 @@ type ServedModelOutput struct {
 }
 
 type ServedModelSpec struct {
-	// The name of the model in Databricks Model Registry.
+	// The name of the model in Databricks Model Registry or the full name of
+	// the model in Unity Catalog.
 	ModelName string `json:"model_name,omitempty"`
-	// The version of the model in Databricks Model Registry.
+	// The version of the model in Databricks Model Registry or Unity Catalog to
+	// be served.
 	ModelVersion string `json:"model_version,omitempty"`
 	// The name of the served model.
 	Name string `json:"name,omitempty"`

--- a/service/sharing/model.go
+++ b/service/sharing/model.go
@@ -514,6 +514,9 @@ type SharedDataObject struct {
 	Comment string `json:"comment,omitempty"`
 	// The type of the data object.
 	DataObjectType string `json:"data_object_type,omitempty"`
+	// Whether to enable or disable sharing of data history. If not specified,
+	// the default is **DISABLED**.
+	HistoryDataSharingStatus SharedDataObjectHistoryDataSharingStatus `json:"history_data_sharing_status,omitempty"`
 	// A fully qualified name that uniquely identifies a data object.
 	//
 	// For example, a table's fully qualified name is in the format of
@@ -536,6 +539,35 @@ type SharedDataObject struct {
 	StartVersion int64 `json:"start_version,omitempty"`
 	// One of: **ACTIVE**, **PERMISSION_DENIED**.
 	Status SharedDataObjectStatus `json:"status,omitempty"`
+}
+
+// Whether to enable or disable sharing of data history. If not specified, the
+// default is **DISABLED**.
+type SharedDataObjectHistoryDataSharingStatus string
+
+const SharedDataObjectHistoryDataSharingStatusDisabled SharedDataObjectHistoryDataSharingStatus = `DISABLED`
+
+const SharedDataObjectHistoryDataSharingStatusEnabled SharedDataObjectHistoryDataSharingStatus = `ENABLED`
+
+// String representation for [fmt.Print]
+func (f *SharedDataObjectHistoryDataSharingStatus) String() string {
+	return string(*f)
+}
+
+// Set raw string value and validate it against allowed values
+func (f *SharedDataObjectHistoryDataSharingStatus) Set(v string) error {
+	switch v {
+	case `DISABLED`, `ENABLED`:
+		*f = SharedDataObjectHistoryDataSharingStatus(v)
+		return nil
+	default:
+		return fmt.Errorf(`value "%s" is not one of "DISABLED", "ENABLED"`, v)
+	}
+}
+
+// Type always returns SharedDataObjectHistoryDataSharingStatus to satisfy [pflag.Value] interface
+func (f *SharedDataObjectHistoryDataSharingStatus) Type() string {
+	return "SharedDataObjectHistoryDataSharingStatus"
 }
 
 // One of: **ACTIVE**, **PERMISSION_DENIED**.

--- a/workspace_client.go
+++ b/workspace_client.go
@@ -456,15 +456,16 @@ type WorkspaceClient struct {
 	// serving endpoints.
 	//
 	// You can use a serving endpoint to serve models from the Databricks Model
-	// Registry. Endpoints expose the underlying models as scalable REST API
-	// endpoints using serverless compute. This means the endpoints and
-	// associated compute resources are fully managed by Databricks and will not
-	// appear in your cloud account. A serving endpoint can consist of one or
-	// more MLflow models from the Databricks Model Registry, called served
-	// models. A serving endpoint can have at most ten served models. You can
-	// configure traffic settings to define how requests should be routed to
-	// your served models behind an endpoint. Additionally, you can configure
-	// the scale of resources that should be applied to each served model.
+	// Registry or from Unity Catalog. Endpoints expose the underlying models as
+	// scalable REST API endpoints using serverless compute. This means the
+	// endpoints and associated compute resources are fully managed by
+	// Databricks and will not appear in your cloud account. A serving endpoint
+	// can consist of one or more MLflow models from the Databricks Model
+	// Registry, called served models. A serving endpoint can have at most ten
+	// served models. You can configure traffic settings to define how requests
+	// should be routed to your served models behind an endpoint. Additionally,
+	// you can configure the scale of resources that should be applied to each
+	// served model.
 	ServingEndpoints *serving.ServingEndpointsAPI
 
 	// Databricks Shares REST API


### PR DESCRIPTION
## Changes
Regenerates the OpenAPI Spec at commit c411c04c62262f1bdacc047356f1d2030f41e660.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [x] terraform provider unit tests pass with the new SDK
- [ ] relevant integration tests applied

