### PR TITLE
Parse Camel Case and Pascal Case Enum Values

### DIFF
--- a/openapi/code/named.go
+++ b/openapi/code/named.go
@@ -99,13 +99,42 @@ func (n *Named) splitASCII() (w []string) {
 	return SplitASCII(n.Name)
 }
 
+// Return the value of cond evaluated at the nearest letter to index i in name.
+// dir determines the direction of search: if true, search forwards, if false,
+// search backwards.
+func search(name string, cond func(rune) bool, dir bool, i int) bool {
+	nameLen := len(name)
+	incr := 1
+	if !dir {
+		incr = -1
+	}
+	for j := i; j >= 0 && j < nameLen; j += incr {
+		if unicode.IsLetter(rune(name[j])) {
+			return cond(rune(name[j]))
+		}
+	}
+	return false
+}
+
+// Return the value of cond evaluated on the rune at index i in name. If that
+// rune is not a letter, search in both directions for the nearest letter and
+// return the result of cond on those letters.
+func checkCondAtNearestLetters(name string, cond func(rune) bool, i int) bool {
+	r := rune(name[i])
+
+	if unicode.IsLetter(r) {
+		return cond(r)
+	}
+	return search(name, cond, true, i) && search(name, cond, false, i)
+}
+
 // emulate positive lookaheads from JVM regex:
 // (?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|([-_\s])
 // and convert all words to lower case
 func SplitASCII(name string) (w []string) {
 	var current []rune
 	nameLen := len(name)
-	var last, this, next, lookahead bool
+	var isPrevUpper, isCurrentUpper, isNextLower, isNextUpper, isNotLastChar bool
 	// we do assume here that all named entities are strictly ASCII
 	for i := 0; i < nameLen; i++ {
 		r := rune(name[i])
@@ -113,27 +142,33 @@ func SplitASCII(name string) (w []string) {
 			// we're naming language literals, $ is usually not allowed
 			continue
 		}
-		this = unicode.IsUpper(r)
+		// if the current rune is a digit, check the neighboring runes to
+		// determine whether to treat this one as upper-case.
+		isCurrentUpper = checkCondAtNearestLetters(name, unicode.IsUpper, i)
 		r = unicode.ToLower(r)
-		next = false
-		lookahead = i+1 < nameLen
-		if lookahead {
-			next = unicode.IsUpper(rune(name[i+1]))
+		isNextLower = false
+		isNextUpper = false
+		isNotLastChar = i+1 < nameLen
+		if isNotLastChar {
+			isNextLower = checkCondAtNearestLetters(name, unicode.IsLower, i)
+			isNextUpper = checkCondAtNearestLetters(name, unicode.IsUpper, i)
 		}
 		split, before, after := false, false, true
-		if last && this && !next && lookahead {
+		// At the end of a string of capital letters (e.g. HTML[P]arser).
+		if isPrevUpper && isCurrentUpper && isNextLower && isNotLastChar {
 			// (?<=[A-Z])(?=[A-Z][a-z])
 			split = true
 			before = false
 			after = true
 		}
-		if !this && next {
+		// At the end of a camel- or pascal-case word (e.g. htm[l]Parser).
+		if !isCurrentUpper && isNextUpper {
 			// (?<=[a-z])(?=[A-Z])
 			split = true
 			before = true
 			after = false
 		}
-		if r == '-' || r == '_' || r == ' ' {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) {
 			// ([-_\s])
 			split = true
 			before = false
@@ -149,7 +184,7 @@ func SplitASCII(name string) (w []string) {
 		if after {
 			current = append(current, r)
 		}
-		last = this
+		isPrevUpper = isCurrentUpper
 	}
 	if len(current) > 0 {
 		w = append(w, string(current))

--- a/openapi/code/named.go
+++ b/openapi/code/named.go
@@ -95,16 +95,20 @@ func (n *Named) Singular() *Named {
 	return n
 }
 
+func (n *Named) splitASCII() (w []string) {
+	return SplitASCII(n.Name)
+}
+
 // emulate positive lookaheads from JVM regex:
 // (?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|([-_\s])
 // and convert all words to lower case
-func (n *Named) splitASCII() (w []string) {
+func SplitASCII(name string) (w []string) {
 	var current []rune
-	nameLen := len(n.Name)
+	nameLen := len(name)
 	var last, this, next, lookahead bool
 	// we do assume here that all named entities are strictly ASCII
 	for i := 0; i < nameLen; i++ {
-		r := rune(n.Name[i])
+		r := rune(name[i])
 		if r == '$' {
 			// we're naming language literals, $ is usually not allowed
 			continue
@@ -114,7 +118,7 @@ func (n *Named) splitASCII() (w []string) {
 		next = false
 		lookahead = i+1 < nameLen
 		if lookahead {
-			next = unicode.IsUpper(rune(n.Name[i+1]))
+			next = unicode.IsUpper(rune(name[i+1]))
 		}
 		split, before, after := false, false, true
 		if last && this && !next && lookahead {

--- a/openapi/code/named.go
+++ b/openapi/code/named.go
@@ -150,8 +150,8 @@ func SplitASCII(name string) (w []string) {
 		isNextUpper = false
 		isNotLastChar = i+1 < nameLen
 		if isNotLastChar {
-			isNextLower = checkCondAtNearestLetters(name, unicode.IsLower, i)
-			isNextUpper = checkCondAtNearestLetters(name, unicode.IsUpper, i)
+			isNextLower = checkCondAtNearestLetters(name, unicode.IsLower, i+1)
+			isNextUpper = checkCondAtNearestLetters(name, unicode.IsUpper, i+1)
 		}
 		split, before, after := false, false, true
 		// At the end of a string of capital letters (e.g. HTML[P]arser).

--- a/openapi/code/named_test.go
+++ b/openapi/code/named_test.go
@@ -102,8 +102,12 @@ func TestNamedDecamel(t *testing.T) {
 		"HTMLParser":    {"html", "parser"},
 		"BigO":          {"big", "o"},
 		"OCaml":         {"o", "caml"},
+		"K8S_FAILURE":   {"k8s", "failure"},
+		"k8sFailure":    {"k8s", "failure"},
+		"i18nFailure":   {"i18n", "failure"},
+		"Patch:Request": {"patch", "request"},
 	} {
-		assert.Equal(t, out, (&Named{Name: in}).splitASCII())
+		assert.Equal(t, out, (&Named{Name: in}).splitASCII(), in)
 	}
 }
 

--- a/openapi/code/named_test.go
+++ b/openapi/code/named_test.go
@@ -106,6 +106,7 @@ func TestNamedDecamel(t *testing.T) {
 		"k8sFailure":    {"k8s", "failure"},
 		"i18nFailure":   {"i18n", "failure"},
 		"Patch:Request": {"patch", "request"},
+		"urn:ietf:params:scim:api:messages:2.0:PatchOp": {"urn", "ietf", "params", "scim", "api", "messages", "2", "0", "patch", "op"},
 	} {
 		assert.Equal(t, out, (&Named{Name: in}).splitASCII(), in)
 	}

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -208,18 +208,14 @@ func (pkg *Package) makeObject(e *Entity, s *openapi.Schema, path []string) *Ent
 	return e
 }
 
-var nonAlphanum = regexp.MustCompile(`[^a-zA-Z]`)
 var whitespace = regexp.MustCompile(`\s+`)
 
 func (pkg *Package) makeEnum(e *Entity, s *openapi.Schema, path []string) *Entity {
 	for idx, content := range s.Enum {
 		name := content
-		name = nonAlphanum.ReplaceAllString(name, " ")
 		var splits []string
-		for _, v := range whitespace.Split(name, -1) {
-			for _, v2 := range SplitASCII(v) {
-				splits = append(splits, strings.Title(strings.ToLower(v2)))
-			}
+		for _, v := range SplitASCII(name) {
+			splits = append(splits, strings.Title(strings.ToLower(v)))
 		}
 		name = strings.Join(splits, "")
 		if len(s.AliasEnum) == len(s.Enum) {

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -217,7 +217,9 @@ func (pkg *Package) makeEnum(e *Entity, s *openapi.Schema, path []string) *Entit
 		name = nonAlphanum.ReplaceAllString(name, " ")
 		var splits []string
 		for _, v := range whitespace.Split(name, -1) {
-			splits = append(splits, strings.Title(strings.ToLower(v)))
+			for _, v2 := range SplitASCII(v) {
+				splits = append(splits, strings.Title(strings.ToLower(v2)))
+			}
 		}
 		name = strings.Join(splits, "")
 		if len(s.AliasEnum) == len(s.Enum) {

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -213,11 +213,6 @@ var whitespace = regexp.MustCompile(`\s+`)
 func (pkg *Package) makeEnum(e *Entity, s *openapi.Schema, path []string) *Entity {
 	for idx, content := range s.Enum {
 		name := content
-		var splits []string
-		for _, v := range SplitASCII(name) {
-			splits = append(splits, strings.Title(strings.ToLower(v)))
-		}
-		name = strings.Join(splits, "")
 		if len(s.AliasEnum) == len(s.Enum) {
 			name = s.AliasEnum[idx]
 		}

--- a/service/compute/model.go
+++ b/service/compute/model.go
@@ -249,9 +249,9 @@ type CloudProviderNodeInfo struct {
 
 type CloudProviderNodeStatus string
 
-const CloudProviderNodeStatusNotavailableinregion CloudProviderNodeStatus = `NotAvailableInRegion`
+const CloudProviderNodeStatusNotAvailableInRegion CloudProviderNodeStatus = `NotAvailableInRegion`
 
-const CloudProviderNodeStatusNotenabledonsubscription CloudProviderNodeStatus = `NotEnabledOnSubscription`
+const CloudProviderNodeStatusNotEnabledOnSubscription CloudProviderNodeStatus = `NotEnabledOnSubscription`
 
 // String representation for [fmt.Print]
 func (f *CloudProviderNodeStatus) String() string {

--- a/service/compute/model.go
+++ b/service/compute/model.go
@@ -3290,9 +3290,9 @@ const TerminationReasonCodeIpExhaustionFailure TerminationReasonCode = `IP_EXHAU
 
 const TerminationReasonCodeJobFinished TerminationReasonCode = `JOB_FINISHED`
 
-const TerminationReasonCodeKsAutoscalingFailure TerminationReasonCode = `K8S_AUTOSCALING_FAILURE`
+const TerminationReasonCodeK8sAutoscalingFailure TerminationReasonCode = `K8S_AUTOSCALING_FAILURE`
 
-const TerminationReasonCodeKsDbrClusterLaunchTimeout TerminationReasonCode = `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`
+const TerminationReasonCodeK8sDbrClusterLaunchTimeout TerminationReasonCode = `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`
 
 const TerminationReasonCodeMetastoreComponentUnhealthy TerminationReasonCode = `METASTORE_COMPONENT_UNHEALTHY`
 

--- a/service/compute/node_type.go
+++ b/service/compute/node_type.go
@@ -54,7 +54,7 @@ func (nt NodeType) shouldBeSkipped() bool {
 	}
 	for _, st := range nt.NodeInfo.Status {
 		switch st {
-		case CloudProviderNodeStatusNotavailableinregion, CloudProviderNodeStatusNotenabledonsubscription:
+		case CloudProviderNodeStatusNotAvailableInRegion, CloudProviderNodeStatusNotEnabledOnSubscription:
 			return true
 		}
 	}

--- a/service/compute/node_type_test.go
+++ b/service/compute/node_type_test.go
@@ -150,8 +150,8 @@ func TestNodeTypeCategoryNotAvailable(t *testing.T) {
 				},
 				NodeInfo: &CloudProviderNodeInfo{
 					Status: []CloudProviderNodeStatus{
-						CloudProviderNodeStatusNotavailableinregion,
-						CloudProviderNodeStatusNotenabledonsubscription},
+						CloudProviderNodeStatusNotAvailableInRegion,
+						CloudProviderNodeStatusNotEnabledOnSubscription},
 				},
 				Category: "Storage Optimized",
 			},

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -478,7 +478,7 @@ func (f *PatchOp) Type() string {
 
 type PatchSchema string
 
-const PatchSchemaUrnIetfParamsScimApiMessagesPatchOp PatchSchema = `urn:ietf:params:scim:api:messages:2.0:PatchOp`
+const PatchSchemaUrnIetfParamsScimApiMessages20PatchOp PatchSchema = `urn:ietf:params:scim:api:messages:2.0:PatchOp`
 
 // String representation for [fmt.Print]
 func (f *PatchSchema) String() string {
@@ -652,7 +652,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -478,7 +478,7 @@ func (f *PatchOp) Type() string {
 
 type PatchSchema string
 
-const PatchSchemaUrnIetfParamsScimApiMessagesPatchop PatchSchema = `urn:ietf:params:scim:api:messages:2.0:PatchOp`
+const PatchSchemaUrnIetfParamsScimApiMessagesPatchOp PatchSchema = `urn:ietf:params:scim:api:messages:2.0:PatchOp`
 
 // String representation for [fmt.Print]
 func (f *PatchSchema) String() string {
@@ -652,7 +652,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -466,21 +466,21 @@ type GetRunRequest struct {
 
 type GitProvider string
 
-const GitProviderAwscodecommit GitProvider = `awsCodeCommit`
+const GitProviderAwsCodeCommit GitProvider = `awsCodeCommit`
 
-const GitProviderAzuredevopsservices GitProvider = `azureDevOpsServices`
+const GitProviderAzureDevOpsServices GitProvider = `azureDevOpsServices`
 
-const GitProviderBitbucketcloud GitProvider = `bitbucketCloud`
+const GitProviderBitbucketCloud GitProvider = `bitbucketCloud`
 
-const GitProviderBitbucketserver GitProvider = `bitbucketServer`
+const GitProviderBitbucketServer GitProvider = `bitbucketServer`
 
-const GitProviderGithub GitProvider = `gitHub`
+const GitProviderGitHub GitProvider = `gitHub`
 
-const GitProviderGithubenterprise GitProvider = `gitHubEnterprise`
+const GitProviderGitHubEnterprise GitProvider = `gitHubEnterprise`
 
-const GitProviderGitlab GitProvider = `gitLab`
+const GitProviderGitLab GitProvider = `gitLab`
 
-const GitProviderGitlabenterpriseedition GitProvider = `gitLabEnterpriseEdition`
+const GitProviderGitLabEnterpriseEdition GitProvider = `gitLabEnterpriseEdition`
 
 // String representation for [fmt.Print]
 func (f *GitProvider) String() string {

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -58,7 +58,7 @@ func ExampleModelRegistryAPI_CreateComment_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
@@ -92,7 +92,7 @@ func ExampleModelRegistryAPI_CreateModel_models() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
+func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -58,23 +58,6 @@ func ExampleModelRegistryAPI_CreateComment_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
-	ctx := context.Background()
-	w, err := databricks.NewWorkspaceClient()
-	if err != nil {
-		panic(err)
-	}
-
-	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
-		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", model)
-
-}
-
 func ExampleModelRegistryAPI_CreateModel_models() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
@@ -92,7 +75,7 @@ func ExampleModelRegistryAPI_CreateModel_models() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
@@ -109,7 +92,7 @@ func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
@@ -123,15 +106,6 @@ func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", model)
-
-	created, err := w.ModelRegistry.CreateModelVersion(ctx, ml.CreateModelVersionRequest{
-		Name:   model.RegisteredModel.Name,
-		Source: "dbfs:/tmp",
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", created)
 
 }
 
@@ -158,6 +132,32 @@ func ExampleModelRegistryAPI_CreateModelVersion_modelVersionComments() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", mv)
+
+}
+
+func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", model)
+
+	created, err := w.ModelRegistry.CreateModelVersion(ctx, ml.CreateModelVersionRequest{
+		Name:   model.RegisteredModel.Name,
+		Source: "dbfs:/tmp",
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
 
 }
 

--- a/service/provisioning/model.go
+++ b/service/provisioning/model.go
@@ -310,9 +310,9 @@ type ErrorType string
 
 const ErrorTypeCredentials ErrorType = `credentials`
 
-const ErrorTypeNetworkacl ErrorType = `networkAcl`
+const ErrorTypeNetworkAcl ErrorType = `networkAcl`
 
-const ErrorTypeSecuritygroup ErrorType = `securityGroup`
+const ErrorTypeSecurityGroup ErrorType = `securityGroup`
 
 const ErrorTypeSubnet ErrorType = `subnet`
 
@@ -873,7 +873,7 @@ func (f *VpcStatus) Type() string {
 // The AWS resource associated with this warning: a subnet or a security group.
 type WarningType string
 
-const WarningTypeSecuritygroup WarningType = `securityGroup`
+const WarningTypeSecurityGroup WarningType = `securityGroup`
 
 const WarningTypeSubnet WarningType = `subnet`
 

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -158,6 +158,7 @@ type ChannelInfo struct {
 	Name ChannelName `json:"name,omitempty"`
 }
 
+// Name of the channel
 type ChannelName string
 
 const ChannelNameChannelNameCurrent ChannelName = `CHANNEL_NAME_CURRENT`
@@ -2475,9 +2476,9 @@ const TerminationReasonCodeIpExhaustionFailure TerminationReasonCode = `IP_EXHAU
 
 const TerminationReasonCodeJobFinished TerminationReasonCode = `JOB_FINISHED`
 
-const TerminationReasonCodeKsAutoscalingFailure TerminationReasonCode = `K8S_AUTOSCALING_FAILURE`
+const TerminationReasonCodeK8sAutoscalingFailure TerminationReasonCode = `K8S_AUTOSCALING_FAILURE`
 
-const TerminationReasonCodeKsDbrClusterLaunchTimeout TerminationReasonCode = `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`
+const TerminationReasonCodeK8sDbrClusterLaunchTimeout TerminationReasonCode = `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`
 
 const TerminationReasonCodeMetastoreComponentUnhealthy TerminationReasonCode = `METASTORE_COMPONENT_UNHEALTHY`
 


### PR DESCRIPTION
## Changes
Currently, enum values that use camelCase or PascalCase are not split into separate words during the parse phase of the OpenAPI spec. As a result, `PascalCase()` returns `Camelcase` or `Pascalcase`, respectively. To fix this, I've modified SplitASCII to support parsing more forms (snake-case and constant-case), to split words based on all non-alphanumeric symbols, and to estimate the "case" of a number by looking at the neighboring letters.

## Tests
- [x] Added several cases to SplitASCII unit tests.
- [x] Regenerated the Go, Python, and Java SDKs with this change, and the results are positive. https://github.com/databricks/databricks-sdk-py/pull/229 and https://github.com/databricks/databricks-sdk-java/pull/115

