### PR TITLE
Fix names of keyword arguments in examples

### DIFF
--- a/openapi/roll/ast.go
+++ b/openapi/roll/ast.go
@@ -220,7 +220,7 @@ func (c *call) IsWait() bool {
 func (c *call) Request() (fv []*fieldValue) {
 	if strings.Contains(c.Name, "By") {
 		fields := strings.Split(strings.Split(c.Name, "By")[0], "And")
-		for i, name := range fields {
+		for i, name := range fields[1:] {
 			fv = append(fv, &fieldValue{
 				Named: code.Named{
 					Name: name,

--- a/openapi/roll/ast.go
+++ b/openapi/roll/ast.go
@@ -219,8 +219,12 @@ func (c *call) IsWait() bool {
 
 func (c *call) Request() (fv []*fieldValue) {
 	if strings.Contains(c.Name, "By") {
-		fields := strings.Split(strings.Split(c.Name, "By")[0], "And")
-		for i, name := range fields[1:] {
+		// E.g. DeleteByJobId, DeleteByClusterIdAndWait
+		firstSplit := strings.SplitN(c.Name, "By", 2)
+		// And is used to separate field names, but some methods end with AndWait
+		joinedFields := strings.TrimSuffix(firstSplit[1], "AndWait")
+		fields := strings.Split(joinedFields, "And")
+		for i, name := range fields {
 			fv = append(fv, &fieldValue{
 				Named: code.Named{
 					Name: name,


### PR DESCRIPTION
## Changes
When generating the names of the arguments to use in methods named XByYAndZ (e.g. DeleteByJobId), the field names are derived from the name of the method. The logic for this was incorrect. This doesn't affect Go, since Go examples don't use the `.Request()` method on `call` but instead read from the call name and args directly.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

