### PR TITLE
Add ability to generate flat names

### DIFF
--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -348,7 +348,7 @@ func (m *Method) AsFlat() *Named {
 		"Libraries":       "ClusterLibraries",
 		"PolicyFamilies":  "ClusterPolicyFamilies",
 		"Workspace":       "Notebooks", // or WorkspaceObjects
-		"OAuthEnrollment": "Oauth",
+		"OAuthEnrollment": "OauthEnrollment",
 		"CurrentUser":     "",
 	}
 	if replace, ok := remap[svc.PascalName()]; ok {

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -335,3 +335,64 @@ func (m *Method) IsPrivatePreview() bool {
 func (m *Method) IsPublicPreview() bool {
 	return isPublicPreview(&m.operation.Node)
 }
+
+func (m *Method) AsFlat() *Named {
+	if m.PascalName() == "CreateOboToken" {
+		return &m.Named
+	}
+	methodWords := m.Named.splitASCII()
+	svc := m.Service.Named
+
+	remap := map[string]string{
+		"ModelRegistry":   "Models",
+		"Libraries":       "ClusterLibraries",
+		"PolicyFamilies":  "ClusterPolicyFamilies",
+		"Workspace":       "Notebooks", // or WorkspaceObjects
+		"OAuthEnrollment": "Oauth",
+		"CurrentUser":     "",
+	}
+	if replace, ok := remap[svc.PascalName()]; ok {
+		svc = Named{
+			Name: replace,
+		}
+	}
+
+	serviceWords := svc.splitASCII()
+	serviceSingularWords := svc.Singular().splitASCII()
+
+	words := []string{}
+	if len(methodWords) == 1 && strings.ToLower(methodWords[0]) == "list" {
+		words = append(words, "list")
+		words = append(words, serviceWords...)
+	} else if methodWords[0] == "execute" {
+		words = append(words, methodWords[0])
+		// command_execution.execute -> execute-command-execution
+		words = append(words, serviceWords[0])
+	} else {
+		words = append(words, methodWords[0])
+		words = append(words, serviceSingularWords...)
+	}
+	words = append(words, methodWords[1:]...)
+	// warehouses.get_workspace_warehouse_config -> get-warehouse-workspace-config
+	seen := map[string]bool{}
+	tmp := []string{}
+	for _, w := range words {
+		if seen[w] {
+			continue
+		}
+		tmp = append(tmp, w)
+		seen[w] = true
+	}
+
+	return &Named{
+		Name: strings.Join(tmp, "_"),
+	}
+}
+
+func (m *Method) CmdletName() string {
+	words := m.AsFlat().splitASCII()
+	noun := &Named{
+		Name: strings.Join(words[1:], "_"),
+	}
+	return fmt.Sprintf("%s-Databricks%s", strings.Title(words[0]), noun.PascalName())
+}

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -389,10 +389,12 @@ func (m *Method) AsFlat() *Named {
 	}
 }
 
-func (m *Method) CmdletName() string {
+func (m *Method) CmdletName(prefix string) string {
 	words := m.AsFlat().splitASCII()
 	noun := &Named{
 		Name: strings.Join(words[1:], "_"),
 	}
-	return fmt.Sprintf("%s-Databricks%s", strings.Title(words[0]), noun.PascalName())
+	verb := strings.Title(words[0])
+	prefix = strings.Title(prefix)
+	return fmt.Sprintf("%s-%s%s", verb, prefix, noun.PascalName())
 }

--- a/openapi/code/method_test.go
+++ b/openapi/code/method_test.go
@@ -1,0 +1,71 @@
+package code
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlatNames(t *testing.T) {
+	for _, v := range []struct {
+		service, method, flat string
+	}{
+		{"secrets", "delete_acl", "delete_secret_acl"},
+		{"secrets", "list_scopes", "list_secret_scopes"},
+		{"workspace_conf", "get_status", "get_workspace_conf_status"},
+		{"statement_execution", "execute_statement", "execute_statement"},
+		{"statement_execution", "get_statement_result_chunk_n", "get_statement_execution_result_chunk_n"},
+
+		// TBD:
+		{"current_user", "me", "me"},
+		{"warehouses", "get_workspace_warehouse_config", "get_warehouse_workspace_config"},
+		{"libraries", "install", "install_cluster_library"},
+		{"policy_families", "get", "get_cluster_policy_family"},
+		{"workspace", "get_status", "get_notebook_status"},
+		{"model_registry", "create_comment", "create_model_comment"},
+		{"token_management", "create_obo_token", "create_obo_token"},
+	} {
+		m := &Method{
+			Named: Named{
+				Name: v.method,
+			},
+			Service: &Service{
+				Named: Named{
+					Name: v.service,
+				},
+			},
+		}
+		assert.Equal(t, v.flat, m.AsFlat().SnakeName())
+	}
+}
+
+func TestCmdletNames(t *testing.T) {
+	for _, v := range []struct {
+		service, method, cmdlet string
+	}{
+		{"secrets", "delete_acl", "Delete-DatabricksSecretAcl"},
+		{"secrets", "list_scopes", "List-DatabricksSecretScopes"},
+		{"workspace_conf", "get_status", "Get-DatabricksWorkspaceConfStatus"},
+
+		// TBD:
+		{"current_user", "me", "Me-Databricks"},
+		{"warehouses", "get_workspace_warehouse_config", "Get-DatabricksWarehouseWorkspaceConfig"},
+		{"libraries", "install", "Install-DatabricksClusterLibrary"},
+		{"policy_families", "get", "Get-DatabricksClusterPolicyFamily"},
+		{"workspace", "get_status", "Get-DatabricksNotebookStatus"},
+		{"model_registry", "create_comment", "Create-DatabricksModelComment"},
+		{"token_management", "create_obo_token", "Create-DatabricksOboToken"},
+	} {
+		m := &Method{
+			Named: Named{
+				Name: v.method,
+			},
+			Service: &Service{
+				Named: Named{
+					Name: v.service,
+				},
+			},
+		}
+		assert.Equal(t, v.cmdlet, m.CmdletName())
+	}
+}

--- a/openapi/code/method_test.go
+++ b/openapi/code/method_test.go
@@ -66,6 +66,6 @@ func TestCmdletNames(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, v.cmdlet, m.CmdletName())
+		assert.Equal(t, v.cmdlet, m.CmdletName("Databricks"))
 	}
 }


### PR DESCRIPTION
Adds extra naming schemes for generating other SDKs. Here's the table for all 3 types of names:

1. The normal method name appears in the workspace and account clients.
2. flattened name for R SDK, representing a function in a big namespace just for Databricks.
3. [cmdlet](https://learn.microsoft.com/en-us/powershell/module/az.keyvault/?view=azps-10.2.0)-like name, that represents a command it a global namespace, that contains not only Databricks.

Example of exceptions to general rules:

| `service`.`method` | flattened name | [cmdlet](https://learn.microsoft.com/en-us/powershell/module/az.keyvault/?view=azps-10.2.0) name |
| --- | --- | --- |
| model_registry.create_comment | create_model_comment | Create-DatabricksModelComment |
| model_registry.create_model | create_model | Create-DatabricksModel |
| model_registry.create_model_version | create_model_version | Create-DatabricksModelVersion |
| libraries.all_cluster_statuses | all_cluster_library_statuses | All-DatabricksClusterLibraryStatuses |
| libraries.cluster_status | cluster_library_status | Cluster-DatabricksLibraryStatus |
| libraries.install | install_cluster_library | Install-DatabricksClusterLibrary |
| libraries.uninstall | uninstall_cluster_library | Uninstall-DatabricksClusterLibrary |
| policy_families.get | get_cluster_policy_family | Get-DatabricksClusterPolicyFamily |
| policy_families.list | list_cluster_policy_families | List-DatabricksClusterPolicyFamilies |
| statement_execution.cancel_execution | cancel_statement_execution | Cancel-DatabricksStatementExecution |
| statement_execution.execute_statement | execute_statement | Execute-DatabricksStatement |
| statement_execution.get_statement | get_statement_execution | Get-DatabricksStatementExecution |
| warehouses.create | create_warehouse | Create-DatabricksWarehouse |
| warehouses.delete | delete_warehouse | Delete-DatabricksWarehouse |
| warehouses.edit | edit_warehouse | Edit-DatabricksWarehouse |
| warehouses.get | get_warehouse | Get-DatabricksWarehouse |
| warehouses.get_workspace_warehouse_config | get_warehouse_workspace_config | Get-DatabricksWarehouseWorkspaceConfig |
| workspace.delete | delete_notebook | Delete-DatabricksNotebook |
| workspace.export | export_notebook | Export-DatabricksNotebook |
| workspace.get_status | get_notebook_status | Get-DatabricksNotebookStatus |
| workspace.import | import_notebook | Import-DatabricksNotebook |
| workspace.list | list_notebooks | List-DatabricksNotebooks |
| workspace.mkdirs | mkdirs_notebook | Mkdirs-DatabricksNotebook |

Entire namespace:

| `service`.`method` | flattened name | [cmdlet](https://learn.microsoft.com/en-us/powershell/module/az.keyvault/?view=azps-10.2.0) name |
| --- | --- | --- |
| billable_usage.download | download_billable_usage | Download-DatabricksBillableUsage |
| budgets.create | create_budget | Create-DatabricksBudget |
| budgets.delete | delete_budget | Delete-DatabricksBudget |
| budgets.get | get_budget | Get-DatabricksBudget |
| budgets.list | list_budgets | List-DatabricksBudgets |
| budgets.update | update_budget | Update-DatabricksBudget |
| log_delivery.create | create_log_delivery | Create-DatabricksLogDelivery |
| log_delivery.get | get_log_delivery | Get-DatabricksLogDelivery |
| log_delivery.list | list_log_delivery | List-DatabricksLogDelivery |
| log_delivery.patch_status | patch_log_delivery_status | Patch-DatabricksLogDeliveryStatus |
| account_metastore_assignments.create | create_account_metastore_assignment | Create-DatabricksAccountMetastoreAssignment |
| account_metastore_assignments.delete | delete_account_metastore_assignment | Delete-DatabricksAccountMetastoreAssignment |
| account_metastore_assignments.get | get_account_metastore_assignment | Get-DatabricksAccountMetastoreAssignment |
| account_metastore_assignments.list | list_account_metastore_assignments | List-DatabricksAccountMetastoreAssignments |
| account_metastore_assignments.update | update_account_metastore_assignment | Update-DatabricksAccountMetastoreAssignment |
| account_metastores.create | create_account_metastore | Create-DatabricksAccountMetastore |
| account_metastores.delete | delete_account_metastore | Delete-DatabricksAccountMetastore |
| account_metastores.get | get_account_metastore | Get-DatabricksAccountMetastore |
| account_metastores.list | list_account_metastores | List-DatabricksAccountMetastores |
| account_metastores.update | update_account_metastore | Update-DatabricksAccountMetastore |
| account_storage_credentials.create | create_account_storage_credential | Create-DatabricksAccountStorageCredential |
| account_storage_credentials.delete | delete_account_storage_credential | Delete-DatabricksAccountStorageCredential |
| account_storage_credentials.get | get_account_storage_credential | Get-DatabricksAccountStorageCredential |
| account_storage_credentials.list | list_account_storage_credentials | List-DatabricksAccountStorageCredentials |
| account_storage_credentials.update | update_account_storage_credential | Update-DatabricksAccountStorageCredential |
| catalogs.create | create_catalog | Create-DatabricksCatalog |
| catalogs.delete | delete_catalog | Delete-DatabricksCatalog |
| catalogs.get | get_catalog | Get-DatabricksCatalog |
| catalogs.list | list_catalogs | List-DatabricksCatalogs |
| catalogs.update | update_catalog | Update-DatabricksCatalog |
| connections.create | create_connection | Create-DatabricksConnection |
| connections.delete | delete_connection | Delete-DatabricksConnection |
| connections.get | get_connection | Get-DatabricksConnection |
| connections.list | list_connections | List-DatabricksConnections |
| connections.update | update_connection | Update-DatabricksConnection |
| external_locations.create | create_external_location | Create-DatabricksExternalLocation |
| external_locations.delete | delete_external_location | Delete-DatabricksExternalLocation |
| external_locations.get | get_external_location | Get-DatabricksExternalLocation |
| external_locations.list | list_external_locations | List-DatabricksExternalLocations |
| external_locations.update | update_external_location | Update-DatabricksExternalLocation |
| functions.create | create_function | Create-DatabricksFunction |
| functions.delete | delete_function | Delete-DatabricksFunction |
| functions.get | get_function | Get-DatabricksFunction |
| functions.list | list_functions | List-DatabricksFunctions |
| functions.update | update_function | Update-DatabricksFunction |
| grants.get | get_grant | Get-DatabricksGrant |
| grants.get_effective | get_grant_effective | Get-DatabricksGrantEffective |
| grants.update | update_grant | Update-DatabricksGrant |
| metastores.assign | assign_metastore | Assign-DatabricksMetastore |
| metastores.create | create_metastore | Create-DatabricksMetastore |
| metastores.current | current_metastore | Current-DatabricksMetastore |
| metastores.delete | delete_metastore | Delete-DatabricksMetastore |
| metastores.get | get_metastore | Get-DatabricksMetastore |
| metastores.list | list_metastores | List-DatabricksMetastores |
| metastores.maintenance | maintenance_metastore | Maintenance-DatabricksMetastore |
| metastores.summary | summary_metastore | Summary-DatabricksMetastore |
| metastores.unassign | unassign_metastore | Unassign-DatabricksMetastore |
| metastores.update | update_metastore | Update-DatabricksMetastore |
| metastores.update_assignment | update_metastore_assignment | Update-DatabricksMetastoreAssignment |
| schemas.create | create_schema | Create-DatabricksSchema |
| schemas.delete | delete_schema | Delete-DatabricksSchema |
| schemas.get | get_schema | Get-DatabricksSchema |
| schemas.list | list_schemas | List-DatabricksSchemas |
| schemas.update | update_schema | Update-DatabricksSchema |
| storage_credentials.create | create_storage_credential | Create-DatabricksStorageCredential |
| storage_credentials.delete | delete_storage_credential | Delete-DatabricksStorageCredential |
| storage_credentials.get | get_storage_credential | Get-DatabricksStorageCredential |
| storage_credentials.list | list_storage_credentials | List-DatabricksStorageCredentials |
| storage_credentials.update | update_storage_credential | Update-DatabricksStorageCredential |
| storage_credentials.validate | validate_storage_credential | Validate-DatabricksStorageCredential |
| system_schemas.disable | disable_system_schema | Disable-DatabricksSystemSchema |
| system_schemas.enable | enable_system_schema | Enable-DatabricksSystemSchema |
| system_schemas.list | list_system_schemas | List-DatabricksSystemSchemas |
| table_constraints.create | create_table_constraint | Create-DatabricksTableConstraint |
| table_constraints.delete | delete_table_constraint | Delete-DatabricksTableConstraint |
| tables.delete | delete_table | Delete-DatabricksTable |
| tables.get | get_table | Get-DatabricksTable |
| tables.list | list_tables | List-DatabricksTables |
| tables.list_summaries | list_table_summaries | List-DatabricksTableSummaries |
| volumes.create | create_volume | Create-DatabricksVolume |
| volumes.delete | delete_volume | Delete-DatabricksVolume |
| volumes.list | list_volumes | List-DatabricksVolumes |
| volumes.read | read_volume | Read-DatabricksVolume |
| volumes.update | update_volume | Update-DatabricksVolume |
| workspace_bindings.get | get_workspace_binding | Get-DatabricksWorkspaceBinding |
| workspace_bindings.update | update_workspace_binding | Update-DatabricksWorkspaceBinding |
| cluster_policies.create | create_cluster_policy | Create-DatabricksClusterPolicy |
| cluster_policies.delete | delete_cluster_policy | Delete-DatabricksClusterPolicy |
| cluster_policies.edit | edit_cluster_policy | Edit-DatabricksClusterPolicy |
| cluster_policies.get | get_cluster_policy | Get-DatabricksClusterPolicy |
| cluster_policies.list | list_cluster_policies | List-DatabricksClusterPolicies |
| clusters.change_owner | change_cluster_owner | Change-DatabricksClusterOwner |
| clusters.create | create_cluster | Create-DatabricksCluster |
| clusters.delete | delete_cluster | Delete-DatabricksCluster |
| clusters.edit | edit_cluster | Edit-DatabricksCluster |
| clusters.events | events_cluster | Events-DatabricksCluster |
| clusters.get | get_cluster | Get-DatabricksCluster |
| clusters.list | list_clusters | List-DatabricksClusters |
| clusters.list_node_types | list_cluster_node_types | List-DatabricksClusterNodeTypes |
| clusters.list_zones | list_cluster_zones | List-DatabricksClusterZones |
| clusters.permanent_delete | permanent_cluster_delete | Permanent-DatabricksClusterDelete |
| clusters.pin | pin_cluster | Pin-DatabricksCluster |
| clusters.resize | resize_cluster | Resize-DatabricksCluster |
| clusters.restart | restart_cluster | Restart-DatabricksCluster |
| clusters.spark_versions | spark_cluster_versions | Spark-DatabricksClusterVersions |
| clusters.start | start_cluster | Start-DatabricksCluster |
| clusters.unpin | unpin_cluster | Unpin-DatabricksCluster |
| command_execution.cancel | cancel_command_execution | Cancel-DatabricksCommandExecution |
| command_execution.command_status | command_execution_status | Command-DatabricksExecutionStatus |
| command_execution.context_status | context_command_execution_status | Context-DatabricksCommandExecutionStatus |
| command_execution.create | create_command_execution | Create-DatabricksCommandExecution |
| command_execution.destroy | destroy_command_execution | Destroy-DatabricksCommandExecution |
| command_execution.execute | execute_command | Execute-DatabricksCommand |
| global_init_scripts.create | create_global_init_script | Create-DatabricksGlobalInitScript |
| global_init_scripts.delete | delete_global_init_script | Delete-DatabricksGlobalInitScript |
| global_init_scripts.get | get_global_init_script | Get-DatabricksGlobalInitScript |
| global_init_scripts.list | list_global_init_scripts | List-DatabricksGlobalInitScripts |
| global_init_scripts.update | update_global_init_script | Update-DatabricksGlobalInitScript |
| instance_pools.create | create_instance_pool | Create-DatabricksInstancePool |
| instance_pools.delete | delete_instance_pool | Delete-DatabricksInstancePool |
| instance_pools.edit | edit_instance_pool | Edit-DatabricksInstancePool |
| instance_pools.get | get_instance_pool | Get-DatabricksInstancePool |
| instance_pools.list | list_instance_pools | List-DatabricksInstancePools |
| instance_profiles.add | add_instance_profile | Add-DatabricksInstanceProfile |
| instance_profiles.edit | edit_instance_profile | Edit-DatabricksInstanceProfile |
| instance_profiles.list | list_instance_profiles | List-DatabricksInstanceProfiles |
| instance_profiles.remove | remove_instance_profile | Remove-DatabricksInstanceProfile |
| libraries.all_cluster_statuses | all_cluster_library_statuses | All-DatabricksClusterLibraryStatuses |
| libraries.cluster_status | cluster_library_status | Cluster-DatabricksLibraryStatus |
| libraries.install | install_cluster_library | Install-DatabricksClusterLibrary |
| libraries.uninstall | uninstall_cluster_library | Uninstall-DatabricksClusterLibrary |
| policy_families.get | get_cluster_policy_family | Get-DatabricksClusterPolicyFamily |
| policy_families.list | list_cluster_policy_families | List-DatabricksClusterPolicyFamilies |
| dbfs.add_block | add_dbfs_block | Add-DatabricksDbfsBlock |
| dbfs.close | close_dbfs | Close-DatabricksDbfs |
| dbfs.create | create_dbfs | Create-DatabricksDbfs |
| dbfs.delete | delete_dbfs | Delete-DatabricksDbfs |
| dbfs.get_status | get_dbfs_status | Get-DatabricksDbfsStatus |
| dbfs.list | list_dbfs | List-DatabricksDbfs |
| dbfs.mkdirs | mkdirs_dbfs | Mkdirs-DatabricksDbfs |
| dbfs.move | move_dbfs | Move-DatabricksDbfs |
| dbfs.put | put_dbfs | Put-DatabricksDbfs |
| dbfs.read | read_dbfs | Read-DatabricksDbfs |
| account_access_control.get_assignable_roles_for_resource | get_account_access_control_assignable_roles_for_resource | Get-DatabricksAccountAccessControlAssignableRolesForResource |
| account_access_control.get_rule_set | get_account_access_control_rule_set | Get-DatabricksAccountAccessControlRuleSet |
| account_access_control.update_rule_set | update_account_access_control_rule_set | Update-DatabricksAccountAccessControlRuleSet |
| account_access_control_proxy.get_assignable_roles_for_resource | get_account_access_control_proxy_assignable_roles_for_resource | Get-DatabricksAccountAccessControlProxyAssignableRolesForResource |
| account_access_control_proxy.get_rule_set | get_account_access_control_proxy_rule_set | Get-DatabricksAccountAccessControlProxyRuleSet |
| account_access_control_proxy.update_rule_set | update_account_access_control_proxy_rule_set | Update-DatabricksAccountAccessControlProxyRuleSet |
| account_groups.create | create_account_group | Create-DatabricksAccountGroup |
| account_groups.delete | delete_account_group | Delete-DatabricksAccountGroup |
| account_groups.get | get_account_group | Get-DatabricksAccountGroup |
| account_groups.list | list_account_groups | List-DatabricksAccountGroups |
| account_groups.patch | patch_account_group | Patch-DatabricksAccountGroup |
| account_groups.update | update_account_group | Update-DatabricksAccountGroup |
| account_service_principals.create | create_account_service_principal | Create-DatabricksAccountServicePrincipal |
| account_service_principals.delete | delete_account_service_principal | Delete-DatabricksAccountServicePrincipal |
| account_service_principals.get | get_account_service_principal | Get-DatabricksAccountServicePrincipal |
| account_service_principals.list | list_account_service_principals | List-DatabricksAccountServicePrincipals |
| account_service_principals.patch | patch_account_service_principal | Patch-DatabricksAccountServicePrincipal |
| account_service_principals.update | update_account_service_principal | Update-DatabricksAccountServicePrincipal |
| account_users.create | create_account_user | Create-DatabricksAccountUser |
| account_users.delete | delete_account_user | Delete-DatabricksAccountUser |
| account_users.get | get_account_user | Get-DatabricksAccountUser |
| account_users.list | list_account_users | List-DatabricksAccountUsers |
| account_users.patch | patch_account_user | Patch-DatabricksAccountUser |
| account_users.update | update_account_user | Update-DatabricksAccountUser |
| current_user.me | me | Me-Databricks |
| groups.create | create_group | Create-DatabricksGroup |
| groups.delete | delete_group | Delete-DatabricksGroup |
| groups.get | get_group | Get-DatabricksGroup |
| groups.list | list_groups | List-DatabricksGroups |
| groups.patch | patch_group | Patch-DatabricksGroup |
| groups.update | update_group | Update-DatabricksGroup |
| permissions.get | get_permission | Get-DatabricksPermission |
| permissions.get_permission_levels | get_permission_levels | Get-DatabricksPermissionLevels |
| permissions.set | set_permission | Set-DatabricksPermission |
| permissions.update | update_permission | Update-DatabricksPermission |
| service_principals.create | create_service_principal | Create-DatabricksServicePrincipal |
| service_principals.delete | delete_service_principal | Delete-DatabricksServicePrincipal |
| service_principals.get | get_service_principal | Get-DatabricksServicePrincipal |
| service_principals.list | list_service_principals | List-DatabricksServicePrincipals |
| service_principals.patch | patch_service_principal | Patch-DatabricksServicePrincipal |
| service_principals.update | update_service_principal | Update-DatabricksServicePrincipal |
| users.create | create_user | Create-DatabricksUser |
| users.delete | delete_user | Delete-DatabricksUser |
| users.get | get_user | Get-DatabricksUser |
| users.list | list_users | List-DatabricksUsers |
| users.patch | patch_user | Patch-DatabricksUser |
| users.update | update_user | Update-DatabricksUser |
| workspace_assignment.delete | delete_workspace_assignment | Delete-DatabricksWorkspaceAssignment |
| workspace_assignment.get | get_workspace_assignment | Get-DatabricksWorkspaceAssignment |
| workspace_assignment.list | list_workspace_assignment | List-DatabricksWorkspaceAssignment |
| workspace_assignment.update | update_workspace_assignment | Update-DatabricksWorkspaceAssignment |
| jobs.cancel_all_runs | cancel_job_all_runs | Cancel-DatabricksJobAllRuns |
| jobs.cancel_run | cancel_job_run | Cancel-DatabricksJobRun |
| jobs.create | create_job | Create-DatabricksJob |
| jobs.delete | delete_job | Delete-DatabricksJob |
| jobs.delete_run | delete_job_run | Delete-DatabricksJobRun |
| jobs.export_run | export_job_run | Export-DatabricksJobRun |
| jobs.get | get_job | Get-DatabricksJob |
| jobs.get_run | get_job_run | Get-DatabricksJobRun |
| jobs.get_run_output | get_job_run_output | Get-DatabricksJobRunOutput |
| jobs.list | list_jobs | List-DatabricksJobs |
| jobs.list_runs | list_job_runs | List-DatabricksJobRuns |
| jobs.repair_run | repair_job_run | Repair-DatabricksJobRun |
| jobs.reset | reset_job | Reset-DatabricksJob |
| jobs.run_now | run_job_now | Run-DatabricksJobNow |
| jobs.submit | submit_job | Submit-DatabricksJob |
| jobs.update | update_job | Update-DatabricksJob |
| experiments.create_experiment | create_experiment | Create-DatabricksExperiment |
| experiments.create_run | create_experiment_run | Create-DatabricksExperimentRun |
| experiments.delete_experiment | delete_experiment | Delete-DatabricksExperiment |
| experiments.delete_run | delete_experiment_run | Delete-DatabricksExperimentRun |
| experiments.delete_tag | delete_experiment_tag | Delete-DatabricksExperimentTag |
| experiments.get_by_name | get_experiment_by_name | Get-DatabricksExperimentByName |
| experiments.get_experiment | get_experiment | Get-DatabricksExperiment |
| experiments.get_history | get_experiment_history | Get-DatabricksExperimentHistory |
| experiments.get_run | get_experiment_run | Get-DatabricksExperimentRun |
| experiments.list_artifacts | list_experiment_artifacts | List-DatabricksExperimentArtifacts |
| experiments.list_experiments | list_experiment_experiments | List-DatabricksExperimentExperiments |
| experiments.log_batch | log_experiment_batch | Log-DatabricksExperimentBatch |
| experiments.log_inputs | log_experiment_inputs | Log-DatabricksExperimentInputs |
| experiments.log_metric | log_experiment_metric | Log-DatabricksExperimentMetric |
| experiments.log_model | log_experiment_model | Log-DatabricksExperimentModel |
| experiments.log_param | log_experiment_param | Log-DatabricksExperimentParam |
| experiments.restore_experiment | restore_experiment | Restore-DatabricksExperiment |
| experiments.restore_run | restore_experiment_run | Restore-DatabricksExperimentRun |
| experiments.search_experiments | search_experiment_experiments | Search-DatabricksExperimentExperiments |
| experiments.search_runs | search_experiment_runs | Search-DatabricksExperimentRuns |
| experiments.set_experiment_tag | set_experiment_tag | Set-DatabricksExperimentTag |
| experiments.set_tag | set_experiment_tag | Set-DatabricksExperimentTag |
| experiments.update_experiment | update_experiment | Update-DatabricksExperiment |
| experiments.update_run | update_experiment_run | Update-DatabricksExperimentRun |
| model_registry.approve_transition_request | approve_model_transition_request | Approve-DatabricksModelTransitionRequest |
| model_registry.create_comment | create_model_comment | Create-DatabricksModelComment |
| model_registry.create_model | create_model | Create-DatabricksModel |
| model_registry.create_model_version | create_model_version | Create-DatabricksModelVersion |
| model_registry.create_transition_request | create_model_transition_request | Create-DatabricksModelTransitionRequest |
| model_registry.create_webhook | create_model_webhook | Create-DatabricksModelWebhook |
| model_registry.delete_comment | delete_model_comment | Delete-DatabricksModelComment |
| model_registry.delete_model | delete_model | Delete-DatabricksModel |
| model_registry.delete_model_tag | delete_model_tag | Delete-DatabricksModelTag |
| model_registry.delete_model_version | delete_model_version | Delete-DatabricksModelVersion |
| model_registry.delete_model_version_tag | delete_model_version_tag | Delete-DatabricksModelVersionTag |
| model_registry.delete_transition_request | delete_model_transition_request | Delete-DatabricksModelTransitionRequest |
| model_registry.delete_webhook | delete_model_webhook | Delete-DatabricksModelWebhook |
| model_registry.get_latest_versions | get_model_latest_versions | Get-DatabricksModelLatestVersions |
| model_registry.get_model | get_model | Get-DatabricksModel |
| model_registry.get_model_version | get_model_version | Get-DatabricksModelVersion |
| model_registry.get_model_version_download_uri | get_model_version_download_uri | Get-DatabricksModelVersionDownloadUri |
| model_registry.list_models | list_model_models | List-DatabricksModelModels |
| model_registry.list_transition_requests | list_model_transition_requests | List-DatabricksModelTransitionRequests |
| model_registry.list_webhooks | list_model_webhooks | List-DatabricksModelWebhooks |
| model_registry.reject_transition_request | reject_model_transition_request | Reject-DatabricksModelTransitionRequest |
| model_registry.rename_model | rename_model | Rename-DatabricksModel |
| model_registry.search_model_versions | search_model_versions | Search-DatabricksModelVersions |
| model_registry.search_models | search_model_models | Search-DatabricksModelModels |
| model_registry.set_model_tag | set_model_tag | Set-DatabricksModelTag |
| model_registry.set_model_version_tag | set_model_version_tag | Set-DatabricksModelVersionTag |
| model_registry.test_registry_webhook | test_model_registry_webhook | Test-DatabricksModelRegistryWebhook |
| model_registry.transition_stage | transition_model_stage | Transition-DatabricksModelStage |
| model_registry.update_comment | update_model_comment | Update-DatabricksModelComment |
| model_registry.update_model | update_model | Update-DatabricksModel |
| model_registry.update_model_version | update_model_version | Update-DatabricksModelVersion |
| model_registry.update_webhook | update_model_webhook | Update-DatabricksModelWebhook |
| custom_app_integration.create | create_custom_app_integration | Create-DatabricksCustomAppIntegration |
| custom_app_integration.delete | delete_custom_app_integration | Delete-DatabricksCustomAppIntegration |
| custom_app_integration.get | get_custom_app_integration | Get-DatabricksCustomAppIntegration |
| custom_app_integration.list | list_custom_app_integration | List-DatabricksCustomAppIntegration |
| custom_app_integration.update | update_custom_app_integration | Update-DatabricksCustomAppIntegration |
| o_auth_enrollment.create | create_oauth | Create-DatabricksOauth |
| o_auth_enrollment.get | get_oauth | Get-DatabricksOauth |
| published_app_integration.create | create_published_app_integration | Create-DatabricksPublishedAppIntegration |
| published_app_integration.delete | delete_published_app_integration | Delete-DatabricksPublishedAppIntegration |
| published_app_integration.get | get_published_app_integration | Get-DatabricksPublishedAppIntegration |
| published_app_integration.list | list_published_app_integration | List-DatabricksPublishedAppIntegration |
| published_app_integration.update | update_published_app_integration | Update-DatabricksPublishedAppIntegration |
| service_principal_secrets.create | create_service_principal_secret | Create-DatabricksServicePrincipalSecret |
| service_principal_secrets.delete | delete_service_principal_secret | Delete-DatabricksServicePrincipalSecret |
| service_principal_secrets.list | list_service_principal_secrets | List-DatabricksServicePrincipalSecrets |
| pipelines.create | create_pipeline | Create-DatabricksPipeline |
| pipelines.delete | delete_pipeline | Delete-DatabricksPipeline |
| pipelines.get | get_pipeline | Get-DatabricksPipeline |
| pipelines.get_update | get_pipeline_update | Get-DatabricksPipelineUpdate |
| pipelines.list_pipeline_events | list_pipeline_events | List-DatabricksPipelineEvents |
| pipelines.list_pipelines | list_pipeline_pipelines | List-DatabricksPipelinePipelines |
| pipelines.list_updates | list_pipeline_updates | List-DatabricksPipelineUpdates |
| pipelines.reset | reset_pipeline | Reset-DatabricksPipeline |
| pipelines.start_update | start_pipeline_update | Start-DatabricksPipelineUpdate |
| pipelines.stop | stop_pipeline | Stop-DatabricksPipeline |
| pipelines.update | update_pipeline | Update-DatabricksPipeline |
| credentials.create | create_credential | Create-DatabricksCredential |
| credentials.delete | delete_credential | Delete-DatabricksCredential |
| credentials.get | get_credential | Get-DatabricksCredential |
| credentials.list | list_credentials | List-DatabricksCredentials |
| encryption_keys.create | create_encryption_key | Create-DatabricksEncryptionKey |
| encryption_keys.delete | delete_encryption_key | Delete-DatabricksEncryptionKey |
| encryption_keys.get | get_encryption_key | Get-DatabricksEncryptionKey |
| encryption_keys.list | list_encryption_keys | List-DatabricksEncryptionKeys |
| networks.create | create_network | Create-DatabricksNetwork |
| networks.delete | delete_network | Delete-DatabricksNetwork |
| networks.get | get_network | Get-DatabricksNetwork |
| networks.list | list_networks | List-DatabricksNetworks |
| private_access.create | create_private_acces | Create-DatabricksPrivateAcces |
| private_access.delete | delete_private_acces | Delete-DatabricksPrivateAcces |
| private_access.create | create_private_acces | Create-DatabricksPrivateAcces |
| private_access.delete | delete_private_acces | Delete-DatabricksPrivateAcces |
| private_access.get | get_private_acces | Get-DatabricksPrivateAcces |
| private_access.list | list_private_access | List-DatabricksPrivateAccess |
| private_access.replace | replace_private_acces | Replace-DatabricksPrivateAcces |
| storage.create | create_storage | Create-DatabricksStorage |
| storage.delete | delete_storage | Delete-DatabricksStorage |
| storage.get | get_storage | Get-DatabricksStorage |
| storage.list | list_storage | List-DatabricksStorage |
| vpc_endpoints.create | create_vpc_endpoint | Create-DatabricksVpcEndpoint |
| vpc_endpoints.delete | delete_vpc_endpoint | Delete-DatabricksVpcEndpoint |
| vpc_endpoints.get | get_vpc_endpoint | Get-DatabricksVpcEndpoint |
| vpc_endpoints.list | list_vpc_endpoints | List-DatabricksVpcEndpoints |
| workspaces.create | create_workspace | Create-DatabricksWorkspace |
| workspaces.delete | delete_workspace | Delete-DatabricksWorkspace |
| workspaces.get | get_workspace | Get-DatabricksWorkspace |
| workspaces.list | list_workspaces | List-DatabricksWorkspaces |
| workspaces.update | update_workspace | Update-DatabricksWorkspace |
| serving_endpoints.build_logs | build_serving_endpoint_logs | Build-DatabricksServingEndpointLogs |
| serving_endpoints.create | create_serving_endpoint | Create-DatabricksServingEndpoint |
| serving_endpoints.delete | delete_serving_endpoint | Delete-DatabricksServingEndpoint |
| serving_endpoints.export_metrics | export_serving_endpoint_metrics | Export-DatabricksServingEndpointMetrics |
| serving_endpoints.get | get_serving_endpoint | Get-DatabricksServingEndpoint |
| serving_endpoints.list | list_serving_endpoints | List-DatabricksServingEndpoints |
| serving_endpoints.logs | logs_serving_endpoint | Logs-DatabricksServingEndpoint |
| serving_endpoints.query | query_serving_endpoint | Query-DatabricksServingEndpoint |
| serving_endpoints.update_config | update_serving_endpoint_config | Update-DatabricksServingEndpointConfig |
| account_ip_access_lists.create | create_account_ip_access_list | Create-DatabricksAccountIpAccessList |
| account_ip_access_lists.delete | delete_account_ip_access_list | Delete-DatabricksAccountIpAccessList |
| account_ip_access_lists.get | get_account_ip_access_list | Get-DatabricksAccountIpAccessList |
| account_ip_access_lists.list | list_account_ip_access_lists | List-DatabricksAccountIpAccessLists |
| account_ip_access_lists.replace | replace_account_ip_access_list | Replace-DatabricksAccountIpAccessList |
| account_ip_access_lists.update | update_account_ip_access_list | Update-DatabricksAccountIpAccessList |
| account_settings.read_personal_compute_setting | read_account_setting_personal_compute | Read-DatabricksAccountSettingPersonalCompute |
| ip_access_lists.create | create_ip_access_list | Create-DatabricksIpAccessList |
| ip_access_lists.delete | delete_ip_access_list | Delete-DatabricksIpAccessList |
| ip_access_lists.get | get_ip_access_list | Get-DatabricksIpAccessList |
| ip_access_lists.list | list_ip_access_lists | List-DatabricksIpAccessLists |
| ip_access_lists.replace | replace_ip_access_list | Replace-DatabricksIpAccessList |
| ip_access_lists.update | update_ip_access_list | Update-DatabricksIpAccessList |
| token_management.create_obo_token | create_obo_token | Create-DatabricksOboToken |
| token_management.delete | delete_token_management | Delete-DatabricksTokenManagement |
| token_management.get | get_token_management | Get-DatabricksTokenManagement |
| token_management.list | list_token_management | List-DatabricksTokenManagement |
| tokens.create | create_token | Create-DatabricksToken |
| tokens.delete | delete_token | Delete-DatabricksToken |
| tokens.list | list_tokens | List-DatabricksTokens |
| workspace_conf.get_status | get_workspace_conf_status | Get-DatabricksWorkspaceConfStatus |
| workspace_conf.set_status | set_workspace_conf_status | Set-DatabricksWorkspaceConfStatus |
| providers.create | create_provider | Create-DatabricksProvider |
| providers.delete | delete_provider | Delete-DatabricksProvider |
| providers.get | get_provider | Get-DatabricksProvider |
| providers.list | list_providers | List-DatabricksProviders |
| providers.list_shares | list_provider_shares | List-DatabricksProviderShares |
| providers.update | update_provider | Update-DatabricksProvider |
| recipient_activation.get_activation_url_info | get_recipient_activation_url_info | Get-DatabricksRecipientActivationUrlInfo |
| recipient_activation.retrieve_token | retrieve_recipient_activation_token | Retrieve-DatabricksRecipientActivationToken |
| recipients.create | create_recipient | Create-DatabricksRecipient |
| recipients.delete | delete_recipient | Delete-DatabricksRecipient |
| recipients.get | get_recipient | Get-DatabricksRecipient |
| recipients.list | list_recipients | List-DatabricksRecipients |
| recipients.rotate_token | rotate_recipient_token | Rotate-DatabricksRecipientToken |
| recipients.share_permissions | share_recipient_permissions | Share-DatabricksRecipientPermissions |
| recipients.update | update_recipient | Update-DatabricksRecipient |
| shares.create | create_share | Create-DatabricksShare |
| shares.delete | delete_share | Delete-DatabricksShare |
| shares.get | get_share | Get-DatabricksShare |
| shares.list | list_shares | List-DatabricksShares |
| shares.share_permissions | share_permissions | Share-DatabricksPermissions |
| shares.update | update_share | Update-DatabricksShare |
| shares.update_permissions | update_share_permissions | Update-DatabricksSharePermissions |
| alerts.create | create_alert | Create-DatabricksAlert |
| alerts.delete | delete_alert | Delete-DatabricksAlert |
| alerts.get | get_alert | Get-DatabricksAlert |
| alerts.list | list_alerts | List-DatabricksAlerts |
| alerts.update | update_alert | Update-DatabricksAlert |
| dashboards.create | create_dashboard | Create-DatabricksDashboard |
| dashboards.delete | delete_dashboard | Delete-DatabricksDashboard |
| dashboards.get | get_dashboard | Get-DatabricksDashboard |
| dashboards.list | list_dashboards | List-DatabricksDashboards |
| dashboards.restore | restore_dashboard | Restore-DatabricksDashboard |
| data_sources.list | list_data_sources | List-DatabricksDataSources |
| dbsql_permissions.get | get_dbsql_permission | Get-DatabricksDbsqlPermission |
| dbsql_permissions.set | set_dbsql_permission | Set-DatabricksDbsqlPermission |
| dbsql_permissions.transfer_ownership | transfer_dbsql_permission_ownership | Transfer-DatabricksDbsqlPermissionOwnership |
| queries.create | create_query | Create-DatabricksQuery |
| queries.delete | delete_query | Delete-DatabricksQuery |
| queries.get | get_query | Get-DatabricksQuery |
| queries.list | list_queries | List-DatabricksQueries |
| queries.restore | restore_query | Restore-DatabricksQuery |
| queries.update | update_query | Update-DatabricksQuery |
| query_history.list | list_query_history | List-DatabricksQueryHistory |
| statement_execution.cancel_execution | cancel_statement_execution | Cancel-DatabricksStatementExecution |
| statement_execution.execute_statement | execute_statement | Execute-DatabricksStatement |
| statement_execution.get_statement | get_statement_execution | Get-DatabricksStatementExecution |
| statement_execution.get_statement_result_chunk_n | get_statement_execution_result_chunk_n | Get-DatabricksStatementExecutionResultChunkN |
| warehouses.create | create_warehouse | Create-DatabricksWarehouse |
| warehouses.delete | delete_warehouse | Delete-DatabricksWarehouse |
| warehouses.edit | edit_warehouse | Edit-DatabricksWarehouse |
| warehouses.get | get_warehouse | Get-DatabricksWarehouse |
| warehouses.get_workspace_warehouse_config | get_warehouse_workspace_config | Get-DatabricksWarehouseWorkspaceConfig |
| warehouses.list | list_warehouses | List-DatabricksWarehouses |
| warehouses.set_workspace_warehouse_config | set_warehouse_workspace_config | Set-DatabricksWarehouseWorkspaceConfig |
| warehouses.start | start_warehouse | Start-DatabricksWarehouse |
| warehouses.stop | stop_warehouse | Stop-DatabricksWarehouse |
| git_credentials.create | create_git_credential | Create-DatabricksGitCredential |
| git_credentials.delete | delete_git_credential | Delete-DatabricksGitCredential |
| git_credentials.get | get_git_credential | Get-DatabricksGitCredential |
| git_credentials.list | list_git_credentials | List-DatabricksGitCredentials |
| git_credentials.update | update_git_credential | Update-DatabricksGitCredential |
| repos.create | create_repo | Create-DatabricksRepo |
| repos.delete | delete_repo | Delete-DatabricksRepo |
| repos.get | get_repo | Get-DatabricksRepo |
| repos.list | list_repos | List-DatabricksRepos |
| repos.update | update_repo | Update-DatabricksRepo |
| secrets.create_scope | create_secret_scope | Create-DatabricksSecretScope |
| secrets.delete_acl | delete_secret_acl | Delete-DatabricksSecretAcl |
| secrets.delete_scope | delete_secret_scope | Delete-DatabricksSecretScope |
| secrets.delete_secret | delete_secret | Delete-DatabricksSecret |
| secrets.get_acl | get_secret_acl | Get-DatabricksSecretAcl |
| secrets.list_acls | list_secret_acls | List-DatabricksSecretAcls |
| secrets.list_scopes | list_secret_scopes | List-DatabricksSecretScopes |
| secrets.list_secrets | list_secret_secrets | List-DatabricksSecretSecrets |
| secrets.put_acl | put_secret_acl | Put-DatabricksSecretAcl |
| secrets.put_secret | put_secret | Put-DatabricksSecret |
| workspace.delete | delete_notebook | Delete-DatabricksNotebook |
| workspace.export | export_notebook | Export-DatabricksNotebook |
| workspace.get_status | get_notebook_status | Get-DatabricksNotebookStatus |
| workspace.import | import_notebook | Import-DatabricksNotebook |
| workspace.list | list_notebooks | List-DatabricksNotebooks |
| workspace.mkdirs | mkdirs_notebook | Mkdirs-DatabricksNotebook |