### PR TITLE
Enable merge queue for Go SDK

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,8 +3,8 @@ name: build
 on:
   pull_request:
     types: [opened, synchronize]
-  push:
-    branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   tests:


### PR DESCRIPTION
## Changes
Add merge queue for Go SDK to support merging PRs which haven't been manually updated to latest main.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

