### PR TITLE
Properly skip request placeholder types

### DIFF
--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -75,6 +75,9 @@ type Entity struct {
 	RequiredOrder []string
 	fields        map[string]*Field
 
+	// if entity is only used as a request container
+	IsRequestOnly bool
+
 	// Schema references the OpenAPI schema this entity was created from.
 	Schema *openapi.Schema
 }
@@ -264,6 +267,7 @@ func (e *Entity) IsPublicPreview() bool {
 	return e.Schema != nil && isPublicPreview(&e.Schema.Node)
 }
 
+// Deprecated: use IsRequestOnly
 func (e *Entity) IsRequest() bool {
 	for _, svc := range e.Package.services {
 		for _, m := range svc.methods {

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -62,6 +62,18 @@ func (pkg *Package) Types() (types []*Entity) {
 	return types
 }
 
+// Returns sorted slice of types that are not mere request placeholders.
+// This method is designed to simplify keyed args UX for Python SDK.
+func (pkg *Package) NonPlaceholderTypes() (types []*Entity) {
+	for _, v := range pkg.Types() {
+		if v.IsRequestOnly {
+			continue
+		}
+		types = append(types, v)
+	}
+	return types
+}
+
 // EmptyTypes returns sorted list of types without fields
 func (pkg *Package) EmptyTypes() (types []*Named) {
 	types = append(types, pkg.emptyTypes...)

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -206,6 +206,17 @@ func (svc *Service) newRequest(params []openapi.Parameter, op *openapi.Operation
 		request.Description = op.Summary
 		svc.Package.define(request)
 	}
+	isOnlyUsedAsRequest := true
+	for _, e := range svc.Package.types {
+		for _, f := range e.fields {
+			if f.Entity == request {
+				// this type is not only a request placeholder, but is also
+				// part of other type definitions.
+				isOnlyUsedAsRequest = false
+			}
+		}
+	}
+	request.IsRequestOnly = isOnlyUsedAsRequest
 	return request
 }
 


### PR DESCRIPTION
This PR adds a way to list types that are not mere request placeholders, so that Python SDK keyed args UX is not cluttered with the types of no use.

To be verified after https://github.com/databricks/databricks-sdk-py/pull/264 is merged