### PR TITLE
Log consistently rather than printing to stdout

### DIFF
--- a/openapi/code/load.go
+++ b/openapi/code/load.go
@@ -1,6 +1,7 @@
 package code
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -14,7 +15,7 @@ type Batch struct {
 }
 
 // NewFromFile loads OpenAPI specification from file
-func NewFromFile(name string) (*Batch, error) {
+func NewFromFile(ctx context.Context, name string) (*Batch, error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return nil, fmt.Errorf("no %s file: %w", name, err)
@@ -24,11 +25,11 @@ func NewFromFile(name string) (*Batch, error) {
 	if err != nil {
 		return nil, fmt.Errorf("spec from %s: %w", name, err)
 	}
-	return NewFromSpec(spec)
+	return NewFromSpec(ctx, spec)
 }
 
 // NewFromSpec converts OpenAPI spec to intermediate representation
-func NewFromSpec(spec *openapi.Specification) (*Batch, error) {
+func NewFromSpec(ctx context.Context, spec *openapi.Specification) (*Batch, error) {
 	batch := Batch{
 		packages: map[string]*Package{},
 	}
@@ -43,7 +44,7 @@ func NewFromSpec(spec *openapi.Specification) (*Batch, error) {
 			}
 			batch.packages[tag.Package] = pkg
 		}
-		err := pkg.Load(spec, tag)
+		err := pkg.Load(ctx, spec, tag)
 		if err != nil {
 			return nil, fmt.Errorf("fail to load %s: %w", tag.Name, err)
 		}

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -1,6 +1,7 @@
 package code
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +13,8 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	batch, err := NewFromFile("../testdata/spec.json")
+	ctx := context.Background()
+	batch, err := NewFromFile(ctx, "../testdata/spec.json")
 	require.NoError(t, err)
 
 	require.Len(t, batch.Packages(), 1)
@@ -68,8 +70,9 @@ func TestBasic(t *testing.T) {
 // This test is used for debugging purposes
 func TestMethodsReport(t *testing.T) {
 	t.SkipNow()
+	ctx := context.Background()
 	home, _ := os.UserHomeDir()
-	batch, err := NewFromFile(filepath.Join(home,
+	batch, err := NewFromFile(ctx, filepath.Join(home,
 		"universe/bazel-bin/openapi/all-internal.json"))
 	assert.NoError(t, err)
 

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -3,6 +3,7 @@
 package code
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sort"
@@ -10,6 +11,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/openapi"
 )
 
@@ -317,7 +319,7 @@ func (pkg *Package) HasWaits() bool {
 }
 
 // Load takes OpenAPI specification and loads a service model
-func (pkg *Package) Load(spec *openapi.Specification, tag openapi.Tag) error {
+func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag openapi.Tag) error {
 	for k, v := range spec.Components.Schemas {
 		split := strings.Split(k, ".")
 		if split[0] != pkg.Name {
@@ -327,6 +329,7 @@ func (pkg *Package) Load(spec *openapi.Specification, tag openapi.Tag) error {
 	}
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {
+			logger.Infof(ctx, "pkg.Load %s %s", verb, prefix)
 			if !op.HasTag(tag.Name) {
 				continue
 			}

--- a/openapi/render/render.go
+++ b/openapi/render/render.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/openapi/code"
 )
 
@@ -79,9 +81,10 @@ type pass[T Named] struct {
 	Filenames []string
 }
 
-func (p *pass[T]) Run() error {
+func (p *pass[T]) Run(ctx context.Context) error {
 	for _, item := range p.Items {
-		fmt.Printf("Processing: %s\n", item.FullName())
+		name := item.FullName()
+		logger.Infof(ctx, "Processing: %s\n", name)
 		for k, v := range p.fileset {
 			err := p.File(item, k, v)
 			if err != nil {
@@ -136,10 +139,10 @@ func (p *pass[T]) File(item T, contentTRef, nameT string) error {
 	return file.Close()
 }
 
-func Fomratter(target string, filenames []string, formatSpec string) error {
+func Formatter(ctx context.Context, target string, filenames []string, formatSpec string) error {
 	for _, formatter := range strings.Split(formatSpec, "&&") {
 		formatter = strings.TrimSpace(formatter)
-		fmt.Printf("Formatting: %s\n", formatter)
+		logger.Infof(ctx, "Formatting: %s\n", formatter)
 
 		formatter = strings.ReplaceAll(formatter, "$FILENAMES",
 			strings.Join(filenames, " "))

--- a/openapi/roll/tool_test.go
+++ b/openapi/roll/tool_test.go
@@ -1,6 +1,7 @@
 package roll
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,8 +38,9 @@ func TestLoadsFolder(t *testing.T) {
 
 func TestOptimize(t *testing.T) {
 	t.Skip()
+	ctx := context.Background()
 	home, _ := os.UserHomeDir()
-	batch, err := code.NewFromFile(filepath.Join(home,
+	batch, err := code.NewFromFile(ctx, filepath.Join(home,
 		"universe/bazel-bin/openapi/all-internal.json"))
 	require.NoError(t, err)
 
@@ -51,6 +53,7 @@ func TestOptimize(t *testing.T) {
 
 func TestRegenerateExamples(t *testing.T) {
 	t.Skip() // temporary measure
+	ctx := context.Background()
 	s, err := NewSuite("../../internal")
 	require.NoError(t, err)
 
@@ -58,15 +61,16 @@ func TestRegenerateExamples(t *testing.T) {
 	pass := render.NewPass(target, s.ServicesExamples(), map[string]string{
 		".codegen/examples_test.go.tmpl": "service/{{.Package}}/{{.SnakeName}}_usage_test.go",
 	})
-	err = pass.Run()
+	err = pass.Run(ctx)
 	assert.NoError(t, err)
 
-	err = render.Fomratter(target, pass.Filenames, "go fmt ./... && go run golang.org/x/tools/cmd/goimports@latest -w $FILENAMES")
+	err = render.Formatter(ctx, target, pass.Filenames, "go fmt ./... && go run golang.org/x/tools/cmd/goimports@latest -w $FILENAMES")
 	assert.NoError(t, err)
 }
 
 func TestRegeneratePythonExamples(t *testing.T) {
 	t.Skip()
+	ctx := context.Background()
 	s, err := NewSuite("../../internal")
 	require.NoError(t, err)
 
@@ -74,9 +78,9 @@ func TestRegeneratePythonExamples(t *testing.T) {
 	pass := render.NewPass(target, s.Samples(), map[string]string{
 		".codegen/example.py.tmpl": "examples/{{.Service.SnakeName}}/{{.Method.SnakeName}}_{{.SnakeName}}.py",
 	})
-	err = pass.Run()
+	err = pass.Run(ctx)
 	assert.NoError(t, err)
 
-	err = render.Fomratter(target, pass.Filenames, "yapf -pri $FILENAMES && autoflake -i $FILENAMES && isort $FILENAMES")
+	err = render.Formatter(ctx, target, pass.Filenames, "yapf -pri $FILENAMES && autoflake -i $FILENAMES && isort $FILENAMES")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Changes
Small cleanup: use logger everywhere instead of printing to stdout.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

