### PR TITLE
Fix nightly test failures for Go SDK

### DIFF
--- a/.codegen/impl.go.tmpl
+++ b/.codegen/impl.go.tmpl
@@ -32,7 +32,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 {{end}}
 
 {{ define "request-param" -}}
-  {{ if or (and .Request (eq .Verb "GET") (eq .Verb "DELETE")) (and .Request .Request.Operation .Request.Operation.RequestBody) -}}
+  {{ if or (and .Request (or (eq .Verb "GET") (eq .Verb "DELETE"))) (and .Operation .Operation.RequestBody) -}}
     request{{ if .RequestBodyField }}.{{.RequestBodyField.PascalName}}{{end}}
   {{- else }}nil
   {{- end }}

--- a/.codegen/impl.go.tmpl
+++ b/.codegen/impl.go.tmpl
@@ -32,7 +32,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 {{end}}
 
 {{ define "request-param" -}}
-  {{ if .Request -}}
+  {{ if or (and .Request (eq .Verb "GET") (eq .Verb "DELETE")) (and .Request .Request.Operation .Request.Operation.RequestBody) -}}
     request{{ if .RequestBodyField }}.{{.RequestBodyField.PascalName}}{{end}}
   {{- else }}nil
   {{- end }}

--- a/.codegen/impl.go.tmpl
+++ b/.codegen/impl.go.tmpl
@@ -60,7 +60,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 {{ define "response" -}}
   {{ if .Response -}}
   {{ if .IsResponseByteStream -}}
-    &{{ .Response.PascalName }}{ {{ .ResponseBodyField.CamelName }}: {{ .Response.CamelName }} }
+    &{{ .Response.PascalName }}{ {{ .ResponseBodyField.PascalName }}: {{ .Response.CamelName }} }
   {{- else -}}
     {{ if not .Response.ArrayValue }}&{{end}}{{.Response.CamelName}}
   {{- end }}, {{end}}err

--- a/client/client.go
+++ b/client/client.go
@@ -413,10 +413,13 @@ func serializeQueryParamsToRequestBody(data any) (Body, error) {
 			continue
 		}
 		key := strings.Split(tag, ",")[0]
+		if key == "-" {
+			continue
+		}
 		m[key] = value
 	}
 
-	return fromJsonData(data)
+	return fromJsonData(m)
 }
 
 // List of (method, URL) pairs whose request bodies need to be serialized in a

--- a/client/client.go
+++ b/client/client.go
@@ -465,7 +465,7 @@ func makeQueryString(data interface{}) (string, error) {
 }
 
 func makeRequestBody(method string, requestURL *string, data interface{}) (requestBody, error) {
-	if data == nil && (method == "DELETE" || method == "GET") {
+	if data == nil {
 		return requestBody{}, nil
 	}
 	if method == "GET" || method == "DELETE" {

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -391,67 +390,9 @@ func makeQueryString(data interface{}) (string, error) {
 	return "", fmt.Errorf("unsupported query string data: %#v", data)
 }
 
-// Remove all custom request serializer logic once APP-1331 is rolled out.
-type serializer func(any) (Body, error)
-
-func serializeQueryParamsToRequestBody(data any) (Body, error) {
-	m := map[string]any{}
-	rv := reflect.ValueOf(data)
-	rt := reflect.TypeOf(data)
-	// If data is a map, just serialize it to JSON.
-	if rv.Kind() == reflect.Map {
-		return fromJsonData(data)
-	}
-	for i := 0; i < rv.NumField(); i++ {
-		field := rv.Field(i)
-		tag := rt.Field(i).Tag.Get("url")
-		if tag == "" {
-			continue
-		}
-		value := field.Interface()
-		if field.IsZero() {
-			continue
-		}
-		key := strings.Split(tag, ",")[0]
-		if key == "-" {
-			continue
-		}
-		m[key] = value
-	}
-
-	return fromJsonData(m)
-}
-
-// List of (method, URL) pairs whose request bodies need to be serialized in a
-// custom way. These can be removed after APP-1331 is rolled out.
-var requestInBodyOverrides = []struct {
-	method     string
-	urlRegexp  *regexp.Regexp
-	serializer serializer
-}{
-	{"DELETE", regexp.MustCompile("(/api/2.1)?/unity-catalog/(metastores|catalogs)/[^/]+"), serializeQueryParamsToRequestBody},
-	{"DELETE", regexp.MustCompile("(/api/2.1)?/unity-catalog/workspaces/[^/]+/(metastore|catalog)"), serializeQueryParamsToRequestBody},
-}
-
-func getRequestCustomSerializer(method string, requestURL *string) serializer {
-	for _, override := range requestInBodyOverrides {
-		// Return true if the request URL has the prefix and no trailing segments
-		// which would indicate other APIs.
-		matchRequestMethod := method == override.method
-		matchRequestURL := override.urlRegexp.MatchString(*requestURL)
-		if matchRequestMethod && matchRequestURL {
-			return override.serializer
-		}
-	}
-	return nil
-}
-
 func makeRequestBody(method string, requestURL *string, data interface{}) (Body, error) {
 	if data == nil && (method == "DELETE" || method == "GET") {
 		return Body{}, nil
-	}
-	if customSerializer := getRequestCustomSerializer(method, requestURL); customSerializer != nil {
-		return customSerializer(data)
 	}
 	if method == "GET" || method == "DELETE" {
 		qs, err := makeQueryString(data)

--- a/client/client.go
+++ b/client/client.go
@@ -124,7 +124,7 @@ func (r requestBody) reset() error {
 		_, err := v.Seek(0, io.SeekStart)
 		return err
 	} else {
-		return fmt.Errorf("cannot reset reader of type %T", v)
+		return fmt.Errorf("cannot reset reader of type %T", r.Reader)
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -182,10 +182,14 @@ func (c *DatabricksClient) unmarshal(body *ResponseBody, response any) error {
 	if len(bs) == 0 {
 		return nil
 	}
-	// If the destination is a byte slice, pass the body verbatim.
+	// If the destination is a byte slice or buffer, pass the body verbatim.
 	if raw, ok := response.(*[]byte); ok {
 		*raw = bs
 		return nil
+	}
+	if raw, ok := response.(*bytes.Buffer); ok {
+		_, err := raw.Write(bs)
+		return err
 	}
 	return json.Unmarshal(bs, &response)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -71,7 +71,7 @@ func TestSimpleRequestFailsURLError(t *testing.T) {
 	}, map[string]string{
 		"c": "d",
 	}, nil)
-	assert.EqualError(t, err, "GET \"/a/b\": nope")
+	assert.EqualError(t, err, "non-retriable error: GET \"/a/b\": nope")
 }
 
 func TestSimpleRequestFailsAPIError(t *testing.T) {
@@ -100,7 +100,7 @@ func TestSimpleRequestFailsAPIError(t *testing.T) {
 	}, map[string]string{
 		"c": "d",
 	}, nil)
-	assert.EqualError(t, err, "nope")
+	assert.EqualError(t, err, "non-retriable error: nope")
 }
 
 func TestSimpleRequestSucceeds(t *testing.T) {
@@ -170,7 +170,7 @@ func TestHaltAttemptForLimit(t *testing.T) {
 	_, rerr := c.attempt(ctx, "GET", "foo", nil, req)()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
-	assert.EqualError(t, rerr.Err, "rate: Wait(n=1) exceeds limiter's burst 0")
+	assert.EqualError(t, rerr.Err, "failed in rate limiter: rate: Wait(n=1) exceeds limiter's burst 0")
 }
 
 func TestHaltAttemptForNewRequest(t *testing.T) {
@@ -183,7 +183,7 @@ func TestHaltAttemptForNewRequest(t *testing.T) {
 	_, rerr := c.attempt(ctx, "🥱", "/", nil, req)()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
-	assert.EqualError(t, rerr.Err, `net/http: invalid method "🥱"`)
+	assert.EqualError(t, rerr.Err, `failed creating new request: net/http: invalid method "🥱"`)
 }
 
 func TestHaltAttemptForVisitor(t *testing.T) {
@@ -199,7 +199,7 @@ func TestHaltAttemptForVisitor(t *testing.T) {
 		})()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
-	assert.EqualError(t, rerr.Err, "🥱")
+	assert.EqualError(t, rerr.Err, "failed during request visitor: 🥱")
 }
 
 func TestMakeRequestBody(t *testing.T) {
@@ -320,7 +320,7 @@ func TestSimpleRequestErrReaderBody(t *testing.T) {
 	}
 	headers := map[string]string{"Accept": "application/json"}
 	err := c.Do(context.Background(), "PATCH", "/a", headers, map[string]any{}, nil)
-	assert.EqualError(t, err, "response body: test error")
+	assert.EqualError(t, err, "failed while reading response: response body: test error")
 }
 
 func TestSimpleRequestErrReaderBodyStreamResponse(t *testing.T) {
@@ -358,7 +358,7 @@ func TestSimpleRequestErrReaderCloseBody(t *testing.T) {
 	}
 	headers := map[string]string{"Accept": "application/json"}
 	err := c.Do(context.Background(), "PATCH", "/a", headers, map[string]any{}, nil)
-	assert.EqualError(t, err, "response body: test error")
+	assert.EqualError(t, err, "failed while reading response: response body: test error")
 }
 
 func TestSimpleRequestErrReaderCloseBody_StreamResponse(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -203,7 +203,7 @@ func TestMakeRequestBody(t *testing.T) {
 	requestURL := "/a/b/c"
 	body, err := makeRequestBody("GET", &requestURL, x{"test"})
 	assert.NoError(t, err)
-	bodyBytes, err := io.ReadAll(body.ReadCloser)
+	bodyBytes, err := io.ReadAll(body.Reader)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c?scope=test", requestURL)
 	assert.Equal(t, 0, len(bodyBytes))
@@ -211,7 +211,7 @@ func TestMakeRequestBody(t *testing.T) {
 	requestURL = "/a/b/c"
 	body, err = makeRequestBody("POST", &requestURL, x{"test"})
 	assert.NoError(t, err)
-	bodyBytes, err = io.ReadAll(body.ReadCloser)
+	bodyBytes, err = io.ReadAll(body.Reader)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c", requestURL)
 	x1 := `{"scope":"test"}`
@@ -222,7 +222,7 @@ func TestMakeRequestBodyFromReader(t *testing.T) {
 	requestURL := "/a/b/c"
 	body, err := makeRequestBody("PUT", &requestURL, strings.NewReader("abc"))
 	assert.NoError(t, err)
-	bodyBytes, err := io.ReadAll(body.ReadCloser)
+	bodyBytes, err := io.ReadAll(body.Reader)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("abc"), bodyBytes)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -165,7 +165,9 @@ func TestHaltAttemptForLimit(t *testing.T) {
 	c := &DatabricksClient{
 		rateLimiter: &rate.Limiter{},
 	}
-	_, rerr := c.attempt(ctx, "GET", "foo", nil, fromBytes([]byte{}))()
+	req, err := newRequestBody([]byte{})
+	assert.NoError(t, err)
+	_, rerr := c.attempt(ctx, "GET", "foo", nil, req)()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
 	assert.EqualError(t, rerr.Err, "rate: Wait(n=1) exceeds limiter's burst 0")
@@ -176,7 +178,9 @@ func TestHaltAttemptForNewRequest(t *testing.T) {
 	c := &DatabricksClient{
 		rateLimiter: rate.NewLimiter(rate.Inf, 1),
 	}
-	_, rerr := c.attempt(ctx, "🥱", "/", nil, fromBytes([]byte{}))()
+	req, err := newRequestBody([]byte{})
+	assert.NoError(t, err)
+	_, rerr := c.attempt(ctx, "🥱", "/", nil, req)()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
 	assert.EqualError(t, rerr.Err, `net/http: invalid method "🥱"`)
@@ -187,7 +191,9 @@ func TestHaltAttemptForVisitor(t *testing.T) {
 	c := &DatabricksClient{
 		rateLimiter: rate.NewLimiter(rate.Inf, 1),
 	}
-	_, rerr := c.attempt(ctx, "GET", "/", nil, fromBytes([]byte{}),
+	req, err := newRequestBody([]byte{})
+	assert.NoError(t, err)
+	_, rerr := c.attempt(ctx, "GET", "/", nil, req,
 		func(r *http.Request) error {
 			return fmt.Errorf("🥱")
 		})()

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -74,7 +74,7 @@ func TestAccDbfsOpen(t *testing.T) {
 	// Upload through [io.Writer] should fail because the file exists.
 	{
 		_, err := w.Dbfs.Open(ctx, path, files.FileModeWrite)
-		require.ErrorContains(t, err, "dbfs open: A file or directory already exists at the input path")
+		require.ErrorContains(t, err, "dbfs open: non-retriable error: A file or directory already exists at the input path")
 	}
 
 	// Upload through [io.ReadFrom] with overwrite bit set.
@@ -141,11 +141,11 @@ func TestAccDbfsOpenDirectory(t *testing.T) {
 
 	// Try to open the directory for writing.
 	_, err = w.Dbfs.Open(ctx, path, files.FileModeWrite)
-	assert.ErrorContains(t, err, "dbfs open: A file or directory already exists")
+	assert.ErrorContains(t, err, "dbfs open: non-retriable error: A file or directory already exists")
 
 	// Try to open the directory for writing with overwrite flag set.
 	_, err = w.Dbfs.Open(ctx, path, files.FileModeWrite|files.FileModeOverwrite)
-	assert.ErrorContains(t, err, "dbfs open: A file or directory already exists")
+	assert.ErrorContains(t, err, "dbfs open: non-retriable error: A file or directory already exists")
 }
 
 func TestAccDbfsReadFileWriteFile(t *testing.T) {

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -103,7 +103,7 @@ func TestMethodsReport(t *testing.T) {
 					m.KebabName(),
 					methodWithoutService,
 					singleService,
-					m.operation.Crud,
+					m.Operation.Crud,
 					strings.Join(fields, ", "),
 				))
 			}

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -46,7 +46,7 @@ type Method struct {
 
 	wait       *openapi.Wait
 	pagination *openapi.Pagination
-	operation  *openapi.Operation
+	Operation  *openapi.Operation
 	shortcut   bool
 }
 
@@ -168,15 +168,15 @@ func (m *Method) Shortcut() *Shortcut {
 }
 
 func (m *Method) IsCrudRead() bool {
-	return m.operation.Crud == "read"
+	return m.Operation.Crud == "read"
 }
 
 func (m *Method) IsCrudCreate() bool {
-	return m.operation.Crud == "create"
+	return m.Operation.Crud == "create"
 }
 
 func (m *Method) IsJsonOnly() bool {
-	return m.operation.JsonOnly
+	return m.Operation.JsonOnly
 }
 
 func (m *Method) HasIdentifierField() bool {
@@ -238,7 +238,7 @@ func (m *Method) Pagination() *Pagination {
 	results := m.Response.Field(m.pagination.Results)
 	if results == nil {
 		panic(fmt.Errorf("invalid results field '%v': %s",
-			m.pagination.Results, m.operation.OperationId))
+			m.pagination.Results, m.Operation.OperationId))
 	}
 	entity := results.Entity.ArrayValue
 	increment := m.pagination.Increment
@@ -336,12 +336,12 @@ func (m *Method) TitleVerb() string {
 
 // IsPrivatePreview flags object being in private preview.
 func (m *Method) IsPrivatePreview() bool {
-	return isPrivatePreview(&m.operation.Node)
+	return isPrivatePreview(&m.Operation.Node)
 }
 
 // IsPublicPreview flags object being in public preview.
 func (m *Method) IsPublicPreview() bool {
-	return isPublicPreview(&m.operation.Node)
+	return isPublicPreview(&m.Operation.Node)
 }
 
 func (m *Method) AsFlat() *Named {

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -45,7 +45,7 @@ func (svc *Service) Methods() (methods []*Method) {
 // List returns a method annotated with x-databricks-crud:list
 func (svc *Service) List() *Method {
 	for _, v := range svc.methods {
-		if v.operation.Crud == "list" {
+		if v.Operation.Crud == "list" {
 			return v
 		}
 	}
@@ -55,7 +55,7 @@ func (svc *Service) List() *Method {
 // List returns a method annotated with x-databricks-crud:create
 func (svc *Service) Create() *Method {
 	for _, v := range svc.methods {
-		if v.operation.Crud == "create" {
+		if v.Operation.Crud == "create" {
 			return v
 		}
 	}
@@ -65,7 +65,7 @@ func (svc *Service) Create() *Method {
 // List returns a method annotated with x-databricks-crud:read
 func (svc *Service) Read() *Method {
 	for _, v := range svc.methods {
-		if v.operation.Crud == "read" {
+		if v.Operation.Crud == "read" {
 			return v
 		}
 	}
@@ -75,7 +75,7 @@ func (svc *Service) Read() *Method {
 // List returns a method annotated with x-databricks-crud:update
 func (svc *Service) Update() *Method {
 	for _, v := range svc.methods {
-		if v.operation.Crud == "update" {
+		if v.Operation.Crud == "update" {
 			return v
 		}
 	}
@@ -85,7 +85,7 @@ func (svc *Service) Update() *Method {
 // List returns a method annotated with x-databricks-crud:delete
 func (svc *Service) Delete() *Method {
 	for _, v := range svc.methods {
-		if v.operation.Crud == "delete" {
+		if v.Operation.Crud == "delete" {
 			return v
 		}
 	}
@@ -434,7 +434,7 @@ func (svc *Service) newMethod(verb, path string, params []openapi.Parameter, op 
 		ResponseBodyField:   respBodyField,
 		FixedRequestHeaders: headers,
 		wait:                op.Wait,
-		operation:           op,
+		Operation:           op,
 		pagination:          op.Pagination,
 		shortcut:            op.Shortcut,
 	}

--- a/openapi/code/wait.go
+++ b/openapi/code/wait.go
@@ -30,7 +30,7 @@ const defaultLongRunningTimeout = 20
 
 // Timeout returns timeout in minutes, defaulting to 20
 func (w *Wait) Timeout() int {
-	t := w.Method.operation.Wait.Timeout
+	t := w.Method.Operation.Wait.Timeout
 	if t == 0 {
 		return defaultLongRunningTimeout
 	}
@@ -175,7 +175,7 @@ func (w *Wait) ComplexMessagePath() bool {
 func (w *Wait) MessagePathHead() *Field {
 	path := w.MessagePath()
 	if len(path) == 0 {
-		panic("message path is empty for " + w.Method.operation.OperationId)
+		panic("message path is empty for " + w.Method.Operation.OperationId)
 	}
 	return path[0]
 }

--- a/service/catalog/impl.go
+++ b/service/catalog/impl.go
@@ -704,7 +704,7 @@ func (a *systemSchemasImpl) Enable(ctx context.Context, request EnableRequest) e
 	path := fmt.Sprintf("/api/2.1/unity-catalog/metastores/%v/systemschemas/%v", request.MetastoreId, request.SchemaName)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPut, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPut, path, headers, nil, nil)
 	return err
 }
 

--- a/service/compute/commands_test.go
+++ b/service/compute/commands_test.go
@@ -193,7 +193,7 @@ func TestCommandsAPIExecute_FailGettingCluster(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "Does not compute")
+		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
 	})
 }
 
@@ -233,7 +233,7 @@ func TestCommandsAPIExecute_FailToCreateContext(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "Does not compute")
+		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
 	})
 }
 
@@ -264,7 +264,7 @@ func TestCommandsAPIExecute_FailToWaitForContext(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "Does not compute")
+		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
 	})
 }
 
@@ -311,7 +311,7 @@ func TestCommandsAPIExecute_FailToCreateCommand(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "Does not compute")
+		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
 	})
 }
 
@@ -365,7 +365,7 @@ func TestCommandsAPIExecute_FailToWaitForCommand(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "Does not compute")
+		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
 	})
 }
 
@@ -419,7 +419,7 @@ func TestCommandsAPIExecute_FailToGetCommand(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "Does not compute")
+		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
 	})
 }
 

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -195,7 +195,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 	// Container for the group identifier. Workspace local versus account.
@@ -776,7 +776,7 @@ type User struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks user ID.
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Name *Name `json:"name,omitempty"`
 

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -75,23 +75,6 @@ func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersions() {
-	ctx := context.Background()
-	w, err := databricks.NewWorkspaceClient()
-	if err != nil {
-		panic(err)
-	}
-
-	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
-		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", model)
-
-}
-
 func ExampleModelRegistryAPI_CreateModel_models() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
@@ -106,6 +89,23 @@ func ExampleModelRegistryAPI_CreateModel_models() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", created)
+
+}
+
+func ExampleModelRegistryAPI_CreateModel_modelVersions() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", model)
 
 }
 

--- a/service/oauth2/impl.go
+++ b/service/oauth2/impl.go
@@ -142,7 +142,7 @@ func (a *servicePrincipalSecretsImpl) Create(ctx context.Context, request Create
 	path := fmt.Sprintf("/api/2.0/accounts/%v/servicePrincipals/%v/credentials/secrets", a.client.ConfiguredAccountID(), request.ServicePrincipalId)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, &createServicePrincipalSecretResponse)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, &createServicePrincipalSecretResponse)
 	return &createServicePrincipalSecretResponse, err
 }
 

--- a/service/pipelines/impl.go
+++ b/service/pipelines/impl.go
@@ -100,7 +100,7 @@ func (a *pipelinesImpl) Reset(ctx context.Context, request ResetRequest) error {
 	path := fmt.Sprintf("/api/2.0/pipelines/%v/reset", request.PipelineId)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 
@@ -128,7 +128,7 @@ func (a *pipelinesImpl) Stop(ctx context.Context, request StopRequest) error {
 	path := fmt.Sprintf("/api/2.0/pipelines/%v/stop", request.PipelineId)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 

--- a/service/serving/impl.go
+++ b/service/serving/impl.go
@@ -99,7 +99,7 @@ func (a *servingEndpointsImpl) Query(ctx context.Context, request QueryRequest) 
 	path := fmt.Sprintf("/serving-endpoints/%v/invocations", request.Name)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, &queryEndpointResponse)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, &queryEndpointResponse)
 	return &queryEndpointResponse, err
 }
 

--- a/service/sql/impl.go
+++ b/service/sql/impl.go
@@ -105,7 +105,7 @@ func (a *dashboardsImpl) Restore(ctx context.Context, request RestoreDashboardRe
 	path := fmt.Sprintf("/api/2.0/preview/sql/dashboards/trash/%v", request.DashboardId)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 
@@ -202,7 +202,7 @@ func (a *queriesImpl) Restore(ctx context.Context, request RestoreQueryRequest) 
 	path := fmt.Sprintf("/api/2.0/preview/sql/queries/trash/%v", request.QueryId)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 
@@ -238,7 +238,7 @@ type statementExecutionImpl struct {
 func (a *statementExecutionImpl) CancelExecution(ctx context.Context, request CancelExecutionRequest) error {
 	path := fmt.Sprintf("/api/2.0/sql/statements/%v/cancel", request.StatementId)
 	headers := make(map[string]string)
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 
@@ -370,7 +370,7 @@ func (a *warehousesImpl) Start(ctx context.Context, request StartRequest) error 
 	path := fmt.Sprintf("/api/2.0/sql/warehouses/%v/start", request.Id)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 
@@ -378,7 +378,7 @@ func (a *warehousesImpl) Stop(ctx context.Context, request StopRequest) error {
 	path := fmt.Sprintf("/api/2.0/sql/warehouses/%v/stop", request.Id)
 	headers := make(map[string]string)
 	headers["Accept"] = "application/json"
-	err := a.client.Do(ctx, http.MethodPost, path, headers, request, nil)
+	err := a.client.Do(ctx, http.MethodPost, path, headers, nil, nil)
 	return err
 }
 


### PR DESCRIPTION
## Changes
The latest refactor of the client code in the Go SDK caused several regressions:
1. API calls using content-type: application/json apparently don't support transfer-encoding: chunked. To address this, I rewrite the internals of client.go to explicitly not wrap the bytes.NewReader or strings.NewReader in io.NopCloser. net/http's Client checks whether the body is a byte or string reader explicitly in order to set content-length and not use the chunked encoding.
2. UC API deletes that previously required query parameters in the body are not correctly serialized. However, the underlying issue has been fixed upstream, so we can remove all of this custom serialization code now.
3. Previously, the application/json Content-Type was sent with every request. However, there are some requests that have no request body, and as a result, that header was not being set on the request anymore. This conflicts with the Go SDK's implementation that always serializes the request object and adds it to the request body. Some services tolerate a request body without Content-Type, others do not. In this change, we pass `nil` for `request` if there is a request body or if there are request query parameters in the request structure (only for GET and DELETE). This involves one small OpenAPI change: exposing the underlying OpenAPI operation to see if there is a request body defined.
4. After changing the request body to use io.Reader, the reader is consumed during `httpClient.Do()`. If the client needs to retry, the request body is not reset, causing the retried request to have an empty body. We refactor the request body implementation to support resetting. As part of this, I made a number of changes to the error handling to clarify method behaviors and consolidate common functionality into simple functions.
5. Currently, we specify that the input for streaming bodies must be an `io.ReadCloser`. This isn't strictly the case: we can accept `io.Reader` as well, as the HTTP client will never close the request body. This does make it slightly more verbose for users: if they have an `io.Reader` that they want to use with a streaming body, they need to wrap it in `io.NopCloser()`. This PR separates the types for request and response body logic so that, internally, `io.Reader` is used for requests and `io.ReadCloser` for responses. This is not propagated to the generated parts of the SDK directly yet, as that would require a more invasive change (which may not be possible with our OpenAPI model), but at least it should allow us to handle requests and responses appropriately within the client.

Additionally, the name of the field of the response in streaming response bodies should be capitalized, so we must use PascalCase instead of CamelCase.

Finally, I've made small changes to error messages to better indicate where errors were happening within the client, so tests that matched on error messages exactly have changed.

## Tests
Integration tests are passing.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

