### PR TITLE
Fix loading of databrickscfg with a password containing a hash

### DIFF
--- a/config/config_file.go
+++ b/config/config_file.go
@@ -45,7 +45,13 @@ func LoadFile(path string) (*File, error) {
 		path = fmt.Sprintf("%s%s", homedir, path[1:])
 	}
 
-	iniFile, err := ini.Load(path)
+	opts := ini.LoadOptions{
+		// Passwords may contain '#'. Require a space before '#' for inline comments.
+		// See https://github.com/databricks/databricks-sdk-go/issues/594
+		SpaceBeforeInlineComment: true,
+	}
+
+	iniFile, err := ini.LoadSources(opts, path)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFileLoad(t *testing.T) {
+	f, err := LoadFile("testdata/.databrickscfg")
+	require.NoError(t, err)
+	assert.NotNil(t, f)
+
+	for _, name := range []string{
+		"password-with-double-quotes",
+		"password-with-single-quotes",
+		"password-without-quotes",
+	} {
+		section := f.Section(name)
+		require.NotNil(t, section)
+		assert.Equal(t, "%Y#X$Z", section.Key("password").String())
+	}
+}

--- a/config/testdata/.databrickscfg
+++ b/config/testdata/.databrickscfg
@@ -39,3 +39,18 @@ google_credentials = paw48590aw8e09t8apu
 [pat.with.dot]
 host = https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/
 token = PT0+IC9kZXYvdXJhbmRvbSA8PT0KYFZ
+
+[password-with-double-quotes]
+host = https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/
+username = abc
+password = "%Y#X$Z"
+
+[password-with-single-quotes]
+host = https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/
+username = abc
+password = '%Y#X$Z'
+
+[password-without-quotes]
+host = https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/
+username = abc
+password = %Y#X$Z


### PR DESCRIPTION
## Changes

Pass options to the ini loader to indicate that inline comments require a leading whitespace. Any existing configuration that uses inline comments _without_ a leading whitespace will be interpreted differently with this change.

## Tests

- [x] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

