### PR TITLE
Added `ErrNotWorkspaceClient`

### DIFF
--- a/.codegen/workspaces.go.tmpl
+++ b/.codegen/workspaces.go.tmpl
@@ -17,7 +17,9 @@ type WorkspaceClient struct {
 	{{end}}{{end}}
 }
 
-// NewWorkspaceClient creates new Databricks SDK client for Workspaces or 
+var ErrNotWorkspaceClient = errors.New("invalid Databricks Workspace configuration")
+
+// NewWorkspaceClient creates new Databricks SDK client for Workspaces or
 // returns error in case configuration is wrong
 func NewWorkspaceClient(c ...*Config) (*WorkspaceClient, error) {
 	var cfg *config.Config
@@ -27,6 +29,13 @@ func NewWorkspaceClient(c ...*Config) (*WorkspaceClient, error) {
 	} else {
 		// default config
 		cfg = &config.Config{}
+	}
+	err := cfg.EnsureResolved()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.IsAccountClient() {
+		return nil, ErrNotWorkspaceClient
 	}
 	apiClient, err := client.New(cfg)
 	if err != nil {

--- a/internal/acceptance_test.go
+++ b/internal/acceptance_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -15,10 +16,10 @@ import (
 
 func TestAccDefaultCredentials(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	w := databricks.Must(databricks.NewWorkspaceClient())
-	if w.Config.IsAccountClient() {
-		t.SkipNow()
+	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
+		skipf(t)("Skipping workspace test on account level")
 	}
+	w := databricks.Must(databricks.NewWorkspaceClient())
 	ctx := context.Background()
 	versions, err := w.Clusters.SparkVersions(ctx)
 	require.NoError(t, err)
@@ -34,12 +35,13 @@ func TestAccDefaultCredentials(t *testing.T) {
 // TODO: add CredentialProviderChain
 
 func TestAccExplicitDatabricksCfg(t *testing.T) {
+	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
+	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
+		skipf(t)("Skipping workspace test on account level")
+	}
 	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{
 		Profile: GetEnvOrSkipTest(t, "DATABRICKS_CONFIG_PROFILE"),
 	}))
-	if w.Config.IsAccountClient() {
-		t.SkipNow()
-	}
 	ctx := context.Background()
 	versions, err := w.Clusters.SparkVersions(ctx)
 	require.NoError(t, err)
@@ -105,4 +107,22 @@ func TestAccExplicitAzureSpnAuth(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, v)
+}
+
+func TestAccErrNotAccountClient(t *testing.T) {
+	workspaceTest(t)
+
+	// Confirm that we get an error when trying to create an account client
+	// if the configuration indicates a workspace.
+	_, err := databricks.NewAccountClient()
+	assert.ErrorIs(t, err, databricks.ErrNotAccountClient)
+}
+
+func TestAccErrNotWorkspaceClient(t *testing.T) {
+	accountTest(t)
+
+	// Confirm that we get an error when trying to create a workspace client
+	// if the configuration indicates an account.
+	_, err := databricks.NewWorkspaceClient()
+	assert.ErrorIs(t, err, databricks.ErrNotWorkspaceClient)
 }

--- a/workspace_client.go
+++ b/workspace_client.go
@@ -3,6 +3,8 @@
 package databricks
 
 import (
+	"errors"
+
 	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
 
@@ -902,6 +904,8 @@ type WorkspaceClient struct {
 	WorkspaceConf *settings.WorkspaceConfAPI
 }
 
+var ErrNotWorkspaceClient = errors.New("invalid Databricks Workspace configuration")
+
 // NewWorkspaceClient creates new Databricks SDK client for Workspaces or
 // returns error in case configuration is wrong
 func NewWorkspaceClient(c ...*Config) (*WorkspaceClient, error) {
@@ -912,6 +916,13 @@ func NewWorkspaceClient(c ...*Config) (*WorkspaceClient, error) {
 	} else {
 		// default config
 		cfg = &config.Config{}
+	}
+	err := cfg.EnsureResolved()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.IsAccountClient() {
+		return nil, ErrNotWorkspaceClient
 	}
 	apiClient, err := client.New(cfg)
 	if err != nil {


### PR DESCRIPTION
## Changes

Analogous to #238.

This enables the CLI to return an error if a user attempts to use configuration for an account client with a workspace client.

Also see https://github.com/databricks/cli/issues/721.

## Tests

New and existing integration tests pass (tested at workspace and account level).