### PR TITLE
Handle Azure authentication when WorkspaceResourceID is provided

### DIFF
--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -159,7 +159,7 @@ func (ts *azureCliTokenSource) getTokenBytes() ([]byte, error) {
 		return nil, fmt.Errorf("cannot get access token: %s", string(ee.Stderr))
 	}
 	if err != nil {
-		return nil, fmt.Errorf("cannot get access token: %v", err)
+		return nil, fmt.Errorf("cannot get access token: %w", err)
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Changes
Handle Azure authentication when WorkspaceResourceID is provided

Get token for the correct subscription 

## Tests
* Created Unit tests
* Manually listed workspace cluster in the following scenarios:
  * User with wrong default tenant. No WorkspaceResourceID provided: Fail (expected). WARN log emitted.
  * User with wrong default tenant. WorkspaceResourceID provided: Succeed
  * User with no subscription. No WorkspaceResourceID provided: Succeed. WARN log  emitted.
  * User with no subscription. WorkspaceResourceID provided: Succeed (fallback mode, expected).

- [X] `make test` passing
- [X] `make fmt` applied
- [x] relevant integration tests applied
https://github.com/databricks/eng-dev-ecosystem/actions/runs/6038851262/job/16386160429
