### PR TITLE
Use an operation's request type name if specified

### DIFF
--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -3,7 +3,6 @@ package code
 import (
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/openapi"
@@ -33,31 +32,14 @@ func (svc *Service) MatchesPackageName() bool {
 }
 
 // Methods returns sorted slice of methods
-func (svc *Service) Methods() []*Method {
-	permissionOperationRegex := regexp.MustCompile(`(Permissions|PermissionLevels)$`)
-
-	// Order the primary methods first, followed by the permission methods.
-	// This keeps the docs in a more logical order. Otherwise, the permission
-	// methods would be interspersed with the primary methods.
-	primaryMethods := []*Method{}
-	permissionMethods := []*Method{}
+func (svc *Service) Methods() (methods []*Method) {
 	for _, v := range svc.methods {
-		if permissionOperationRegex.MatchString(v.Operation.OperationId) {
-			permissionMethods = append(permissionMethods, v)
-		} else {
-			primaryMethods = append(primaryMethods, v)
-		}
+		methods = append(methods, v)
 	}
-
-	slices.SortFunc(primaryMethods, func(a, b *Method) bool {
+	slices.SortFunc(methods, func(a, b *Method) bool {
 		return a.CamelName() < b.CamelName()
 	})
-
-	slices.SortFunc(permissionMethods, func(a, b *Method) bool {
-		return a.CamelName() < b.CamelName()
-	})
-
-	return append(primaryMethods, permissionMethods...)
+	return methods
 }
 
 // List returns a method annotated with x-databricks-crud:list

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -138,6 +138,12 @@ type Operation struct {
 	// an action and the request body represents the resource.
 	PathStyle PathStyle `json:"x-databricks-path-style,omitempty"`
 
+	// The x-databricks-request-type-name field defines the name to use for
+	// the request type in the generated client. This may be specified only
+	// if the operation does NOT have a request body, thus only uses a request
+	// type to encapsulate path and query parameters.
+	RequestTypeName string `json:"x-databricks-request-type-name,omitempty"`
+
 	// For list APIs, the path to the field in the response entity that contains
 	// the resource ID.
 	IdField fieldPath `json:"x-databricks-id,omitempty"`


### PR DESCRIPTION
## Changes

The spec can contain the `x-databricks-request-type-name` annotation for requests that do not have a request body but need a request type to parameterize their URL path and query. This is necessary to 1) keep the method names for permissions APIs at the service level in check, and 2) have unique request type names.

When using this change with a new spec, the diff is (for the `JobsService`):
* `GetJobPermissionLevels` -> `GetPermissionLevels`
* `GetJobPermissions` -> `GetPermissions`
* `SetJobPermissions` -> `SetPermissions`
* `UpdateJobPermissions` -> `UpdateJobPermissions`

The request type names for these methods remain the same (because of this commit).

## Tests

Manually confirmed that with this change the request type name is used if specified