### PR TITLE
Work on GitHub Action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,14 @@ on:
     types: [opened, synchronize]
   merge_group:
     types: [checks_requested]
+  push:
+    # Always run on push to main. The build cache can only be reused
+    # if it was saved by a run from the repository's default branch.
+    # The run result will be identical to that from the merge queue
+    # because the commit is identical, yet we need to perform it to
+    # propertly use the build cache.
+    branches:
+      - main
 
 jobs:
   tests:
@@ -12,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goVersion: [1.19.x, 1.20.x]
+        goVersion: ["1.19", "1.20", "1.21"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,10 +29,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.goVersion }}
-          cache: true
 
       - name: Set go env
         run: |
@@ -48,7 +55,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ on:
     # if it was saved by a run from the repository's default branch.
     # The run result will be identical to that from the merge queue
     # because the commit is identical, yet we need to perform it to
-    # propertly use the build cache.
+    # seed the build cache.
     branches:
       - main
 


### PR DESCRIPTION
## Changes

* Update to actions/setup-go@v4; this uses caching by default
* Run the build workflow on push to main to properly use the build cache
* Include Go 1.21 in the test matrix

## Tests

n/a