### PR TITLE
Revert error message changes from client.go

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,7 +79,7 @@ func TestSimpleRequestFailsURLError(t *testing.T) {
 	}, map[string]string{
 		"c": "d",
 	}, nil)
-	assert.EqualError(t, err, "non-retriable error: GET \"/a/b\": nope")
+	assert.EqualError(t, err, "GET \"/a/b\": nope")
 }
 
 func TestSimpleRequestFailsAPIError(t *testing.T) {
@@ -108,7 +108,7 @@ func TestSimpleRequestFailsAPIError(t *testing.T) {
 	}, map[string]string{
 		"c": "d",
 	}, nil)
-	assert.EqualError(t, err, "non-retriable error: nope")
+	assert.EqualError(t, err, "nope")
 }
 
 func TestSimpleRequestSucceeds(t *testing.T) {
@@ -178,7 +178,7 @@ func TestHaltAttemptForLimit(t *testing.T) {
 	_, rerr := c.attempt(ctx, "GET", "foo", nil, req)()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
-	assert.EqualError(t, rerr.Err, "failed in rate limiter: rate: Wait(n=1) exceeds limiter's burst 0")
+	assert.EqualError(t, rerr.Err, "rate: Wait(n=1) exceeds limiter's burst 0")
 }
 
 func TestHaltAttemptForNewRequest(t *testing.T) {
@@ -191,7 +191,7 @@ func TestHaltAttemptForNewRequest(t *testing.T) {
 	_, rerr := c.attempt(ctx, "🥱", "/", nil, req)()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
-	assert.EqualError(t, rerr.Err, `failed creating new request: net/http: invalid method "🥱"`)
+	assert.EqualError(t, rerr.Err, `net/http: invalid method "🥱"`)
 }
 
 func TestHaltAttemptForVisitor(t *testing.T) {
@@ -207,7 +207,7 @@ func TestHaltAttemptForVisitor(t *testing.T) {
 		})()
 	assert.NotNil(t, rerr)
 	assert.Equal(t, true, rerr.Halt)
-	assert.EqualError(t, rerr.Err, "failed during request visitor: 🥱")
+	assert.EqualError(t, rerr.Err, "🥱")
 }
 
 func TestMakeRequestBody(t *testing.T) {
@@ -328,7 +328,7 @@ func TestSimpleRequestErrReaderBody(t *testing.T) {
 	}
 	headers := map[string]string{"Accept": "application/json"}
 	err := c.Do(context.Background(), "PATCH", "/a", headers, map[string]any{}, nil)
-	assert.EqualError(t, err, "failed while reading response: response body: test error")
+	assert.EqualError(t, err, "response body: test error")
 }
 
 func TestSimpleRequestErrReaderBodyStreamResponse(t *testing.T) {
@@ -366,7 +366,7 @@ func TestSimpleRequestErrReaderCloseBody(t *testing.T) {
 	}
 	headers := map[string]string{"Accept": "application/json"}
 	err := c.Do(context.Background(), "PATCH", "/a", headers, map[string]any{}, nil)
-	assert.EqualError(t, err, "failed while reading response: response body: test error")
+	assert.EqualError(t, err, "response body: test error")
 }
 
 func TestSimpleRequestErrReaderCloseBody_StreamResponse(t *testing.T) {

--- a/service/compute/commands_test.go
+++ b/service/compute/commands_test.go
@@ -193,7 +193,7 @@ func TestCommandsAPIExecute_FailGettingCluster(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
+		assert.EqualError(t, cr.Err(), "Does not compute")
 	})
 }
 
@@ -233,7 +233,7 @@ func TestCommandsAPIExecute_FailToCreateContext(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
+		assert.EqualError(t, cr.Err(), "Does not compute")
 	})
 }
 
@@ -264,7 +264,7 @@ func TestCommandsAPIExecute_FailToWaitForContext(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
+		assert.EqualError(t, cr.Err(), "Does not compute")
 	})
 }
 
@@ -311,7 +311,7 @@ func TestCommandsAPIExecute_FailToCreateCommand(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
+		assert.EqualError(t, cr.Err(), "Does not compute")
 	})
 }
 
@@ -365,7 +365,7 @@ func TestCommandsAPIExecute_FailToWaitForCommand(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
+		assert.EqualError(t, cr.Err(), "Does not compute")
 	})
 }
 
@@ -419,7 +419,7 @@ func TestCommandsAPIExecute_FailToGetCommand(t *testing.T) {
 	}.ApplyClient(t, func(ctx context.Context, client *client.DatabricksClient) {
 		commands := NewCommandExecutor(client)
 		cr := commands.Execute(ctx, "abc", "cobol", "Hello?")
-		assert.EqualError(t, cr.Err(), "non-retriable error: Does not compute")
+		assert.EqualError(t, cr.Err(), "Does not compute")
 	})
 }
 


### PR DESCRIPTION
## Changes
https://github.com/databricks/databricks-sdk-go/pull/590 made several changes in the error messages returned from the client. It turns out that many users depend on these error messages exactly. I'll revert this change for now to unblock users who depended on these error messages exactly. Going forward, we recommend that users check if the returned error is an API Error, and then to use the ErrorCode to make decisions about how to handle errors in the APIs.

## Tests
- [x] Unit tests are reverted and no longer reference these nested fields.
- [x] Upgraded TF provider to use this commit locally and unit tests pass.

