### PR TITLE
Reuse tokens after first call to Azure CLI

### DIFF
--- a/config/auth_azure_cli_test.go
+++ b/config/auth_azure_cli_test.go
@@ -72,6 +72,31 @@ func TestAzureCliCredentials_Valid(t *testing.T) {
 	assert.Equal(t, "...", r.Header.Get("X-Databricks-Azure-SP-Management-Token"))
 }
 
+func TestAzureCliCredentials_ReuseTokens(t *testing.T) {
+	env.CleanupEnvironment(t)
+	os.Setenv("PATH", testdataPath())
+	os.Setenv("EXPIRE", "10M")
+
+	// Use temporary file to store the number of calls to the AZ CLI.
+	tmp := t.TempDir()
+	count := filepath.Join(tmp, "count")
+	os.Setenv("COUNT", count)
+
+	aa := AzureCliCredentials{}
+	visitor, err := aa.Configure(context.Background(), azDummy)
+	assert.NoError(t, err)
+
+	r := &http.Request{Header: http.Header{}}
+	err = visitor(r)
+	assert.NoError(t, err)
+
+	// We verify the headers in the test above.
+	// This test validates we do not call the AZ CLI more than we need.
+	buf, err := os.ReadFile(count)
+	require.NoError(t, err)
+	assert.Len(t, buf, 2, "Expected the AZ CLI to be called twice")
+}
+
 func TestAzureCliCredentials_ValidNoManagementAccess(t *testing.T) {
 	env.CleanupEnvironment(t)
 	os.Setenv("PATH", testdataPath())

--- a/config/testdata/az
+++ b/config/testdata/az
@@ -22,7 +22,7 @@ for arg in "$@"; do
     fi
 done
 
-# Add PID to file at $COUNT if it is defined.
+# Add character to file at $COUNT if it is defined.
 if [ -n "$COUNT" ]; then
     echo -n x >> "$COUNT"
 fi

--- a/config/testdata/az
+++ b/config/testdata/az
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-if [ "yes" == "$FAIL" ]; then 
+if [ "yes" == "$FAIL" ]; then
     >&2 /bin/echo "This is just a failing script."
     exit 1
 fi
 
-if [ "logout" == "$FAIL" ]; then 
+if [ "logout" == "$FAIL" ]; then
     >&2 /bin/echo "No subscription found. Run 'az account set' to select a subscription."
     exit 1
 fi
 
-if [ "corrupt" == "$FAIL" ]; then 
+if [ "corrupt" == "$FAIL" ]; then
     /bin/echo "{accessToken: ..corrupt"
     exit
 fi
@@ -21,6 +21,11 @@ for arg in "$@"; do
         exit 1
     fi
 done
+
+# Add PID to file at $COUNT if it is defined.
+if [ -n "$COUNT" ]; then
+    echo -n x >> "$COUNT"
+fi
 
 # Macos
 EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"


### PR DESCRIPTION
## Changes

The call to `oauth2.ReuseTokenSource` in `oauth_visitors.go` doesn't include a token to start with so will always trigger a new call to acquire a token.

We fix this by wrapping the `oauth2.TokenSource` with `oauth2.ReuseTokenSource` from the caller, where we have a copy of a valid token.

Calling `oauth2.ReuseTokenSource` twice is a no-op: https://cs.opensource.google/go/x/oauth2/+/refs/tags/v0.11.0:oauth2.go;l=370

This commit also updates the logging to emit the info line only once we know we can return from `Configure` successfully.

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

