### PR TITLE
Update error message assertions

### DIFF
--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -103,7 +103,7 @@ func TestAccDbfsOpen(t *testing.T) {
 	// Upload through [io.Writer] should fail because the file exists.
 	{
 		_, err := w.Dbfs.Open(ctx, path, files.FileModeWrite)
-		require.ErrorContains(t, err, "dbfs open: non-retriable error: A file or directory already exists at the input path")
+		require.ErrorContains(t, err, "dbfs open: A file or directory already exists at the input path")
 	}
 
 	// Upload through [io.ReadFrom] with overwrite bit set.
@@ -170,11 +170,11 @@ func TestAccDbfsOpenDirectory(t *testing.T) {
 
 	// Try to open the directory for writing.
 	_, err = w.Dbfs.Open(ctx, path, files.FileModeWrite)
-	assert.ErrorContains(t, err, "dbfs open: non-retriable error: A file or directory already exists")
+	assert.ErrorContains(t, err, "dbfs open: A file or directory already exists")
 
 	// Try to open the directory for writing with overwrite flag set.
 	_, err = w.Dbfs.Open(ctx, path, files.FileModeWrite|files.FileModeOverwrite)
-	assert.ErrorContains(t, err, "dbfs open: non-retriable error: A file or directory already exists")
+	assert.ErrorContains(t, err, "dbfs open: A file or directory already exists")
 }
 
 func TestAccDbfsReadFileWriteFile(t *testing.T) {


### PR DESCRIPTION
## Changes

Error messages changed in #592 and got reverted in #604.

This fixes the nightlies.

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

