### PR TITLE
Fix case where retry of a request without body fails

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -113,12 +113,12 @@ func newRequestBody(data any) (requestBody, error) {
 
 // Reset a request body to its initial state.
 //
-// This is used to retry requests with a body that has already been read. If
-// the request body is not strings.Reader or bytes.Reader, this will return an
-// error.
+// This is used to retry requests with a body that has already been read.
+// If the request body is not resettable (i.e. not nil and of type other than
+// strings.Reader or bytes.Reader), this will return an error.
 func (r requestBody) reset() error {
 	if r.Reader == nil {
-		return errors.New("cannot reset nil reader")
+		return nil
 	}
 	if v, ok := r.Reader.(io.Seeker); ok {
 		_, err := v.Seek(0, io.SeekStart)


### PR DESCRIPTION
## Changes

This problem was introduced in #592. It contains an assumption that a `nil` body on the newly introduced `requestBody` struct cannot be `nil`, yet it can be for requests without a body (HEAD, GET, and DELETE). If a request of one of these types fails with a retriable error (e.g. a 429), the code tries to reset the body, which in turn fails because it is nil.

The symptom is a GET request failing with: `cannot reset nil reader`.

Because a nil request body is valid, this change updates the expectation accordingly.

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

