### PR TITLE
Adjust token expiry window to 40 seconds on Azure

### DIFF
--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -122,10 +122,10 @@ func (ts *azureCliTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot unmarshal CLI result: %w", err)
 	}
-	// expiresOn, err := time.ParseInLocation("2006-01-02 15:04:05.999999", it.ExpiresOn, time.Local)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("cannot parse expiry: %w", err)
-	// }
+	expiresOn, err := time.ParseInLocation("2006-01-02 15:04:05.999999", it.ExpiresOn, time.Local)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse expiry: %w", err)
+	}
 	logger.Infof(context.Background(), "Refreshed OAuth token for %s from Azure CLI, which expires on %s",
 		ts.resource, it.ExpiresOn)
 
@@ -138,7 +138,7 @@ func (ts *azureCliTokenSource) Token() (*oauth2.Token, error) {
 		AccessToken:  it.AccessToken,
 		RefreshToken: it.RefreshToken,
 		TokenType:    it.TokenType,
-		Expiry:       time.Now().Add(time.Minute),
+		Expiry:       expiresOn,
 	}).WithExtra(extra), nil
 }
 

--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -42,7 +42,7 @@ func (c AzureCliCredentials) tokenSourceFor(
 //
 // If the user can't access the service management endpoint, we assume they are in case 2 and do not pass the service
 // management token. Otherwise, we always pass the service management token.
-func (c AzureCliCredentials) getVisitor(ctx context.Context, cfg *Config, inner oauth2.TokenSource) (func(*http.Request) error, error) {
+func (c AzureCliCredentials) getVisitor(ctx context.Context, cfg *Config, innerTokenSource oauth2.TokenSource) (func(*http.Request) error, error) {
 	env, err := cfg.GetAzureEnvironment()
 	if err != nil {
 		return nil, err
@@ -51,10 +51,10 @@ func (c AzureCliCredentials) getVisitor(ctx context.Context, cfg *Config, inner 
 	t, err := ts.Token()
 	if err != nil {
 		logger.Debugf(ctx, "Not including service management token in headers: %v", err)
-		return azureVisitor(cfg, refreshableVisitor(inner)), nil
+		return azureVisitor(cfg, refreshableVisitor(innerTokenSource)), nil
 	}
-	management := azureReuseTokenSource(t, ts)
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
+	managementTokenSource := azureReuseTokenSource(t, ts)
+	return azureVisitor(cfg, serviceToServiceVisitor(innerTokenSource, managementTokenSource, xDatabricksAzureSpManagementToken)), nil
 }
 
 func (c AzureCliCredentials) Configure(ctx context.Context, cfg *Config) (func(*http.Request) error, error) {

--- a/config/auth_azure_client_secret.go
+++ b/config/auth_azure_client_secret.go
@@ -52,14 +52,7 @@ func (c AzureClientSecretCredentials) Configure(ctx context.Context, cfg *Config
 	}
 	logger.Infof(ctx, "Generating AAD token for Service Principal (%s)", cfg.AzureClientID)
 	refreshCtx := context.Background()
-	inner := c.tokenSourceFor(refreshCtx, cfg, env, cfg.getAzureLoginAppID())
-	management := c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint)
-	return azureVisitor(
-		cfg,
-		serviceToServiceVisitor(
-			azureAdjustExpiry(inner),
-			azureAdjustExpiry(management),
-			xDatabricksAzureSpManagementToken,
-		),
-	), nil
+	inner := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, cfg.getAzureLoginAppID()))
+	management := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint))
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }

--- a/config/auth_azure_client_secret.go
+++ b/config/auth_azure_client_secret.go
@@ -53,6 +53,13 @@ func (c AzureClientSecretCredentials) Configure(ctx context.Context, cfg *Config
 	logger.Infof(ctx, "Generating AAD token for Service Principal (%s)", cfg.AzureClientID)
 	refreshCtx := context.Background()
 	inner := c.tokenSourceFor(refreshCtx, cfg, env, cfg.getAzureLoginAppID())
-	platform := c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint)
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, platform, xDatabricksAzureSpManagementToken)), nil
+	management := c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint)
+	return azureVisitor(
+		cfg,
+		serviceToServiceVisitor(
+			azureAdjustExpiry(inner),
+			azureAdjustExpiry(management),
+			xDatabricksAzureSpManagementToken,
+		),
+	), nil
 }

--- a/config/auth_azure_client_secret.go
+++ b/config/auth_azure_client_secret.go
@@ -53,6 +53,6 @@ func (c AzureClientSecretCredentials) Configure(ctx context.Context, cfg *Config
 	logger.Infof(ctx, "Generating AAD token for Service Principal (%s)", cfg.AzureClientID)
 	refreshCtx := context.Background()
 	inner := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, cfg.getAzureLoginAppID()))
-	management := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint))
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
+	platform := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint))
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, platform, xDatabricksAzureSpManagementToken)), nil
 }

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -41,22 +41,15 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 		}
 	}
 	logger.Debugf(ctx, "Generating AAD token via Azure MSI")
-	inner := azureMsiTokenSource{
+	inner := azureReuseTokenSource(nil, azureMsiTokenSource{
 		resource: cfg.getAzureLoginAppID(),
 		clientId: cfg.AzureClientID,
-	}
-	management := azureMsiTokenSource{
+	})
+	management := azureReuseTokenSource(nil, azureMsiTokenSource{
 		resource: env.ServiceManagementEndpoint,
 		clientId: cfg.AzureClientID,
-	}
-	return azureVisitor(
-		cfg,
-		serviceToServiceVisitor(
-			azureAdjustExpiry(inner),
-			azureAdjustExpiry(management),
-			xDatabricksAzureSpManagementToken,
-		),
-	), nil
+	})
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }
 
 func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azureEnvironment, error) {

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -45,11 +45,11 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 		resource: cfg.getAzureLoginAppID(),
 		clientId: cfg.AzureClientID,
 	})
-	management := azureReuseTokenSource(nil, azureMsiTokenSource{
+	platform := azureReuseTokenSource(nil, azureMsiTokenSource{
 		resource: env.ServiceManagementEndpoint,
 		clientId: cfg.AzureClientID,
 	})
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, platform, xDatabricksAzureSpManagementToken)), nil
 }
 
 func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azureEnvironment, error) {

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -45,11 +45,18 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 		resource: cfg.getAzureLoginAppID(),
 		clientId: cfg.AzureClientID,
 	}
-	platform := azureMsiTokenSource{
+	management := azureMsiTokenSource{
 		resource: env.ServiceManagementEndpoint,
 		clientId: cfg.AzureClientID,
 	}
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, platform, xDatabricksAzureSpManagementToken)), nil
+	return azureVisitor(
+		cfg,
+		serviceToServiceVisitor(
+			azureAdjustExpiry(inner),
+			azureAdjustExpiry(management),
+			xDatabricksAzureSpManagementToken,
+		),
+	), nil
 }
 
 func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azureEnvironment, error) {

--- a/config/oauth_visitors.go
+++ b/config/oauth_visitors.go
@@ -70,10 +70,10 @@ func azureVisitor(cfg *Config, inner func(*http.Request) error) func(*http.Reque
 	}
 }
 
-// azureAdjustExpiry returns a copy of the specified token source that will refresh the token 40 seconds before it expires.
+// azureReuseTokenSource calls into oauth2.ReuseTokenSourceWithExpiry with a 40 second expiry window.
 // By default, the oauth2 library refreshes a token 10 seconds before it expires.
 // Azure Databricks rejects tokens that expire in 30 seconds or less.
 // We combine these and refresh the token 40 seconds before it expires.
-func azureAdjustExpiry(ts oauth2.TokenSource) oauth2.TokenSource {
-	return oauth2.ReuseTokenSourceWithExpiry(nil, ts, 40*time.Second)
+func azureReuseTokenSource(t *oauth2.Token, ts oauth2.TokenSource) oauth2.TokenSource {
+	return oauth2.ReuseTokenSourceWithExpiry(t, ts, 40*time.Second)
 }

--- a/config/oauth_visitors.go
+++ b/config/oauth_visitors.go
@@ -69,3 +69,11 @@ func azureVisitor(cfg *Config, inner func(*http.Request) error) func(*http.Reque
 		return inner(r)
 	}
 }
+
+// azureAdjustExpiry returns a copy of the specified token source that will refresh the token 40 seconds before it expires.
+// By default, the oauth2 library refreshes a token 10 seconds before it expires.
+// Azure Databricks rejects tokens that expire in 30 seconds or less.
+// We combine these and refresh the token 40 seconds before it expires.
+func azureAdjustExpiry(ts oauth2.TokenSource) oauth2.TokenSource {
+	return oauth2.ReuseTokenSourceWithExpiry(nil, ts, 40*time.Second)
+}

--- a/config/oauth_visitors_test.go
+++ b/config/oauth_visitors_test.go
@@ -58,7 +58,7 @@ func TestOAuthWithValidToken(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestAzureAdjustExpiry(t *testing.T) {
+func TestAzureReuseTokenSource(t *testing.T) {
 	mockSource := mockTokenSource{
 		mockedTokenFunc: func() (*oauth2.Token, error) {
 			return &oauth2.Token{
@@ -68,7 +68,7 @@ func TestAzureAdjustExpiry(t *testing.T) {
 	}
 
 	// Assert the token is not valid if it expires in 35 seconds.
-	adjustedSource := azureAdjustExpiry(mockSource)
+	adjustedSource := azureReuseTokenSource(nil, mockSource)
 	token, err := adjustedSource.Token()
 	assert.NoError(t, err)
 	assert.False(t, token.Valid())

--- a/config/oauth_visitors_test.go
+++ b/config/oauth_visitors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
@@ -55,4 +56,20 @@ func TestOAuthWithValidToken(t *testing.T) {
 	token, err := retriableTokenSource(context.Background(), mockSource)
 	assert.Equal(t, "test", token.TokenType)
 	assert.NoError(t, err)
+}
+
+func TestAzureAdjustExpiry(t *testing.T) {
+	mockSource := mockTokenSource{
+		mockedTokenFunc: func() (*oauth2.Token, error) {
+			return &oauth2.Token{
+				Expiry: time.Now().Add(35 * time.Second),
+			}, nil
+		},
+	}
+
+	// Assert the token is not valid if it expires in 35 seconds.
+	adjustedSource := azureAdjustExpiry(mockSource)
+	token, err := adjustedSource.Token()
+	assert.NoError(t, err)
+	assert.False(t, token.Valid())
 }


### PR DESCRIPTION
## Changes

By default, the oauth2 library refreshes a token 10 seconds before it expires. Azure Databricks rejects tokens that expire in 30 seconds. This leaves a 20-second window where the SDK assumes the token is valid while the backend rejects it.

This change extends the token expiry window to 40 seconds to fix this.

## Tests

* Unit test for the expiry helper.
* Manually confirmed refreshes happen 40 seconds before actual expiry.