### PR TITLE
Rename variables in Azure code to match across auth types

### DIFF
--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -42,7 +42,7 @@ func (c AzureCliCredentials) tokenSourceFor(
 //
 // If the user can't access the service management endpoint, we assume they are in case 2 and do not pass the service
 // management token. Otherwise, we always pass the service management token.
-func (c AzureCliCredentials) getVisitor(ctx context.Context, cfg *Config, innerTokenSource oauth2.TokenSource) (func(*http.Request) error, error) {
+func (c AzureCliCredentials) getVisitor(ctx context.Context, cfg *Config, inner oauth2.TokenSource) (func(*http.Request) error, error) {
 	env, err := cfg.GetAzureEnvironment()
 	if err != nil {
 		return nil, err
@@ -51,10 +51,10 @@ func (c AzureCliCredentials) getVisitor(ctx context.Context, cfg *Config, innerT
 	t, err := ts.Token()
 	if err != nil {
 		logger.Debugf(ctx, "Not including service management token in headers: %v", err)
-		return azureVisitor(cfg, refreshableVisitor(innerTokenSource)), nil
+		return azureVisitor(cfg, refreshableVisitor(inner)), nil
 	}
-	managementTokenSource := azureReuseTokenSource(t, ts)
-	return azureVisitor(cfg, serviceToServiceVisitor(innerTokenSource, managementTokenSource, xDatabricksAzureSpManagementToken)), nil
+	management := azureReuseTokenSource(t, ts)
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }
 
 func (c AzureCliCredentials) Configure(ctx context.Context, cfg *Config) (func(*http.Request) error, error) {

--- a/config/auth_azure_client_secret.go
+++ b/config/auth_azure_client_secret.go
@@ -53,6 +53,6 @@ func (c AzureClientSecretCredentials) Configure(ctx context.Context, cfg *Config
 	logger.Infof(ctx, "Generating AAD token for Service Principal (%s)", cfg.AzureClientID)
 	refreshCtx := context.Background()
 	inner := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, cfg.getAzureLoginAppID()))
-	platform := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint))
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, platform, xDatabricksAzureSpManagementToken)), nil
+	management := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, env, env.ServiceManagementEndpoint))
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -45,11 +45,11 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 		resource: cfg.getAzureLoginAppID(),
 		clientId: cfg.AzureClientID,
 	})
-	platform := azureReuseTokenSource(nil, azureMsiTokenSource{
+	management := azureReuseTokenSource(nil, azureMsiTokenSource{
 		resource: env.ServiceManagementEndpoint,
 		clientId: cfg.AzureClientID,
 	})
-	return azureVisitor(cfg, serviceToServiceVisitor(inner, platform, xDatabricksAzureSpManagementToken)), nil
+	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }
 
 func (c AzureMsiCredentials) getInstanceEnvironment(ctx context.Context) (*azureEnvironment, error) {


### PR DESCRIPTION
## Changes

These are identical but were named differently.

## Tests

n/a
