### PR TITLE
Remove `photon` and `graviton` selectors in `compute.SparkVersionRequ…

### DIFF
--- a/service/compute/spark_version.go
+++ b/service/compute/spark_version.go
@@ -21,8 +21,6 @@ type SparkVersionRequest struct {
 	GPU             bool   `json:"gpu,omitempty" tf:"optional,default:false"`
 	Scala           string `json:"scala,omitempty" tf:"optional,default:2.12"`
 	SparkVersion    string `json:"spark_version,omitempty" tf:"optional,default:"`
-	Photon          bool   `json:"photon,omitempty" tf:"optional,default:false"`
-	Graviton        bool   `json:"graviton,omitempty"`
 }
 
 type sparkVersionsType []string
@@ -57,8 +55,6 @@ func (sv GetSparkVersionsResponse) Select(req SparkVersionRequest) (string, erro
 				(strings.Contains(version.Key, "-ml-") == req.ML) &&
 				(strings.Contains(version.Key, "-hls-") == req.Genomics) &&
 				(strings.Contains(version.Key, "-gpu-") == req.GPU) &&
-				(strings.Contains(version.Key, "-photon-") == req.Photon) &&
-				(strings.Contains(version.Key, "-aarch64-") == req.Graviton) &&
 				(strings.Contains(version.Name, "Beta") == req.Beta))
 			if matches && req.LongTermSupport {
 				matches = (matches && (strings.Contains(version.Name, "LTS") || strings.Contains(version.Key, "-esr-")))


### PR DESCRIPTION
## Changes
Removed `photon` and `graviton` selectors in `compute.SparkVersionRequest`

Solves #619 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

