### PR TITLE
Remove use of cancel by job id in integration test

### DIFF
--- a/internal/jobs_test.go
+++ b/internal/jobs_test.go
@@ -80,7 +80,9 @@ func TestAccJobsApiFullIntegration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = w.Jobs.CancelAllRunsByJobId(ctx, createdJob.JobId)
+	err = w.Jobs.CancelAllRuns(ctx, jobs.CancelAllRuns{
+		JobId: createdJob.JobId,
+	})
 	require.NoError(t, err)
 
 	runNowResponse, err := w.Jobs.RunNow(ctx, jobs.RunNow{

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -740,7 +740,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Roles []ComplexValue `json:"roles,omitempty"`
 }

--- a/service/jobs/jobs_usage_test.go
+++ b/service/jobs/jobs_usage_test.go
@@ -56,7 +56,9 @@ func ExampleJobsAPI_CancelAllRuns_jobsApiFullIntegration() {
 	}
 	logger.Infof(ctx, "found %v", createdJob)
 
-	err = w.Jobs.CancelAllRunsByJobId(ctx, createdJob.JobId)
+	err = w.Jobs.CancelAllRuns(ctx, jobs.CancelAllRuns{
+		JobId: createdJob.JobId,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -75,7 +75,7 @@ func ExampleModelRegistryAPI_CreateModel_models() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
+func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
@@ -92,7 +92,7 @@ func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -206,7 +206,6 @@ type ChannelInfo struct {
 	Name ChannelName `json:"name,omitempty"`
 }
 
-// Name of the channel
 type ChannelName string
 
 const ChannelNameChannelNameCurrent ChannelName = `CHANNEL_NAME_CURRENT`


### PR DESCRIPTION
## Changes
JobId was recently made optional for the cancel API. This means `CancelAllRunsByJobId` will no longer exist once we bump the SDK.

This PR removes usage of this method from our integration tests and examples to unblock SDK generation.

## Tests
Existing tests

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

