### PR TITLE
Add support for template libraries

### DIFF
--- a/openapi/generator/config.go
+++ b/openapi/generator/config.go
@@ -25,6 +25,11 @@ type Toolchain struct {
 type Generator struct {
 	Formatter string `json:"formatter"`
 
+	// TemplateLibraries is a list of files containing go template definitions
+	// that are reused in different stages of codegen. E.g. the "type" template
+	// is needed in both the "types" and "services" stages.
+	TemplateLibraries []string `json:"template_libraries,omitempty"`
+
 	// We can generate SDKs in three modes: Packages, Types, Services
 	// E.g. Go is Package-focused and Java is Types+Services
 	Packages map[string]string `json:"packages,omitempty"`
@@ -74,7 +79,7 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 	}
 	var filenames []string
 	if c.Batch != nil {
-		pass := render.NewPass(c.dir, []render.Named{batch}, c.Batch)
+		pass := render.NewPass(c.dir, []render.Named{batch}, c.Batch, c.TemplateLibraries)
 		err := pass.Run(ctx)
 		if err != nil {
 			return fmt.Errorf("batch: %w", err)
@@ -82,7 +87,7 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 		filenames = append(filenames, pass.Filenames...)
 	}
 	if c.Packages != nil {
-		pass := render.NewPass(c.dir, batch.Packages(), c.Packages)
+		pass := render.NewPass(c.dir, batch.Packages(), c.Packages, c.TemplateLibraries)
 		err := pass.Run(ctx)
 		if err != nil {
 			return fmt.Errorf("packages: %w", err)
@@ -90,7 +95,7 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 		filenames = append(filenames, pass.Filenames...)
 	}
 	if c.Services != nil {
-		pass := render.NewPass(c.dir, batch.Services(), c.Services)
+		pass := render.NewPass(c.dir, batch.Services(), c.Services, c.TemplateLibraries)
 		err := pass.Run(ctx)
 		if err != nil {
 			return fmt.Errorf("services: %w", err)
@@ -98,7 +103,7 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 		filenames = append(filenames, pass.Filenames...)
 	}
 	if c.Types != nil {
-		pass := render.NewPass(c.dir, batch.Types(), c.Types)
+		pass := render.NewPass(c.dir, batch.Types(), c.Types, c.TemplateLibraries)
 		err := pass.Run(ctx)
 		if err != nil {
 			return fmt.Errorf("types: %w", err)
@@ -106,7 +111,7 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 		filenames = append(filenames, pass.Filenames...)
 	}
 	if c.Examples != nil && suite != nil {
-		pass := render.NewPass(c.dir, suite.ServicesExamples(), c.Examples)
+		pass := render.NewPass(c.dir, suite.ServicesExamples(), c.Examples, c.TemplateLibraries)
 		err := pass.Run(ctx)
 		if err != nil {
 			return fmt.Errorf("examples: %w", err)
@@ -114,7 +119,7 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 		filenames = append(filenames, pass.Filenames...)
 	}
 	if c.Samples != nil && suite != nil {
-		pass := render.NewPass(c.dir, suite.Samples(), c.Samples)
+		pass := render.NewPass(c.dir, suite.Samples(), c.Samples, c.TemplateLibraries)
 		err := pass.Run(ctx)
 		if err != nil {
 			return fmt.Errorf("examples: %w", err)

--- a/openapi/render/render.go
+++ b/openapi/render/render.go
@@ -46,7 +46,7 @@ func Config() (toolConfig, error) {
 	return cfg, nil
 }
 
-func NewPass[T Named](target string, items []T, fileset map[string]string) *pass[T] {
+func NewPass[T Named](target string, items []T, fileset map[string]string, libs []string) *pass[T] {
 	var tmpls []string
 	newFileset := map[string]string{}
 	for filename, v := range fileset {
@@ -54,6 +54,7 @@ func NewPass[T Named](target string, items []T, fileset map[string]string) *pass
 		tmpls = append(tmpls, filename)
 		newFileset[filepath.Base(filename)] = v
 	}
+	tmpls = append(tmpls, libs...)
 	t := template.New("codegen").Funcs(code.HelperFuncs)
 	t = t.Funcs(template.FuncMap{
 		"load": func(tmpl string) (string, error) {

--- a/openapi/roll/tool_test.go
+++ b/openapi/roll/tool_test.go
@@ -60,7 +60,7 @@ func TestRegenerateExamples(t *testing.T) {
 	target := "../.."
 	pass := render.NewPass(target, s.ServicesExamples(), map[string]string{
 		".codegen/examples_test.go.tmpl": "service/{{.Package}}/{{.SnakeName}}_usage_test.go",
-	})
+	}, []string{})
 	err = pass.Run(ctx)
 	assert.NoError(t, err)
 
@@ -77,7 +77,7 @@ func TestRegeneratePythonExamples(t *testing.T) {
 	target := "../../../databricks-sdk-py"
 	pass := render.NewPass(target, s.Samples(), map[string]string{
 		".codegen/example.py.tmpl": "examples/{{.Service.SnakeName}}/{{.Method.SnakeName}}_{{.SnakeName}}.py",
-	})
+	}, []string{})
 	err = pass.Run(ctx)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Changes
This PR adds support in the codegen utility for template libraries. These are templates that are reused across multiple stages of code generation. For example, in the Java SDK, we need to compute the type of a field/parameter/return value multiple times in different phases of the SDK. This PR allows us to define these templates a single time and reuse them across multiple files. 

## Tests
Added to the Java SDK and regenerated the SDK.
