### PR TITLE
Added log statement if OIDC response is non 200

### DIFF
--- a/config/auth_m2m.go
+++ b/config/auth_m2m.go
@@ -60,6 +60,7 @@ func oidcEndpoints(ctx context.Context, cfg *Config) (*oauthAuthorizationServer,
 		return nil, fmt.Errorf("fetch .well-known: %w", err)
 	}
 	if oidcResponse.StatusCode != 200 {
+		logger.Debugf(ctx, "Failure getting OIDC response. Response status: %s", oidcResponse.Status)
 		return nil, errOAuthNotSupported
 	}
 	if oidcResponse.Body == nil {

--- a/config/auth_m2m.go
+++ b/config/auth_m2m.go
@@ -60,7 +60,7 @@ func oidcEndpoints(ctx context.Context, cfg *Config) (*oauthAuthorizationServer,
 		return nil, fmt.Errorf("fetch .well-known: %w", err)
 	}
 	if oidcResponse.StatusCode != 200 {
-		logger.Debugf(ctx, "Failure getting OIDC response. Response status: %s", oidcResponse.Status)
+		logger.Warnf(ctx, "Failure getting OIDC response. Response status: %s", oidcResponse.Status)
 		return nil, errOAuthNotSupported
 	}
 	if oidcResponse.Body == nil {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Right now we throw the error string: `"databricks OAuth is not supported for this host"`  without information on response status.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
NA
- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

