### PR TITLE
Only log pkg.Load after checking whether the operation is tagged

### DIFF
--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -329,10 +329,10 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 	}
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {
-			logger.Infof(ctx, "pkg.Load %s %s", verb, prefix)
 			if !op.HasTag(tag.Name) {
 				continue
 			}
+			logger.Infof(ctx, "pkg.Load %s %s", verb, prefix)
 			svc, ok := pkg.services[tag.Service]
 			if !ok {
 				svc = &Service{


### PR DESCRIPTION
## Changes
Small bugfix for the OpenAPI generator logging. The generator calls the `Load` method once per tag. That method iterates through all endpoints, skipping over the endpoints that are not tagged with the provided tag. Logging was done before checking this though, producing many extraneous logs.

## Tests
Ran the generator against the CLI, producing far less noisy output.

