### PR TITLE
Prefix library paths with the target directory to construct absolute paths

### DIFF
--- a/openapi/render/render.go
+++ b/openapi/render/render.go
@@ -54,7 +54,9 @@ func NewPass[T Named](target string, items []T, fileset map[string]string, libs 
 		tmpls = append(tmpls, filename)
 		newFileset[filepath.Base(filename)] = v
 	}
-	tmpls = append(tmpls, libs...)
+	for _, lib := range libs {
+		tmpls = append(tmpls, filepath.Join(target, lib))
+	}
 	t := template.New("codegen").Funcs(code.HelperFuncs)
 	t = t.Funcs(template.FuncMap{
 		"load": func(tmpl string) (string, error) {


### PR DESCRIPTION
## Changes
The OpenAPI generator tool for Databricks recently added support for template libraries to have reusability across go templates in each SDK repo across different generation scopes (e.g. Batch/Service/Type/etc.). There is a bug that as a result causes generation to fail if CWD is not the root of the repo being generated. This PR fixes this.

## Tests
Successfully regenerated the Java SDK with CWD in a different directory. 

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

