### PR TITLE
Added CanSetRequiredFieldsFromJson method for OpenAPI generator

### DIFF
--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -179,6 +179,30 @@ func (m *Method) IsJsonOnly() bool {
 	return m.Operation.JsonOnly
 }
 
+func (m *Method) CanSetRequiredFieldsFromJson() bool {
+	// cmethod supports only JSON input
+	if m.IsJsonOnly() {
+		return true
+	}
+
+	if m.Request == nil {
+		return false
+	}
+
+	// if not all required fields are primitive, then fields should be provided in JSON
+	if !m.Request.IsAllRequiredFieldsPrimitive() {
+		return true
+	}
+
+	// if there are no required fields which are part of request body (URL, query)
+	// it can be fully set via JSON
+	if !m.Request.HasRequiredNonBodyField() {
+		return true
+	}
+
+	return false
+}
+
 func (m *Method) HasIdentifierField() bool {
 	return len(m.IdFieldPath) > 0
 }

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -179,8 +179,12 @@ func (m *Method) IsJsonOnly() bool {
 	return m.Operation.JsonOnly
 }
 
+// CanSetRequiredFieldsFromJson indicates whether we can use
+// JSON input to set all required fields for request.
+// If we can do so, it means we can ignore all positional arguments
+// passed for a certaing command and only use JSON input passed via --json flag.
 func (m *Method) CanSetRequiredFieldsFromJson() bool {
-	// cmethod supports only JSON input
+	// method supports only JSON input
 	if m.IsJsonOnly() {
 		return true
 	}


### PR DESCRIPTION
## Changes
Added CanSetRequiredFieldsFromJson method for OpenAPI generator

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- ~[ ] relevant integration tests applied~

