### PR TITLE
Add integration tests for `ServicePrincipals`: `Patch`

### DIFF
--- a/internal/scim_test.go
+++ b/internal/scim_test.go
@@ -177,6 +177,21 @@ func TestAccServicePrincipalsOnAWS(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, byId.Id, byName.Id)
 
+	err = w.ServicePrincipals.Patch(ctx, iam.PartialUpdate{
+		Id: byId.Id,
+		Operations: []iam.Patch{
+			{
+				Op:    iam.PatchOpReplace,
+				Path:  "active",
+				Value: "false",
+			},
+		},
+		Schemas: []iam.PatchSchema{
+			iam.PatchSchemaUrnIetfParamsScimApiMessages20PatchOp,
+		},
+	})
+	require.NoError(t, err)
+
 	all, err := w.ServicePrincipals.ListAll(ctx, iam.ListServicePrincipalsRequest{})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes
Add integration tests for `ServicePrincipals`: `Patch`

Solves #434

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied
