### PR TITLE
Added separate methods for required path and body parameters and added Must/CanUseJson methods

### DIFF
--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -188,7 +188,7 @@ func (e *Entity) RequiredPathFields() (fields []*Field) {
 func (e *Entity) RequiredRequestBodyFields() (fields []*Field) {
 	for _, r := range e.RequiredOrder {
 		v := e.fields[r]
-		if v.IsPath {
+		if !v.IsJson {
 			continue
 		}
 		v.Of = e
@@ -287,12 +287,11 @@ func (e *Entity) IsAllRequiredFieldsPrimitive() bool {
 }
 
 func (e *Entity) HasRequiredPathFields() bool {
-	for _, v := range e.RequiredFields() {
-		if v.IsPath {
-			return true
-		}
-	}
-	return false
+	return len(e.RequiredPathFields()) > 0
+}
+
+func (e *Entity) HasRequiredRequestBodyFields() bool {
+	return len(e.RequiredRequestBodyFields()) > 0
 }
 
 // IsPrivatePreview flags object being in private preview.

--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -173,6 +173,30 @@ func (e *Entity) RequiredFields() (fields []*Field) {
 	return
 }
 
+func (e *Entity) RequiredPathFields() (fields []*Field) {
+	for _, r := range e.RequiredOrder {
+		v := e.fields[r]
+		if !v.IsPath {
+			continue
+		}
+		v.Of = e
+		fields = append(fields, v)
+	}
+	return
+}
+
+func (e *Entity) RequiredRequestBodyFields() (fields []*Field) {
+	for _, r := range e.RequiredOrder {
+		v := e.fields[r]
+		if v.IsPath {
+			continue
+		}
+		v.Of = e
+		fields = append(fields, v)
+	}
+	return
+}
+
 func (e *Entity) NonRequiredFields() (fields []*Field) {
 	required := map[string]bool{}
 	for _, r := range e.RequiredOrder {
@@ -262,9 +286,9 @@ func (e *Entity) IsAllRequiredFieldsPrimitive() bool {
 	return true
 }
 
-func (e *Entity) HasRequiredNonBodyField() bool {
+func (e *Entity) HasRequiredPathFields() bool {
 	for _, v := range e.RequiredFields() {
-		if !v.IsJson || v.IsPath || v.IsQuery {
+		if v.IsPath {
 			return true
 		}
 	}

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -201,7 +201,7 @@ func (m *Method) MustUseJson() bool {
 // are primitives. Because such fields are not required, the command has not but
 // should support JSON input.
 func (m *Method) CanUseJson() bool {
-	return m.MustUseJson() || (m.Request != nil && !m.Request.IsOnlyPrimitiveFields())
+	return m.MustUseJson() || (m.Request != nil && m.Request.HasJsonField())
 }
 
 func (m *Method) HasIdentifierField() bool {

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -179,32 +179,29 @@ func (m *Method) IsJsonOnly() bool {
 	return m.Operation.JsonOnly
 }
 
-// CanSetRequiredFieldsFromJson indicates whether we can use
+// MustUseJson indicates whether we have to use
 // JSON input to set all required fields for request.
-// If we can do so, it means we can ignore all positional arguments
-// passed for a certaing command and only use JSON input passed via --json flag.
-func (m *Method) CanSetRequiredFieldsFromJson() bool {
+// If we can do so, it means we can only use JSON input passed via --json flag.
+func (m *Method) MustUseJson() bool {
 	// method supports only JSON input
 	if m.IsJsonOnly() {
 		return true
 	}
 
-	if m.Request == nil {
-		return false
-	}
-
 	// if not all required fields are primitive, then fields should be provided in JSON
-	if !m.Request.IsAllRequiredFieldsPrimitive() {
-		return true
-	}
-
-	// if there are no required fields which are part of request body (URL, query)
-	// it can be fully set via JSON
-	if !m.Request.HasRequiredNonBodyField() {
+	if m.Request != nil && !m.Request.IsAllRequiredFieldsPrimitive() {
 		return true
 	}
 
 	return false
+}
+
+// CanUseJson indicates whether the generated command supports --json flag.
+// It happens when either method has to use JSON input or not all fields in request
+// are primitives. Because such fields are not required, the command has not but
+// should support JSON input.
+func (m *Method) CanUseJson() bool {
+	return m.MustUseJson() || (m.Request != nil && !m.Request.IsOnlyPrimitiveFields())
 }
 
 func (m *Method) HasIdentifierField() bool {


### PR DESCRIPTION
## Changes

In attempt to simplify code generation logic (https://github.com/databricks/cli/pull/905) added separate methods for required path and body parameters and added Must/CanUseJson methods.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- ~[ ] relevant integration tests applied~

