### PR TITLE
Make sure path parameters are first in order in RequiredFields

### DIFF
--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -170,6 +170,12 @@ func (e *Entity) RequiredFields() (fields []*Field) {
 		v.Of = e
 		fields = append(fields, v)
 	}
+
+	// Path fields should always be first in required arguments order.
+	// We use stable sort to male sure we preserve the path arguments order
+	slices.SortStableFunc(fields, func(a, b *Field) bool {
+		return a.IsPath && !b.IsPath
+	})
 	return
 }
 


### PR DESCRIPTION
## Changes
Because path parameters can't be set via JSON input they can't be ooptional and therefore should be first in required fields list for generated commands

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- ~[] relevant integration tests applied~

