### PR TITLE
Skip GCP Integration Tests using Statement Execution API

### DIFF
--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -86,6 +86,9 @@ func TestUcAccVolumes(t *testing.T) {
 
 func TestUcAccTables(t *testing.T) {
 	ctx, w := ucwsTest(t)
+	if w.Config.IsGcp() {
+		t.Skip("Statement Execution API not available on GCP, skipping")
+	}
 
 	createdCatalog, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
 		Name: RandomName("catalog_"),

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -12,6 +12,9 @@ import (
 
 func TestUcAccVolumes(t *testing.T) {
 	ctx, w := ucwsTest(t)
+	if !w.Config.IsAws() {
+		skipf(t)("not on aws")
+	}
 
 	createdCatalog, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
 		Name: RandomName("catalog_"),

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -288,7 +288,7 @@ func TestUcAccMetastores(t *testing.T) {
 	_, err = w.Metastores.GetById(ctx, created.MetastoreId)
 	require.NoError(t, err)
 
-	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
+	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "DUMMY_WORKSPACE_ID"))
 
 	err = w.Metastores.Assign(ctx, catalog.CreateMetastoreAssignment{
 		MetastoreId: created.MetastoreId,
@@ -363,7 +363,7 @@ func TestUcAccCatalogWorkspaceBindings(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	thisWorkspaceID := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
+	thisWorkspaceID := MustParseInt64(GetEnvOrSkipTest(t, "DUMMY_WORKSPACE_ID"))
 	_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
 		Name:             created.Name,
 		AssignWorkspaces: []int64{thisWorkspaceID},

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -87,7 +87,7 @@ func TestUcAccVolumes(t *testing.T) {
 func TestUcAccTables(t *testing.T) {
 	ctx, w := ucwsTest(t)
 	if w.Config.IsGcp() {
-		t.Skip("Statement Execution API not available on GCP, skipping")
+		skipf(t)("Statement Execution API not available on GCP, skipping")
 	}
 
 	createdCatalog, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -360,7 +360,7 @@ func TestUcAccCatalogWorkspaceBindings(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	thisWorkspaceID := MustParseInt64(GetEnvOrSkipTest(t, "THIS_WORKSPACE_ID"))
+	thisWorkspaceID := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
 	_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
 		Name:             created.Name,
 		AssignWorkspaces: []int64{thisWorkspaceID},

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -363,7 +363,7 @@ func TestUcAccCatalogWorkspaceBindings(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	thisWorkspaceID := MustParseInt64(GetEnvOrSkipTest(t, "DUMMY_WORKSPACE_ID"))
+	thisWorkspaceID := MustParseInt64(GetEnvOrSkipTest(t, "THIS_WORKSPACE_ID"))
 	_, err = w.WorkspaceBindings.Update(ctx, catalog.UpdateWorkspaceBindings{
 		Name:             created.Name,
 		AssignWorkspaces: []int64{thisWorkspaceID},

--- a/internal/permissions_test.go
+++ b/internal/permissions_test.go
@@ -67,7 +67,7 @@ func TestUcAccWorkspaceAssignmentOnAws(t *testing.T) {
 	if !a.Config.IsAws() {
 		t.SkipNow()
 	}
-	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
+	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "DUMMY_WORKSPACE_ID"))
 
 	spn, err := a.ServicePrincipals.Create(ctx, iam.ServicePrincipal{
 		DisplayName: RandomName("sdk-go-"),

--- a/internal/sharing_test.go
+++ b/internal/sharing_test.go
@@ -128,6 +128,9 @@ func TestUcAccRecipients(t *testing.T) {
 
 func TestUcAccShares(t *testing.T) {
 	ctx, w := ucwsTest(t)
+	if w.Config.IsGcp() {
+		t.Skip("Statement Execution API not available on GCP, skipping")
+	}
 
 	createdCatalog, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{
 		Name: RandomName("catalog_"),

--- a/internal/sharing_test.go
+++ b/internal/sharing_test.go
@@ -129,7 +129,7 @@ func TestUcAccRecipients(t *testing.T) {
 func TestUcAccShares(t *testing.T) {
 	ctx, w := ucwsTest(t)
 	if w.Config.IsGcp() {
-		t.Skip("Statement Execution API not available on GCP, skipping")
+		skipf(t)("Statement Execution API not available on GCP, skipping")
 	}
 
 	createdCatalog, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{

--- a/service/catalog/metastores_usage_test.go
+++ b/service/catalog/metastores_usage_test.go
@@ -28,7 +28,7 @@ func ExampleMetastoresAPI_Assign_metastores() {
 			panic(fmt.Sprintf("`%s` is not int64: %s", v, err))
 		}
 		return i
-	}(os.Getenv("TEST_WORKSPACE_ID"))
+	}(os.Getenv("DUMMY_WORKSPACE_ID"))
 
 	created, err := w.Metastores.Create(ctx, catalog.CreateMetastore{
 		Name:        fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
@@ -215,7 +215,7 @@ func ExampleMetastoresAPI_Unassign_metastores() {
 			panic(fmt.Sprintf("`%s` is not int64: %s", v, err))
 		}
 		return i
-	}(os.Getenv("TEST_WORKSPACE_ID"))
+	}(os.Getenv("DUMMY_WORKSPACE_ID"))
 
 	created, err := w.Metastores.Create(ctx, catalog.CreateMetastore{
 		Name:        fmt.Sprintf("sdk-%x", time.Now().UnixNano()),

--- a/service/iam/workspace_assignment_usage_test.go
+++ b/service/iam/workspace_assignment_usage_test.go
@@ -28,7 +28,7 @@ func ExampleWorkspaceAssignmentAPI_ListAll_workspaceAssignmentOnAws() {
 			panic(fmt.Sprintf("`%s` is not int64: %s", v, err))
 		}
 		return i
-	}(os.Getenv("TEST_WORKSPACE_ID"))
+	}(os.Getenv("DUMMY_WORKSPACE_ID"))
 
 	all, err := a.WorkspaceAssignment.ListByWorkspaceId(ctx, workspaceId)
 	if err != nil {
@@ -67,7 +67,7 @@ func ExampleWorkspaceAssignmentAPI_Update_workspaceAssignmentOnAws() {
 			panic(fmt.Sprintf("`%s` is not int64: %s", v, err))
 		}
 		return i
-	}(os.Getenv("TEST_WORKSPACE_ID"))
+	}(os.Getenv("DUMMY_WORKSPACE_ID"))
 
 	err = a.WorkspaceAssignment.Update(ctx, iam.UpdateWorkspaceAssignments{
 		WorkspaceId: workspaceId,


### PR DESCRIPTION
## Changes
Statement Execution API is not supported in GCP, so we must skip any integration tests in GCP that use this API.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

