### PR TITLE
Added `contains` method in OpenAPI Generator

### DIFF
--- a/openapi/code/tmpl_util_funcs.go
+++ b/openapi/code/tmpl_util_funcs.go
@@ -17,7 +17,8 @@ var HelperFuncs = template.FuncMap{
 	"notLast": func(idx int, a interface{}) bool {
 		return idx+1 != reflect.ValueOf(a).Len()
 	},
-	"lower": strings.ToLower,
+	"contains": strings.Contains,
+	"lower":    strings.ToLower,
 	"lowerFirst": func(s string) string {
 		return strings.ToLower(s[0:1]) + s[1:]
 	},


### PR DESCRIPTION
## Changes
Adds a new function to template generation: `contains` is simply `strings.Contains`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

