### PR TITLE
Skip recipients tests in Azure

### DIFF
--- a/internal/sharing_test.go
+++ b/internal/sharing_test.go
@@ -55,6 +55,9 @@ func TestUcAccProviders(t *testing.T) {
 // TODO: remove NoTranspile
 func TestUcAccRecipientActivationNoTranspile(t *testing.T) {
 	ctx, w := ucwsTest(t)
+	if w.Config.IsAzure() {
+		skipf(t)("temporarily skipping this test on Azure until RetrieveToken uses the same host as specified in the activation URL")
+	}
 
 	created, err := w.Recipients.Create(ctx, sharing.CreateRecipient{
 		Name:               RandomName("go-sdk-"),


### PR DESCRIPTION
## Changes
The recipient activation flow in the SDK doesn't work properly today because the API requires that this request is sent to the host specified in the activation URL of the token generated when creating the recipient. Currently, the SDK only supports using the host from the static configuration. This does work in AWS and GCP today but purely by coincidence, so for now we will stop running these tests in Azure.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

