### PR TITLE
Allow Files API tests to run in UC environments

### DIFF
--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -26,7 +26,7 @@ func (buf hashable) Hash() uint32 {
 	return h.Sum32()
 }
 
-func TestAccFilesAPI(t *testing.T) {
+func TestUcAccFilesAPI(t *testing.T) {
 	ctx, w := ucwsTest(t)
 
 	schema, err := w.Schemas.Create(ctx, catalog.CreateSchema{


### PR DESCRIPTION
## Changes
The test needs to be named TestUcAcc* to run in UC environments.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

