### PR TITLE
Update mapping for `RESOURCE_DOES_NOT_EXIST` to inherit from `NOT_FOUND` and not `BAD_REQUEST`

### DIFF
--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -22,6 +22,7 @@ var ErrorStatusCodeMapping = []ErrorMappingRule{
 
 var ErrorCodeMapping = []ErrorMappingRule{
 	{400, "INVALID_PARAMETER_VALUE", "supplied value for a parameter was invalid"},
+	{404, "RESOURCE_DOES_NOT_EXIST", "operation was performed on a resource that does not exist"},
 	{409, "ABORTED", "the operation was aborted, typically due to a concurrency issue such as a sequencer check failure"},
 	{409, "ALREADY_EXISTS", "operation was rejected due a conflict with an existing resource"},
 	{409, "RESOURCE_ALREADY_EXISTS", "operation was rejected due a conflict with an existing resource"},


### PR DESCRIPTION
Current default hierarchy is counter-intuitive:

example:
```
tests/integration/test_installation.py::test_jobs_with_no_inventory_database - databricks.sdk.errors.mapping.BadRequest: RESOURCE_DOES_NOT_EXIST: Could not find principal with name ucx_bgRu
```