### PR TITLE
Only delete git credentials created by the current test run

### DIFF
--- a/internal/git_credentials_test.go
+++ b/internal/git_credentials_test.go
@@ -11,13 +11,6 @@ import (
 func TestAccGitCredentials(t *testing.T) {
 	ctx, w := workspaceTest(t)
 
-	list, err := w.GitCredentials.ListAll(ctx)
-	require.NoError(t, err)
-	for _, v := range list {
-		err = w.GitCredentials.DeleteByCredentialId(ctx, v.CredentialId)
-		require.NoError(t, err)
-	}
-
 	cr, err := w.GitCredentials.Create(ctx, workspace.CreateCredentials{
 		GitProvider:         "gitHub",
 		GitUsername:         "test",
@@ -28,6 +21,10 @@ func TestAccGitCredentials(t *testing.T) {
 		err = w.GitCredentials.DeleteByCredentialId(ctx, cr.CredentialId)
 		require.NoError(t, err)
 	})
+
+	list, err := w.GitCredentials.ListAll(ctx)
+	require.NoError(t, err)
+	assert.True(t, len(list) >= 1)
 
 	err = w.GitCredentials.Update(ctx, workspace.UpdateCredentials{
 		CredentialId:        cr.CredentialId,


### PR DESCRIPTION
## Changes
If `TestAccGitCredentials` runs twice in parallel, the credentials created by one test can be deleted by another run. This can happen if nightly tests run simultaneously in two Github actions. This PR changes this test to only delete credentials created by the test case itself.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

