### PR TITLE
Handle "no configuration file found at" error during databricks-cli authentication

### DIFF
--- a/config/auth_databricks_cli.go
+++ b/config/auth_databricks_cli.go
@@ -45,6 +45,11 @@ func (c DatabricksCliCredentials) Configure(ctx context.Context, cfg *Config) (f
 
 	_, err = ts.Token()
 	if err != nil {
+		if strings.Contains(err.Error(), "no configuration file found at") {
+			// databricks auth token produced this error message between
+			// v0.207.1 and v0.209.1
+			return nil, nil
+		}
 		if strings.Contains(err.Error(), "databricks OAuth is not") {
 			// OAuth is not configured or not supported
 			return nil, nil


### PR DESCRIPTION
## Changes
The CLI produced a new error message during `databricks auth token` between v0.207.1 and v0.209.1 when no .databrickscfg file exists. This manifests primarily in unit tests which call the `databricks` CLI, but could also affect users using the SDK and CLI between these versions.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

