### PR TITLE
Detect `Accept` header in `httpclient.WithResponseUnmarshal`

### DIFF
--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -61,11 +61,14 @@ func WithResponseUnmarshal(response any) DoOption {
 			}
 			switch response.(type) {
 			case *bytes.Buffer, *io.ReadCloser, *[]byte:
-				r.Header.Set("Accept", "application/octet-stream")
+				// don't send Accept header for raw types, even though we have
+				// openapi/code/method.go:440#IsResponseByteStream() setting the
+				// Accept header explicitly.
+				return nil
 			default:
 				r.Header.Set("Accept", "application/json")
+				return nil
 			}
-			return nil
 		},
 		out: func(body *responseBody) error {
 			if response == nil {

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -55,6 +55,18 @@ func WithResponseHeader(key string, value *string) DoOption {
 
 func WithResponseUnmarshal(response any) DoOption {
 	return DoOption{
+		in: func(r *http.Request) error {
+			if r.Header.Get("Accept") != "" {
+				return nil
+			}
+			switch response.(type) {
+			case *bytes.Buffer, *io.ReadCloser, *[]byte:
+				r.Header.Set("Accept", "application/octet-stream")
+			default:
+				r.Header.Set("Accept", "application/json")
+			}
+			return nil
+		},
 		out: func(body *responseBody) error {
 			if response == nil {
 				return nil


### PR DESCRIPTION
Without doing so, debug logs for HTTP fixtures are not showing bodies.

when calling APIs (AAD, ARM, ACR, ...) via `httpclient.ApiClient`, it's quite redundant to set the `Accept` header every time. This PR removes the need for such redundancy.