### PR TITLE
Detect `Content-Type` header in `newRequestBody` for `httpclient`

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -237,7 +237,7 @@ func (c *ApiClient) attempt(
 		}
 		// request.Context() holds context potentially enhanced by visitors
 		request.Header.Set("User-Agent", useragent.FromContext(request.Context()))
-		if request.Header.Get("Content-Type") != "" {
+		if request.Header.Get("Content-Type") == "" && requestBody.ContentType != "" {
 			request.Header.Set("Content-Type", requestBody.ContentType)
 		}
 

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -237,6 +237,9 @@ func (c *ApiClient) attempt(
 		}
 		// request.Context() holds context potentially enhanced by visitors
 		request.Header.Set("User-Agent", useragent.FromContext(request.Context()))
+		if request.Header.Get("Content-Type") != "" {
+			request.Header.Set("Content-Type", requestBody.ContentType)
+		}
 
 		// attempt the actual request
 		response, err := c.httpClient.Do(request)

--- a/httpclient/request.go
+++ b/httpclient/request.go
@@ -34,21 +34,18 @@ func newRequestBody(data any) (requestBody, error) {
 	switch v := data.(type) {
 	case io.Reader:
 		return requestBody{
-			Reader:      v,
-			ContentType: "application/octet-stream",
-			DebugBytes:  []byte("<io.Reader>"),
+			Reader:     v,
+			DebugBytes: []byte("<io.Reader>"),
 		}, nil
 	case string:
 		return requestBody{
-			Reader:      strings.NewReader(v),
-			ContentType: "application/octet-stream",
-			DebugBytes:  []byte(v),
+			Reader:     strings.NewReader(v),
+			DebugBytes: []byte(v),
 		}, nil
 	case []byte:
 		return requestBody{
-			Reader:      bytes.NewReader(v),
-			ContentType: "application/octet-stream",
-			DebugBytes:  v,
+			Reader:     bytes.NewReader(v),
+			DebugBytes: v,
 		}, nil
 	default:
 		bs, err := json.Marshal(data)

--- a/httpclient/request.go
+++ b/httpclient/request.go
@@ -25,26 +25,30 @@ import (
 // Request bodies are never closed by the client, hence only accepting
 // io.Reader.
 type requestBody struct {
-	Reader     io.Reader
-	DebugBytes []byte
+	Reader      io.Reader
+	ContentType string
+	DebugBytes  []byte
 }
 
 func newRequestBody(data any) (requestBody, error) {
 	switch v := data.(type) {
 	case io.Reader:
 		return requestBody{
-			Reader:     v,
-			DebugBytes: []byte("<io.Reader>"),
+			Reader:      v,
+			ContentType: "application/octet-stream",
+			DebugBytes:  []byte("<io.Reader>"),
 		}, nil
 	case string:
 		return requestBody{
-			Reader:     strings.NewReader(v),
-			DebugBytes: []byte(v),
+			Reader:      strings.NewReader(v),
+			ContentType: "application/octet-stream",
+			DebugBytes:  []byte(v),
 		}, nil
 	case []byte:
 		return requestBody{
-			Reader:     bytes.NewReader(v),
-			DebugBytes: v,
+			Reader:      bytes.NewReader(v),
+			ContentType: "application/octet-stream",
+			DebugBytes:  v,
 		}, nil
 	default:
 		bs, err := json.Marshal(data)
@@ -52,8 +56,9 @@ func newRequestBody(data any) (requestBody, error) {
 			return requestBody{}, fmt.Errorf("request marshal failure: %w", err)
 		}
 		return requestBody{
-			Reader:     bytes.NewReader(bs),
-			DebugBytes: bs,
+			Reader:      bytes.NewReader(bs),
+			ContentType: "application/json",
+			DebugBytes:  bs,
 		}, nil
 	}
 }


### PR DESCRIPTION
This PR adds implicit `Content-Type` header detection to reduce boilerplate for middle-layer HTTP client code, because we already have 100% certainty about sending `application/json`, when we call `json.Marshal`.