### PR TITLE
Trim method path suffix of redundant trailing slashes

### DIFF
--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -429,7 +429,7 @@ func (svc *Service) newMethod(verb, path string, params []openapi.Parameter, op 
 		Named:               Named{methodName, description},
 		Service:             svc,
 		Verb:                strings.ToUpper(verb),
-		Path:                path,
+		Path:                strings.TrimSuffix(path, "/"),
 		Request:             request,
 		PathParts:           svc.paramPath(path, request, params),
 		Response:            response,


### PR DESCRIPTION
## Changes
Fundamentally prevent regressions like

```
PUT /api/2.0/fs/files//Volumes/main/x/y/z
> [non-JSON document of 11 bytes]. <io.Reader>
< HTTP/2.0 400 Bad Request
< {
<   "error_code": "BAD_REQUEST",
<   "message": "Invalid path"
< }
```
