### PR TITLE
Retry request on `REQUEST_LIMIT_EXCEEDED` error returned by the SCIM API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -64,6 +64,7 @@ func New(cfg *config.Config) (*DatabricksClient, error) {
 				},
 			},
 			TransientErrors: []string{
+				"REQUEST_LIMIT_EXCEEDED", // This is temporary workaround for SCIM API returning 500.  Remove when it's fixed
 				"com.databricks.backend.manager.util.UnknownWorkerEnvironmentException",
 				"does not have any associated worker environments",
 				"There is no worker environment with id",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

In Terraform data sources for users & service principals use the SCIM List API with filter condition on user name or SP application ID. But SCIM API have relatively low concurrency limits and this lead to its overload and returning 429 to the internal backend:

```
HTTP/2.0 500 Internal Server Error
{
  "detail": "REQUEST_LIMIT_EXCEEDED: Workspace 1234 exceeded the concurrent limit of 4 requests.",
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:Error"
  ],
  "status": "500"
}
```

But on that backend the error is converted to error with status 500 that isn't retriable by default.  This PR adds a substring `REQUEST_LIMIT_EXCEEDED` into the list of transient errors so it could be retried.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

