### PR TITLE
Wrap url.Error in APIError

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -21,11 +21,6 @@ var (
 		"There is no worker environment with id",
 		"Unknown worker environment",
 		"ClusterNotReadyException",
-		"connection reset by peer",
-		"TLS handshake timeout",
-		"connection refused",
-		"Unexpected error",
-		"i/o timeout",
 	}
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -65,16 +65,6 @@ func New(cfg *config.Config) (*DatabricksClient, error) {
 			},
 			TransientErrors: []string{
 				"REQUEST_LIMIT_EXCEEDED", // This is temporary workaround for SCIM API returning 500.  Remove when it's fixed
-				"com.databricks.backend.manager.util.UnknownWorkerEnvironmentException",
-				"does not have any associated worker environments",
-				"There is no worker environment with id",
-				"Unknown worker environment",
-				"ClusterNotReadyException",
-				"connection reset by peer",
-				"TLS handshake timeout",
-				"connection refused",
-				"Unexpected error",
-				"i/o timeout",
 			},
 			ErrorMapper: apierr.GetAPIError,
 			ErrorRetriable: func(ctx context.Context, err error) bool {

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -178,8 +178,7 @@ func (c *ApiClient) isRetriable(ctx context.Context, err error) bool {
 	}); ok {
 		skipRetryOnIO = skippable.SkipRetryOnIO()
 	}
-	_, isIO := err.(*url.Error)
-	if isIO && !skipRetryOnIO {
+	if isRetriableUrlError(err) && !skipRetryOnIO {
 		// all IO errors are retriable
 		logger.Debugf(ctx, "Attempting retry because of IO error: %s", err)
 		return true


### PR DESCRIPTION
## Changes
https://github.com/databricks/databricks-sdk-go/commit/b0f3c83d9f5eca12dbd4c1daa03e06aff98a94ff introduced a regression in the handling of errors returned from HttpClient.Do. Previously, only some errors returned by Client.Do() were retried; now, all are retried. This PR adds default error handling logic in httpclient for errors returned by Client.Do() matching the previous behavior. As part of this, we remove the duplicated transient error messages between apierr and the default client.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

