### PR TITLE
Support overriding DatabricksEnvironment

### DIFF
--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -59,7 +59,7 @@ func (c AzureCliCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 		return nil, nil
 	}
 	// Eagerly get a token to fail fast in case the user is not logged in with the Azure CLI.
-	ts := &azureCliTokenSource{cfg.Environment().azureApplicationID, cfg.AzureResourceID}
+	ts := &azureCliTokenSource{cfg.Environment().AzureApplicationID, cfg.AzureResourceID}
 	t, err := ts.Token()
 	if err != nil {
 		if strings.Contains(err.Error(), "No subscription found") {

--- a/config/auth_azure_client_secret.go
+++ b/config/auth_azure_client_secret.go
@@ -53,7 +53,7 @@ func (c AzureClientSecretCredentials) Configure(ctx context.Context, cfg *Config
 	env := cfg.Environment()
 	aadEndpoint := env.AzureActiveDirectoryEndpoint()
 	managementEndpoint := env.AzureServiceManagementEndpoint()
-	inner := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, aadEndpoint, env.azureApplicationID))
+	inner := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, aadEndpoint, env.AzureApplicationID))
 	management := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, aadEndpoint, managementEndpoint))
 	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -41,7 +41,7 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 	}
 	logger.Debugf(ctx, "Generating AAD token via Azure MSI")
 	inner := azureReuseTokenSource(nil, azureMsiTokenSource{
-		resource: env.azureApplicationID,
+		resource: env.AzureApplicationID,
 		clientId: cfg.AzureClientID,
 	})
 	management := azureReuseTokenSource(nil, azureMsiTokenSource{

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -118,7 +118,7 @@ func (cf configFixture) configureProviderAndReturnConfig(t *testing.T) (*Config,
 			Cloud:              CloudAzure,
 			DnsZone:            cf.Host,
 			AzureApplicationID: "abc",
-			AzureEnvironment:   &PublicCloud,
+			AzureEnvironment:   &AzurePublicCloud,
 		}
 	}
 	err := client.Authenticate(&http.Request{Header: http.Header{}})

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -116,9 +116,9 @@ func (cf configFixture) configureProviderAndReturnConfig(t *testing.T) (*Config,
 	if client.IsAzure() {
 		client.DatabricksEnvironments = append(client.DatabricksEnvironments, DatabricksEnvironment{
 			Cloud:              CloudAzure,
-			dnsZone:            cf.Host,
-			azureApplicationID: "abc",
-			azureEnvironment:   &publicCloud,
+			DnsZone:            cf.Host,
+			AzureApplicationID: "abc",
+			AzureEnvironment:   &PublicCloud,
 		})
 	}
 	err := client.Authenticate(&http.Request{Header: http.Header{}})

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -114,12 +114,12 @@ func (cf configFixture) configureProviderAndReturnConfig(t *testing.T) (*Config,
 		AuthType:          cf.AuthType,
 	}
 	if client.IsAzure() {
-		client.DatabricksEnvironments = append(client.DatabricksEnvironments, DatabricksEnvironment{
+		client.DatabricksEnvironment = &DatabricksEnvironment{
 			Cloud:              CloudAzure,
 			DnsZone:            cf.Host,
 			AzureApplicationID: "abc",
 			AzureEnvironment:   &PublicCloud,
-		})
+		}
 	}
 	err := client.Authenticate(&http.Request{Header: http.Header{}})
 	if err != nil {

--- a/config/azure.go
+++ b/config/azure.go
@@ -18,21 +18,21 @@ type azureEnvironment struct {
 
 // based on github.com/Azure/go-autorest/autorest/azure/azureEnvironments.go
 var (
-	publicCloud = azureEnvironment{
+	PublicCloud = azureEnvironment{
 		Name:                      "PUBLIC",
 		ServiceManagementEndpoint: "https://management.core.windows.net/",
 		ResourceManagerEndpoint:   "https://management.azure.com/",
 		ActiveDirectoryEndpoint:   "https://login.microsoftonline.com/",
 	}
 
-	usGovernmentCloud = azureEnvironment{
+	UsGovernmentCloud = azureEnvironment{
 		Name:                      "USGOVERNMENT",
 		ServiceManagementEndpoint: "https://management.core.usgovcloudapi.net/",
 		ResourceManagerEndpoint:   "https://management.usgovcloudapi.net/",
 		ActiveDirectoryEndpoint:   "https://login.microsoftonline.us/",
 	}
 
-	chinaCloud = azureEnvironment{
+	ChinaCloud = azureEnvironment{
 		Name:                      "CHINA",
 		ServiceManagementEndpoint: "https://management.core.chinacloudapi.cn/",
 		ResourceManagerEndpoint:   "https://management.chinacloudapi.cn/",
@@ -48,7 +48,7 @@ func (c *Config) azureEnsureWorkspaceUrl(ctx context.Context, ahr azureHostResol
 	if c.AzureResourceID == "" || c.Host != "" {
 		return nil
 	}
-	azureEnv := c.Environment().azureEnvironment
+	azureEnv := c.Environment().AzureEnvironment
 	// azure resource ID can also be used in lieu of host by some of the clients, like Terraform
 	management := ahr.tokenSourceFor(ctx, c, azureEnv.ActiveDirectoryEndpoint, azureEnv.ResourceManagerEndpoint)
 	var workspaceMetadata struct {

--- a/config/azure.go
+++ b/config/azure.go
@@ -18,21 +18,21 @@ type azureEnvironment struct {
 
 // based on github.com/Azure/go-autorest/autorest/azure/azureEnvironments.go
 var (
-	PublicCloud = azureEnvironment{
+	AzurePublicCloud = azureEnvironment{
 		Name:                      "PUBLIC",
 		ServiceManagementEndpoint: "https://management.core.windows.net/",
 		ResourceManagerEndpoint:   "https://management.azure.com/",
 		ActiveDirectoryEndpoint:   "https://login.microsoftonline.com/",
 	}
 
-	UsGovernmentCloud = azureEnvironment{
+	AzureUsGovernmentCloud = azureEnvironment{
 		Name:                      "USGOVERNMENT",
 		ServiceManagementEndpoint: "https://management.core.usgovcloudapi.net/",
 		ResourceManagerEndpoint:   "https://management.usgovcloudapi.net/",
 		ActiveDirectoryEndpoint:   "https://login.microsoftonline.us/",
 	}
 
-	ChinaCloud = azureEnvironment{
+	AzureChinaCloud = azureEnvironment{
 		Name:                      "CHINA",
 		ServiceManagementEndpoint: "https://management.core.chinacloudapi.cn/",
 		ResourceManagerEndpoint:   "https://management.chinacloudapi.cn/",

--- a/config/config.go
+++ b/config/config.go
@@ -113,11 +113,8 @@ type Config struct {
 	// HTTPTransport can be overriden for unit testing and together with tooling like https://github.com/google/go-replayers
 	HTTPTransport http.RoundTripper
 
-	// Additional environments for use when resolving the current environment.
-	//
-	// When isTesting is true, if non-empty, the first value from this slice is returned from Environment(),
-	// regardless of the hostname.
-	DatabricksEnvironments []DatabricksEnvironment
+	// Environment override to return when resolving the current environment.
+	DatabricksEnvironment *DatabricksEnvironment
 
 	Loaders []Loader
 

--- a/config/config.go
+++ b/config/config.go
@@ -113,7 +113,10 @@ type Config struct {
 	// HTTPTransport can be overriden for unit testing and together with tooling like https://github.com/google/go-replayers
 	HTTPTransport http.RoundTripper
 
-	// Metadata about the environment, where Databricks is deployed. Reserved for internal use.
+	// Additional environments for use when resolving the current environment.
+	//
+	// When isTesting is true, if non-empty, the first value from this slice is returned from Environment(),
+	// regardless of the hostname.
 	DatabricksEnvironments []DatabricksEnvironment
 
 	Loaders []Loader

--- a/config/environments.go
+++ b/config/environments.go
@@ -57,11 +57,11 @@ var envs = []DatabricksEnvironment{
 	{Cloud: CloudAWS, DnsZone: ".cloud.databricks.us"},
 	defaultEnvironment,
 
-	{Cloud: CloudAzure, DnsZone: ".dev.azuredatabricks.net", AzureApplicationID: "62a912ac-b58e-4c1d-89ea-b2dbfc7358fc", AzureEnvironment: &PublicCloud},
-	{Cloud: CloudAzure, DnsZone: ".staging.azuredatabricks.net", AzureApplicationID: "4a67d088-db5c-48f1-9ff2-0aace800ae68", AzureEnvironment: &PublicCloud},
-	{Cloud: CloudAzure, DnsZone: ".azuredatabricks.net", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &PublicCloud},
-	{Cloud: CloudAzure, DnsZone: ".databricks.azure.us", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &UsGovernmentCloud},
-	{Cloud: CloudAzure, DnsZone: ".databricks.azure.cn", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &ChinaCloud},
+	{Cloud: CloudAzure, DnsZone: ".dev.azuredatabricks.net", AzureApplicationID: "62a912ac-b58e-4c1d-89ea-b2dbfc7358fc", AzureEnvironment: &AzurePublicCloud},
+	{Cloud: CloudAzure, DnsZone: ".staging.azuredatabricks.net", AzureApplicationID: "4a67d088-db5c-48f1-9ff2-0aace800ae68", AzureEnvironment: &AzurePublicCloud},
+	{Cloud: CloudAzure, DnsZone: ".azuredatabricks.net", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &AzurePublicCloud},
+	{Cloud: CloudAzure, DnsZone: ".databricks.azure.us", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &AzureUsGovernmentCloud},
+	{Cloud: CloudAzure, DnsZone: ".databricks.azure.cn", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &AzureChinaCloud},
 
 	{Cloud: CloudGCP, DnsZone: ".dev.gcp.databricks.com"},
 	{Cloud: CloudGCP, DnsZone: ".staging.gcp.databricks.com"},

--- a/config/environments.go
+++ b/config/environments.go
@@ -8,70 +8,74 @@ import (
 type Cloud string
 
 const (
-	CloudUnspecified Cloud = "Unspecified"
-	CloudAWS         Cloud = "AWS"
-	CloudAzure       Cloud = "Azure"
-	CloudGCP         Cloud = "GCP"
+	CloudAWS   Cloud = "AWS"
+	CloudAzure Cloud = "Azure"
+	CloudGCP   Cloud = "GCP"
 )
 
 type DatabricksEnvironment struct {
 	Cloud              Cloud
-	dnsZone            string
-	azureApplicationID string
-	azureEnvironment   *azureEnvironment
+	DnsZone            string
+	AzureApplicationID string
+	AzureEnvironment   *azureEnvironment
 }
 
 func (de DatabricksEnvironment) DeploymentURL(name string) string {
-	return fmt.Sprintf("https://%s%s", name, de.dnsZone)
+	return fmt.Sprintf("https://%s%s", name, de.DnsZone)
 }
 
 func (de DatabricksEnvironment) AzureServiceManagementEndpoint() string {
-	if de.azureEnvironment == nil {
+	if de.AzureEnvironment == nil {
 		return ""
 	}
-	return de.azureEnvironment.ServiceManagementEndpoint
+	return de.AzureEnvironment.ServiceManagementEndpoint
 }
 
 func (de DatabricksEnvironment) AzureResourceManagerEndpoint() string {
-	if de.azureEnvironment == nil {
+	if de.AzureEnvironment == nil {
 		return ""
 	}
-	return de.azureEnvironment.ResourceManagerEndpoint
+	return de.AzureEnvironment.ResourceManagerEndpoint
 }
 
 func (de DatabricksEnvironment) AzureActiveDirectoryEndpoint() string {
-	if de.azureEnvironment == nil {
+	if de.AzureEnvironment == nil {
 		return ""
 	}
-	return de.azureEnvironment.ActiveDirectoryEndpoint
+	return de.AzureEnvironment.ActiveDirectoryEndpoint
 }
 
 // we default to AWS Prod environment since this case will be a hit for PVC
 var defaultEnvironment = DatabricksEnvironment{
 	Cloud:   CloudAWS,
-	dnsZone: ".cloud.databricks.com",
+	DnsZone: ".cloud.databricks.com",
 }
 
 var envs = []DatabricksEnvironment{
-	{Cloud: CloudUnspecified, dnsZone: "localhost"},
-
-	{Cloud: CloudAWS, dnsZone: ".dev.databricks.com"},
-	{Cloud: CloudAWS, dnsZone: ".staging.cloud.databricks.com"},
-	{Cloud: CloudAWS, dnsZone: ".cloud.databricks.us"},
+	{Cloud: CloudAWS, DnsZone: ".dev.databricks.com"},
+	{Cloud: CloudAWS, DnsZone: ".staging.cloud.databricks.com"},
+	{Cloud: CloudAWS, DnsZone: ".cloud.databricks.us"},
 	defaultEnvironment,
 
-	{Cloud: CloudAzure, dnsZone: ".dev.azuredatabricks.net", azureApplicationID: "62a912ac-b58e-4c1d-89ea-b2dbfc7358fc", azureEnvironment: &publicCloud},
-	{Cloud: CloudAzure, dnsZone: ".staging.azuredatabricks.net", azureApplicationID: "4a67d088-db5c-48f1-9ff2-0aace800ae68", azureEnvironment: &publicCloud},
-	{Cloud: CloudAzure, dnsZone: ".azuredatabricks.net", azureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", azureEnvironment: &publicCloud},
-	{Cloud: CloudAzure, dnsZone: ".databricks.azure.us", azureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", azureEnvironment: &usGovernmentCloud},
-	{Cloud: CloudAzure, dnsZone: ".databricks.azure.cn", azureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", azureEnvironment: &chinaCloud},
+	{Cloud: CloudAzure, DnsZone: ".dev.azuredatabricks.net", AzureApplicationID: "62a912ac-b58e-4c1d-89ea-b2dbfc7358fc", AzureEnvironment: &PublicCloud},
+	{Cloud: CloudAzure, DnsZone: ".staging.azuredatabricks.net", AzureApplicationID: "4a67d088-db5c-48f1-9ff2-0aace800ae68", AzureEnvironment: &PublicCloud},
+	{Cloud: CloudAzure, DnsZone: ".azuredatabricks.net", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &PublicCloud},
+	{Cloud: CloudAzure, DnsZone: ".databricks.azure.us", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &UsGovernmentCloud},
+	{Cloud: CloudAzure, DnsZone: ".databricks.azure.cn", AzureApplicationID: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d", AzureEnvironment: &ChinaCloud},
 
-	{Cloud: CloudGCP, dnsZone: ".dev.gcp.databricks.com"},
-	{Cloud: CloudGCP, dnsZone: ".staging.gcp.databricks.com"},
-	{Cloud: CloudGCP, dnsZone: ".gcp.databricks.com"},
+	{Cloud: CloudGCP, DnsZone: ".dev.gcp.databricks.com"},
+	{Cloud: CloudGCP, DnsZone: ".staging.gcp.databricks.com"},
+	{Cloud: CloudGCP, DnsZone: ".gcp.databricks.com"},
 }
 
 func (c *Config) Environment() DatabricksEnvironment {
+	// Under test, use the provided environment if specified. Tests may configure the client with different hostnames,
+	// like localhost, which are not resolvable to a known environment, while needing to mock a specific environment.
+	if c.isTesting {
+		if len(c.DatabricksEnvironments) > 0 {
+			return c.DatabricksEnvironments[0]
+		}
+	}
 	if c.Host == "" && c.AzureResourceID != "" {
 		// azure resource ID can also be used in lieu of host by some
 		// of the clients, like Terraform. However, in this case, the workspace
@@ -84,10 +88,10 @@ func (c *Config) Environment() DatabricksEnvironment {
 			if v.Cloud != CloudAzure {
 				continue
 			}
-			if v.azureEnvironment.Name != azureEnv {
+			if v.AzureEnvironment.Name != azureEnv {
 				continue
 			}
-			if strings.HasPrefix(v.dnsZone, ".dev") || strings.HasPrefix(v.dnsZone, ".staging") {
+			if strings.HasPrefix(v.DnsZone, ".dev") || strings.HasPrefix(v.DnsZone, ".staging") {
 				continue
 			}
 			return v
@@ -95,7 +99,7 @@ func (c *Config) Environment() DatabricksEnvironment {
 	}
 	hostname := c.CanonicalHostName()
 	for _, e := range append(c.DatabricksEnvironments, envs...) {
-		if strings.HasSuffix(hostname, e.dnsZone) {
+		if strings.HasSuffix(hostname, e.DnsZone) {
 			return e
 		}
 	}

--- a/config/environments.go
+++ b/config/environments.go
@@ -69,12 +69,10 @@ var envs = []DatabricksEnvironment{
 }
 
 func (c *Config) Environment() DatabricksEnvironment {
-	// Under test, use the provided environment if specified. Tests may configure the client with different hostnames,
+	// Use the provided environment if specified. Tests may configure the client with different hostnames,
 	// like localhost, which are not resolvable to a known environment, while needing to mock a specific environment.
-	if c.isTesting {
-		if len(c.DatabricksEnvironments) > 0 {
-			return c.DatabricksEnvironments[0]
-		}
+	if c.DatabricksEnvironment != nil {
+		return *c.DatabricksEnvironment
 	}
 	if c.Host == "" && c.AzureResourceID != "" {
 		// azure resource ID can also be used in lieu of host by some
@@ -98,7 +96,7 @@ func (c *Config) Environment() DatabricksEnvironment {
 		}
 	}
 	hostname := c.CanonicalHostName()
-	for _, e := range append(c.DatabricksEnvironments, envs...) {
+	for _, e := range envs {
 		if strings.HasSuffix(hostname, e.DnsZone) {
 			return e
 		}

--- a/config/environments_test.go
+++ b/config/environments_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverriddenEnvironmentIsReturnedInTesting(t *testing.T) {
+	c := &Config{
+		Host: "something.else",
+		DatabricksEnvironments: []DatabricksEnvironment{
+			{Cloud: CloudAzure, DnsZone: "holla"},
+		},
+	}
+	c.WithTesting()
+	assert.Equal(t, "holla", c.Environment().DnsZone)
+}
+
+func TestOverriddenEnvironmentOverrides(t *testing.T) {
+	c := &Config{
+		Host: "my.workspace.holla",
+		DatabricksEnvironments: []DatabricksEnvironment{
+			{Cloud: CloudAzure, DnsZone: "holla"},
+		},
+	}
+	assert.Equal(t, "holla", c.Environment().DnsZone)
+}
+
+func TestEnvironmentFallback(t *testing.T) {
+	c := &Config{
+		Host: "a.dev.databricks.com",
+		DatabricksEnvironments: []DatabricksEnvironment{
+			{Cloud: CloudAzure, DnsZone: "holla"},
+		},
+	}
+	assert.Equal(t, ".dev.databricks.com", c.Environment().DnsZone)
+}

--- a/config/environments_test.go
+++ b/config/environments_test.go
@@ -9,8 +9,9 @@ import (
 func TestOverriddenEnvironmentIsReturnedInTesting(t *testing.T) {
 	c := &Config{
 		Host: "something.else",
-		DatabricksEnvironments: []DatabricksEnvironment{
-			{Cloud: CloudAzure, DnsZone: "holla"},
+		DatabricksEnvironment: &DatabricksEnvironment{
+			Cloud:   CloudAzure,
+			DnsZone: "holla",
 		},
 	}
 	c.WithTesting()
@@ -20,8 +21,9 @@ func TestOverriddenEnvironmentIsReturnedInTesting(t *testing.T) {
 func TestOverriddenEnvironmentOverrides(t *testing.T) {
 	c := &Config{
 		Host: "my.workspace.holla",
-		DatabricksEnvironments: []DatabricksEnvironment{
-			{Cloud: CloudAzure, DnsZone: "holla"},
+		DatabricksEnvironment: &DatabricksEnvironment{
+			Cloud:   CloudAzure,
+			DnsZone: "holla",
 		},
 	}
 	assert.Equal(t, "holla", c.Environment().DnsZone)
@@ -30,8 +32,9 @@ func TestOverriddenEnvironmentOverrides(t *testing.T) {
 func TestEnvironmentFallback(t *testing.T) {
 	c := &Config{
 		Host: "a.dev.databricks.com",
-		DatabricksEnvironments: []DatabricksEnvironment{
-			{Cloud: CloudAzure, DnsZone: "holla"},
+		DatabricksEnvironment: &DatabricksEnvironment{
+			Cloud:   CloudAzure,
+			DnsZone: "holla",
 		},
 	}
 	assert.Equal(t, ".dev.databricks.com", c.Environment().DnsZone)

--- a/config/environments_test.go
+++ b/config/environments_test.go
@@ -6,7 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOverriddenEnvironmentIsReturnedInTesting(t *testing.T) {
+func TestDefaultEnvironmentIsReturned(t *testing.T) {
+	c := &Config{}
+	assert.Equal(t, ".cloud.databricks.com", c.Environment().DnsZone)
+}
+
+func TestOverriddenEnvironmentIsReturned(t *testing.T) {
 	c := &Config{
 		Host: "something.else",
 		DatabricksEnvironment: &DatabricksEnvironment{
@@ -14,28 +19,5 @@ func TestOverriddenEnvironmentIsReturnedInTesting(t *testing.T) {
 			DnsZone: "holla",
 		},
 	}
-	c.WithTesting()
 	assert.Equal(t, "holla", c.Environment().DnsZone)
-}
-
-func TestOverriddenEnvironmentOverrides(t *testing.T) {
-	c := &Config{
-		Host: "my.workspace.holla",
-		DatabricksEnvironment: &DatabricksEnvironment{
-			Cloud:   CloudAzure,
-			DnsZone: "holla",
-		},
-	}
-	assert.Equal(t, "holla", c.Environment().DnsZone)
-}
-
-func TestEnvironmentFallback(t *testing.T) {
-	c := &Config{
-		Host: "a.dev.databricks.com",
-		DatabricksEnvironment: &DatabricksEnvironment{
-			Cloud:   CloudAzure,
-			DnsZone: "holla",
-		},
-	}
-	assert.Equal(t, ".dev.databricks.com", c.Environment().DnsZone)
 }


### PR DESCRIPTION
## Changes
In testing scenarios when using a mock HTTP server, environment resolution will always return the AWS Prod environment, as that is the fallback. In order to mock out other environments, this PR exposes the fields of DatabricksEnvironment and the available AzureEnvironments, allowing users to configure custom environments in tests. Under test, if specified, the first value of the DatabricksEnvironments field is returned from the `Environment()` method.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

