### PR TITLE
[WIP] allow empty string in enum set methods

### DIFF
--- a/.codegen/model.go.tmpl
+++ b/.codegen/model.go.tmpl
@@ -45,7 +45,7 @@ func (f *{{.PascalName}}) String() string {
 // Set raw string value and validate it against allowed values
 func (f *{{.PascalName}}) Set(v string) error {
     switch v {
-    case {{range $i, $e := .Enum }}{{if $i}}, {{end}}`{{.Content}}`{{end}}:
+    case ``{{range $i, $e := .Enum }}, `{{.Content}}`{{end}}:
         *f = {{.PascalName}}(v)
         return nil
     default:

--- a/service/billing/model.go
+++ b/service/billing/model.go
@@ -271,7 +271,7 @@ func (f *DeliveryStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DeliveryStatus) Set(v string) error {
 	switch v {
-	case `CREATED`, `NOT_FOUND`, `SUCCEEDED`, `SYSTEM_FAILURE`, `USER_FAILURE`:
+	case ``, `CREATED`, `NOT_FOUND`, `SUCCEEDED`, `SYSTEM_FAILURE`, `USER_FAILURE`:
 		*f = DeliveryStatus(v)
 		return nil
 	default:
@@ -363,7 +363,7 @@ func (f *LogDeliveryConfigStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *LogDeliveryConfigStatus) Set(v string) error {
 	switch v {
-	case `DISABLED`, `ENABLED`:
+	case ``, `DISABLED`, `ENABLED`:
 		*f = LogDeliveryConfigStatus(v)
 		return nil
 	default:
@@ -529,7 +529,7 @@ func (f *LogType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *LogType) Set(v string) error {
 	switch v {
-	case `AUDIT_LOGS`, `BILLABLE_USAGE`:
+	case ``, `AUDIT_LOGS`, `BILLABLE_USAGE`:
 		*f = LogType(v)
 		return nil
 	default:
@@ -566,7 +566,7 @@ func (f *OutputFormat) String() string {
 // Set raw string value and validate it against allowed values
 func (f *OutputFormat) Set(v string) error {
 	switch v {
-	case `CSV`, `JSON`:
+	case ``, `CSV`, `JSON`:
 		*f = OutputFormat(v)
 		return nil
 	default:

--- a/service/catalog/model.go
+++ b/service/catalog/model.go
@@ -108,7 +108,7 @@ func (f *ArtifactType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ArtifactType) Set(v string) error {
 	switch v {
-	case `INIT_SCRIPT`, `LIBRARY_JAR`, `LIBRARY_MAVEN`:
+	case ``, `INIT_SCRIPT`, `LIBRARY_JAR`, `LIBRARY_MAVEN`:
 		*f = ArtifactType(v)
 		return nil
 	default:
@@ -287,7 +287,7 @@ func (f *CatalogInfoSecurableKind) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CatalogInfoSecurableKind) Set(v string) error {
 	switch v {
-	case `CATALOG_DELTASHARING`, `CATALOG_FOREIGN_BIGQUERY`, `CATALOG_FOREIGN_DATABRICKS`, `CATALOG_FOREIGN_MYSQL`, `CATALOG_FOREIGN_POSTGRESQL`, `CATALOG_FOREIGN_REDSHIFT`, `CATALOG_FOREIGN_SNOWFLAKE`, `CATALOG_FOREIGN_SQLDW`, `CATALOG_FOREIGN_SQLSERVER`, `CATALOG_INTERNAL`, `CATALOG_ONLINE`, `CATALOG_ONLINE_INDEX`, `CATALOG_STANDARD`, `CATALOG_SYSTEM`, `CATALOG_SYSTEM_DELTASHARING`:
+	case ``, `CATALOG_DELTASHARING`, `CATALOG_FOREIGN_BIGQUERY`, `CATALOG_FOREIGN_DATABRICKS`, `CATALOG_FOREIGN_MYSQL`, `CATALOG_FOREIGN_POSTGRESQL`, `CATALOG_FOREIGN_REDSHIFT`, `CATALOG_FOREIGN_SNOWFLAKE`, `CATALOG_FOREIGN_SQLDW`, `CATALOG_FOREIGN_SQLSERVER`, `CATALOG_INTERNAL`, `CATALOG_ONLINE`, `CATALOG_ONLINE_INDEX`, `CATALOG_STANDARD`, `CATALOG_SYSTEM`, `CATALOG_SYSTEM_DELTASHARING`:
 		*f = CatalogInfoSecurableKind(v)
 		return nil
 	default:
@@ -317,7 +317,7 @@ func (f *CatalogType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CatalogType) Set(v string) error {
 	switch v {
-	case `DELTASHARING_CATALOG`, `MANAGED_CATALOG`, `SYSTEM_CATALOG`:
+	case ``, `DELTASHARING_CATALOG`, `MANAGED_CATALOG`, `SYSTEM_CATALOG`:
 		*f = CatalogType(v)
 		return nil
 	default:
@@ -440,7 +440,7 @@ func (f *ColumnTypeName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ColumnTypeName) Set(v string) error {
 	switch v {
-	case `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TABLE_TYPE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `USER_DEFINED_TYPE`:
+	case ``, `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TABLE_TYPE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `USER_DEFINED_TYPE`:
 		*f = ColumnTypeName(v)
 		return nil
 	default:
@@ -534,7 +534,7 @@ func (f *ConnectionInfoSecurableKind) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ConnectionInfoSecurableKind) Set(v string) error {
 	switch v {
-	case `CONNECTION_BIGQUERY`, `CONNECTION_DATABRICKS`, `CONNECTION_MYSQL`, `CONNECTION_ONLINE_CATALOG`, `CONNECTION_POSTGRESQL`, `CONNECTION_REDSHIFT`, `CONNECTION_SNOWFLAKE`, `CONNECTION_SQLDW`, `CONNECTION_SQLSERVER`:
+	case ``, `CONNECTION_BIGQUERY`, `CONNECTION_DATABRICKS`, `CONNECTION_MYSQL`, `CONNECTION_ONLINE_CATALOG`, `CONNECTION_POSTGRESQL`, `CONNECTION_REDSHIFT`, `CONNECTION_SNOWFLAKE`, `CONNECTION_SQLDW`, `CONNECTION_SQLSERVER`:
 		*f = ConnectionInfoSecurableKind(v)
 		return nil
 	default:
@@ -572,7 +572,7 @@ func (f *ConnectionType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ConnectionType) Set(v string) error {
 	switch v {
-	case `DATABRICKS`, `MYSQL`, `POSTGRESQL`, `REDSHIFT`, `SNOWFLAKE`, `SQLDW`, `SQLSERVER`:
+	case ``, `DATABRICKS`, `MYSQL`, `POSTGRESQL`, `REDSHIFT`, `SNOWFLAKE`, `SQLDW`, `SQLSERVER`:
 		*f = ConnectionType(v)
 		return nil
 	default:
@@ -745,7 +745,7 @@ func (f *CreateFunctionParameterStyle) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreateFunctionParameterStyle) Set(v string) error {
 	switch v {
-	case `S`:
+	case ``, `S`:
 		*f = CreateFunctionParameterStyle(v)
 		return nil
 	default:
@@ -781,7 +781,7 @@ func (f *CreateFunctionRoutineBody) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreateFunctionRoutineBody) Set(v string) error {
 	switch v {
-	case `EXTERNAL`, `SQL`:
+	case ``, `EXTERNAL`, `SQL`:
 		*f = CreateFunctionRoutineBody(v)
 		return nil
 	default:
@@ -807,7 +807,7 @@ func (f *CreateFunctionSecurityType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreateFunctionSecurityType) Set(v string) error {
 	switch v {
-	case `DEFINER`:
+	case ``, `DEFINER`:
 		*f = CreateFunctionSecurityType(v)
 		return nil
 	default:
@@ -837,7 +837,7 @@ func (f *CreateFunctionSqlDataAccess) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreateFunctionSqlDataAccess) Set(v string) error {
 	switch v {
-	case `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`:
+	case ``, `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`:
 		*f = CreateFunctionSqlDataAccess(v)
 		return nil
 	default:
@@ -1004,7 +1004,7 @@ func (f *CredentialType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CredentialType) Set(v string) error {
 	switch v {
-	case `USERNAME_PASSWORD`:
+	case ``, `USERNAME_PASSWORD`:
 		*f = CredentialType(v)
 		return nil
 	default:
@@ -1052,7 +1052,7 @@ func (f *DataSourceFormat) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DataSourceFormat) Set(v string) error {
 	switch v {
-	case `AVRO`, `CSV`, `DELTA`, `DELTASHARING`, `JSON`, `ORC`, `PARQUET`, `TEXT`, `UNITY_CATALOG`:
+	case ``, `AVRO`, `CSV`, `DELTA`, `DELTASHARING`, `JSON`, `ORC`, `PARQUET`, `TEXT`, `UNITY_CATALOG`:
 		*f = DataSourceFormat(v)
 		return nil
 	default:
@@ -1329,7 +1329,7 @@ func (f *DisableSchemaName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DisableSchemaName) Set(v string) error {
 	switch v {
-	case `access`, `billing`, `lineage`, `operational_data`:
+	case ``, `access`, `billing`, `lineage`, `operational_data`:
 		*f = DisableSchemaName(v)
 		return nil
 	default:
@@ -1386,7 +1386,7 @@ func (f *EffectivePredictiveOptimizationFlagInheritedFromType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EffectivePredictiveOptimizationFlagInheritedFromType) Set(v string) error {
 	switch v {
-	case `CATALOG`, `SCHEMA`:
+	case ``, `CATALOG`, `SCHEMA`:
 		*f = EffectivePredictiveOptimizationFlagInheritedFromType(v)
 		return nil
 	default:
@@ -1458,7 +1458,7 @@ func (f *EnablePredictiveOptimization) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EnablePredictiveOptimization) Set(v string) error {
 	switch v {
-	case `DISABLE`, `ENABLE`, `INHERIT`:
+	case ``, `DISABLE`, `ENABLE`, `INHERIT`:
 		*f = EnablePredictiveOptimization(v)
 		return nil
 	default:
@@ -1497,7 +1497,7 @@ func (f *EnableSchemaName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EnableSchemaName) Set(v string) error {
 	switch v {
-	case `access`, `billing`, `lineage`, `operational_data`:
+	case ``, `access`, `billing`, `lineage`, `operational_data`:
 		*f = EnableSchemaName(v)
 		return nil
 	default:
@@ -1665,7 +1665,7 @@ func (f *FunctionInfoParameterStyle) String() string {
 // Set raw string value and validate it against allowed values
 func (f *FunctionInfoParameterStyle) Set(v string) error {
 	switch v {
-	case `S`:
+	case ``, `S`:
 		*f = FunctionInfoParameterStyle(v)
 		return nil
 	default:
@@ -1696,7 +1696,7 @@ func (f *FunctionInfoRoutineBody) String() string {
 // Set raw string value and validate it against allowed values
 func (f *FunctionInfoRoutineBody) Set(v string) error {
 	switch v {
-	case `EXTERNAL`, `SQL`:
+	case ``, `EXTERNAL`, `SQL`:
 		*f = FunctionInfoRoutineBody(v)
 		return nil
 	default:
@@ -1722,7 +1722,7 @@ func (f *FunctionInfoSecurityType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *FunctionInfoSecurityType) Set(v string) error {
 	switch v {
-	case `DEFINER`:
+	case ``, `DEFINER`:
 		*f = FunctionInfoSecurityType(v)
 		return nil
 	default:
@@ -1752,7 +1752,7 @@ func (f *FunctionInfoSqlDataAccess) String() string {
 // Set raw string value and validate it against allowed values
 func (f *FunctionInfoSqlDataAccess) Set(v string) error {
 	switch v {
-	case `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`:
+	case ``, `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`:
 		*f = FunctionInfoSqlDataAccess(v)
 		return nil
 	default:
@@ -1821,7 +1821,7 @@ func (f *FunctionParameterMode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *FunctionParameterMode) Set(v string) error {
 	switch v {
-	case `IN`:
+	case ``, `IN`:
 		*f = FunctionParameterMode(v)
 		return nil
 	default:
@@ -1849,7 +1849,7 @@ func (f *FunctionParameterType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *FunctionParameterType) Set(v string) error {
 	switch v {
-	case `COLUMN`, `PARAM`:
+	case ``, `COLUMN`, `PARAM`:
 		*f = FunctionParameterType(v)
 		return nil
 	default:
@@ -2044,7 +2044,7 @@ func (f *GetMetastoreSummaryResponseDeltaSharingScope) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GetMetastoreSummaryResponseDeltaSharingScope) Set(v string) error {
 	switch v {
-	case `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
+	case ``, `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
 		*f = GetMetastoreSummaryResponseDeltaSharingScope(v)
 		return nil
 	default:
@@ -2123,7 +2123,7 @@ func (f *IsolationMode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *IsolationMode) Set(v string) error {
 	switch v {
-	case `ISOLATED`, `OPEN`:
+	case ``, `ISOLATED`, `OPEN`:
 		*f = IsolationMode(v)
 		return nil
 	default:
@@ -2409,7 +2409,7 @@ func (f *MatchType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *MatchType) Set(v string) error {
 	switch v {
-	case `PREFIX_MATCH`:
+	case ``, `PREFIX_MATCH`:
 		*f = MatchType(v)
 		return nil
 	default:
@@ -2508,7 +2508,7 @@ func (f *MetastoreInfoDeltaSharingScope) String() string {
 // Set raw string value and validate it against allowed values
 func (f *MetastoreInfoDeltaSharingScope) Set(v string) error {
 	switch v {
-	case `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
+	case ``, `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
 		*f = MetastoreInfoDeltaSharingScope(v)
 		return nil
 	default:
@@ -2598,7 +2598,7 @@ func (f *ModelVersionInfoStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ModelVersionInfoStatus) Set(v string) error {
 	switch v {
-	case `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
+	case ``, `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
 		*f = ModelVersionInfoStatus(v)
 		return nil
 	default:
@@ -2739,7 +2739,7 @@ func (f *Privilege) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Privilege) Set(v string) error {
 	switch v {
-	case `ALL_PRIVILEGES`, `APPLY_TAG`, `CREATE`, `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `CREATE_EXTERNAL_VOLUME`, `CREATE_FOREIGN_CATALOG`, `CREATE_FUNCTION`, `CREATE_MANAGED_STORAGE`, `CREATE_MATERIALIZED_VIEW`, `CREATE_MODEL`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SCHEMA`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `CREATE_TABLE`, `CREATE_VIEW`, `CREATE_VOLUME`, `EXECUTE`, `MANAGE_ALLOWLIST`, `MODIFY`, `READ_FILES`, `READ_PRIVATE_FILES`, `READ_VOLUME`, `REFRESH`, `SELECT`, `SET_SHARE_PERMISSION`, `USAGE`, `USE_CATALOG`, `USE_CONNECTION`, `USE_MARKETPLACE_ASSETS`, `USE_PROVIDER`, `USE_RECIPIENT`, `USE_SCHEMA`, `USE_SHARE`, `WRITE_FILES`, `WRITE_PRIVATE_FILES`, `WRITE_VOLUME`:
+	case ``, `ALL_PRIVILEGES`, `APPLY_TAG`, `CREATE`, `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `CREATE_EXTERNAL_VOLUME`, `CREATE_FOREIGN_CATALOG`, `CREATE_FUNCTION`, `CREATE_MANAGED_STORAGE`, `CREATE_MATERIALIZED_VIEW`, `CREATE_MODEL`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SCHEMA`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `CREATE_TABLE`, `CREATE_VIEW`, `CREATE_VOLUME`, `EXECUTE`, `MANAGE_ALLOWLIST`, `MODIFY`, `READ_FILES`, `READ_PRIVATE_FILES`, `READ_VOLUME`, `REFRESH`, `SELECT`, `SET_SHARE_PERMISSION`, `USAGE`, `USE_CATALOG`, `USE_CONNECTION`, `USE_MARKETPLACE_ASSETS`, `USE_PROVIDER`, `USE_RECIPIENT`, `USE_SCHEMA`, `USE_SHARE`, `WRITE_FILES`, `WRITE_PRIVATE_FILES`, `WRITE_VOLUME`:
 		*f = Privilege(v)
 		return nil
 	default:
@@ -2797,7 +2797,7 @@ func (f *ProvisioningInfoState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ProvisioningInfoState) Set(v string) error {
 	switch v {
-	case `ACTIVE`, `DELETING`, `FAILED`, `PROVISIONING`, `STATE_UNSPECIFIED`:
+	case ``, `ACTIVE`, `DELETING`, `FAILED`, `PROVISIONING`, `STATE_UNSPECIFIED`:
 		*f = ProvisioningInfoState(v)
 		return nil
 	default:
@@ -2965,7 +2965,7 @@ func (f *SecurableType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SecurableType) Set(v string) error {
 	switch v {
-	case `catalog`, `connection`, `external_location`, `function`, `metastore`, `pipeline`, `provider`, `recipient`, `schema`, `share`, `storage_credential`, `table`, `volume`:
+	case ``, `catalog`, `connection`, `external_location`, `function`, `metastore`, `pipeline`, `provider`, `recipient`, `schema`, `share`, `storage_credential`, `table`, `volume`:
 		*f = SecurableType(v)
 		return nil
 	default:
@@ -3028,7 +3028,7 @@ func (f *SseEncryptionDetailsAlgorithm) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SseEncryptionDetailsAlgorithm) Set(v string) error {
 	switch v {
-	case `AWS_SSE_KMS`, `AWS_SSE_S3`:
+	case ``, `AWS_SSE_KMS`, `AWS_SSE_S3`:
 		*f = SseEncryptionDetailsAlgorithm(v)
 		return nil
 	default:
@@ -3125,7 +3125,7 @@ func (f *SystemSchemaInfoState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SystemSchemaInfoState) Set(v string) error {
 	switch v {
-	case `AVAILABLE`, `DISABLE_INITIALIZED`, `ENABLE_COMPLETED`, `ENABLE_INITIALIZED`, `UNAVAILABLE`:
+	case ``, `AVAILABLE`, `DISABLE_INITIALIZED`, `ENABLE_COMPLETED`, `ENABLE_INITIALIZED`, `UNAVAILABLE`:
 		*f = SystemSchemaInfoState(v)
 		return nil
 	default:
@@ -3293,7 +3293,7 @@ func (f *TableType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TableType) Set(v string) error {
 	switch v {
-	case `EXTERNAL`, `MANAGED`, `MATERIALIZED_VIEW`, `STREAMING_TABLE`, `VIEW`:
+	case ``, `EXTERNAL`, `MANAGED`, `MATERIALIZED_VIEW`, `STREAMING_TABLE`, `VIEW`:
 		*f = TableType(v)
 		return nil
 	default:
@@ -3480,7 +3480,7 @@ func (f *UpdateMetastoreDeltaSharingScope) String() string {
 // Set raw string value and validate it against allowed values
 func (f *UpdateMetastoreDeltaSharingScope) Set(v string) error {
 	switch v {
-	case `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
+	case ``, `INTERNAL`, `INTERNAL_AND_EXTERNAL`:
 		*f = UpdateMetastoreDeltaSharingScope(v)
 		return nil
 	default:
@@ -3746,7 +3746,7 @@ func (f *ValidationResultOperation) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ValidationResultOperation) Set(v string) error {
 	switch v {
-	case `DELETE`, `LIST`, `READ`, `WRITE`:
+	case ``, `DELETE`, `LIST`, `READ`, `WRITE`:
 		*f = ValidationResultOperation(v)
 		return nil
 	default:
@@ -3776,7 +3776,7 @@ func (f *ValidationResultResult) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ValidationResultResult) Set(v string) error {
 	switch v {
-	case `FAIL`, `PASS`, `SKIP`:
+	case ``, `FAIL`, `PASS`, `SKIP`:
 		*f = ValidationResultResult(v)
 		return nil
 	default:
@@ -3848,7 +3848,7 @@ func (f *VolumeType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *VolumeType) Set(v string) error {
 	switch v {
-	case `EXTERNAL`, `MANAGED`:
+	case ``, `EXTERNAL`, `MANAGED`:
 		*f = VolumeType(v)
 		return nil
 	default:
@@ -3891,7 +3891,7 @@ func (f *WorkspaceBindingBindingType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WorkspaceBindingBindingType) Set(v string) error {
 	switch v {
-	case `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`:
+	case ``, `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`:
 		*f = WorkspaceBindingBindingType(v)
 		return nil
 	default:

--- a/service/compute/model.go
+++ b/service/compute/model.go
@@ -173,7 +173,7 @@ func (f *AwsAvailability) String() string {
 // Set raw string value and validate it against allowed values
 func (f *AwsAvailability) Set(v string) error {
 	switch v {
-	case `ON_DEMAND`, `SPOT`, `SPOT_WITH_FALLBACK`:
+	case ``, `ON_DEMAND`, `SPOT`, `SPOT_WITH_FALLBACK`:
 		*f = AwsAvailability(v)
 		return nil
 	default:
@@ -241,7 +241,7 @@ func (f *AzureAvailability) String() string {
 // Set raw string value and validate it against allowed values
 func (f *AzureAvailability) Set(v string) error {
 	switch v {
-	case `ON_DEMAND_AZURE`, `SPOT_AZURE`, `SPOT_WITH_FALLBACK_AZURE`:
+	case ``, `ON_DEMAND_AZURE`, `SPOT_AZURE`, `SPOT_WITH_FALLBACK_AZURE`:
 		*f = AzureAvailability(v)
 		return nil
 	default:
@@ -314,7 +314,7 @@ func (f *CloudProviderNodeStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CloudProviderNodeStatus) Set(v string) error {
 	switch v {
-	case `NotAvailableInRegion`, `NotEnabledOnSubscription`:
+	case ``, `NotAvailableInRegion`, `NotEnabledOnSubscription`:
 		*f = CloudProviderNodeStatus(v)
 		return nil
 	default:
@@ -812,7 +812,7 @@ func (f *ClusterPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ClusterPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_ATTACH_TO`, `CAN_MANAGE`, `CAN_RESTART`:
+	case ``, `CAN_ATTACH_TO`, `CAN_MANAGE`, `CAN_RESTART`:
 		*f = ClusterPermissionLevel(v)
 		return nil
 	default:
@@ -941,7 +941,7 @@ func (f *ClusterPolicyPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ClusterPolicyPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_USE`:
+	case ``, `CAN_USE`:
 		*f = ClusterPolicyPermissionLevel(v)
 		return nil
 	default:
@@ -1049,7 +1049,7 @@ func (f *ClusterSource) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ClusterSource) Set(v string) error {
 	switch v {
-	case `API`, `JOB`, `MODELS`, `PIPELINE`, `PIPELINE_MAINTENANCE`, `SQL`, `UI`:
+	case ``, `API`, `JOB`, `MODELS`, `PIPELINE`, `PIPELINE_MAINTENANCE`, `SQL`, `UI`:
 		*f = ClusterSource(v)
 		return nil
 	default:
@@ -1263,7 +1263,7 @@ func (f *CommandStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CommandStatus) Set(v string) error {
 	switch v {
-	case `Cancelled`, `Cancelling`, `Error`, `Finished`, `Queued`, `Running`:
+	case ``, `Cancelled`, `Cancelling`, `Error`, `Finished`, `Queued`, `Running`:
 		*f = CommandStatus(v)
 		return nil
 	default:
@@ -1321,7 +1321,7 @@ func (f *ComputeSpecKind) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ComputeSpecKind) Set(v string) error {
 	switch v {
-	case `SERVERLESS_PREVIEW`:
+	case ``, `SERVERLESS_PREVIEW`:
 		*f = ComputeSpecKind(v)
 		return nil
 	default:
@@ -1350,7 +1350,7 @@ func (f *ContextStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ContextStatus) Set(v string) error {
 	switch v {
-	case `Error`, `Pending`, `Running`:
+	case ``, `Error`, `Pending`, `Running`:
 		*f = ContextStatus(v)
 		return nil
 	default:
@@ -1777,7 +1777,7 @@ func (f *DataPlaneEventDetailsEventType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DataPlaneEventDetailsEventType) Set(v string) error {
 	switch v {
-	case `NODE_BLACKLISTED`, `NODE_EXCLUDED_DECOMMISSIONED`:
+	case ``, `NODE_BLACKLISTED`, `NODE_EXCLUDED_DECOMMISSIONED`:
 		*f = DataPlaneEventDetailsEventType(v)
 		return nil
 	default:
@@ -1842,7 +1842,7 @@ func (f *DataSecurityMode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DataSecurityMode) Set(v string) error {
 	switch v {
-	case `LEGACY_PASSTHROUGH`, `LEGACY_SINGLE_USER`, `LEGACY_TABLE_ACL`, `NONE`, `SINGLE_USER`, `USER_ISOLATION`:
+	case ``, `LEGACY_PASSTHROUGH`, `LEGACY_SINGLE_USER`, `LEGACY_TABLE_ACL`, `NONE`, `SINGLE_USER`, `USER_ISOLATION`:
 		*f = DataSecurityMode(v)
 		return nil
 	default:
@@ -1962,7 +1962,7 @@ func (f *DiskTypeAzureDiskVolumeType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DiskTypeAzureDiskVolumeType) Set(v string) error {
 	switch v {
-	case `PREMIUM_LRS`, `STANDARD_LRS`:
+	case ``, `PREMIUM_LRS`, `STANDARD_LRS`:
 		*f = DiskTypeAzureDiskVolumeType(v)
 		return nil
 	default:
@@ -1989,7 +1989,7 @@ func (f *DiskTypeEbsVolumeType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DiskTypeEbsVolumeType) Set(v string) error {
 	switch v {
-	case `GENERAL_PURPOSE_SSD`, `THROUGHPUT_OPTIMIZED_HDD`:
+	case ``, `GENERAL_PURPOSE_SSD`, `THROUGHPUT_OPTIMIZED_HDD`:
 		*f = DiskTypeEbsVolumeType(v)
 		return nil
 	default:
@@ -2050,7 +2050,7 @@ func (f *EbsVolumeType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EbsVolumeType) Set(v string) error {
 	switch v {
-	case `GENERAL_PURPOSE_SSD`, `THROUGHPUT_OPTIMIZED_HDD`:
+	case ``, `GENERAL_PURPOSE_SSD`, `THROUGHPUT_OPTIMIZED_HDD`:
 		*f = EbsVolumeType(v)
 		return nil
 	default:
@@ -2389,7 +2389,7 @@ func (f *EventDetailsCause) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EventDetailsCause) Set(v string) error {
 	switch v {
-	case `AUTORECOVERY`, `AUTOSCALE`, `REPLACE_BAD_NODES`, `USER_REQUEST`:
+	case ``, `AUTORECOVERY`, `AUTOSCALE`, `REPLACE_BAD_NODES`, `USER_REQUEST`:
 		*f = EventDetailsCause(v)
 		return nil
 	default:
@@ -2462,7 +2462,7 @@ func (f *EventType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EventType) Set(v string) error {
 	switch v {
-	case `AUTOSCALING_STATS_REPORT`, `CREATING`, `DBFS_DOWN`, `DID_NOT_EXPAND_DISK`, `DRIVER_HEALTHY`, `DRIVER_NOT_RESPONDING`, `DRIVER_UNAVAILABLE`, `EDITED`, `EXPANDED_DISK`, `FAILED_TO_EXPAND_DISK`, `INIT_SCRIPTS_FINISHED`, `INIT_SCRIPTS_STARTED`, `METASTORE_DOWN`, `NODES_LOST`, `NODE_BLACKLISTED`, `NODE_EXCLUDED_DECOMMISSIONED`, `PINNED`, `RESIZING`, `RESTARTING`, `RUNNING`, `SPARK_EXCEPTION`, `STARTING`, `TERMINATING`, `UNPINNED`, `UPSIZE_COMPLETED`:
+	case ``, `AUTOSCALING_STATS_REPORT`, `CREATING`, `DBFS_DOWN`, `DID_NOT_EXPAND_DISK`, `DRIVER_HEALTHY`, `DRIVER_NOT_RESPONDING`, `DRIVER_UNAVAILABLE`, `EDITED`, `EXPANDED_DISK`, `FAILED_TO_EXPAND_DISK`, `INIT_SCRIPTS_FINISHED`, `INIT_SCRIPTS_STARTED`, `METASTORE_DOWN`, `NODES_LOST`, `NODE_BLACKLISTED`, `NODE_EXCLUDED_DECOMMISSIONED`, `PINNED`, `RESIZING`, `RESTARTING`, `RUNNING`, `SPARK_EXCEPTION`, `STARTING`, `TERMINATING`, `UNPINNED`, `UPSIZE_COMPLETED`:
 		*f = EventType(v)
 		return nil
 	default:
@@ -2525,7 +2525,7 @@ func (f *GcpAvailability) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GcpAvailability) Set(v string) error {
 	switch v {
-	case `ON_DEMAND_GCP`, `PREEMPTIBLE_GCP`, `PREEMPTIBLE_WITH_FALLBACK_GCP`:
+	case ``, `ON_DEMAND_GCP`, `PREEMPTIBLE_GCP`, `PREEMPTIBLE_WITH_FALLBACK_GCP`:
 		*f = GcpAvailability(v)
 		return nil
 	default:
@@ -2632,7 +2632,7 @@ func (f *GetEventsOrder) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GetEventsOrder) Set(v string) error {
 	switch v {
-	case `ASC`, `DESC`:
+	case ``, `ASC`, `DESC`:
 		*f = GetEventsOrder(v)
 		return nil
 	default:
@@ -2983,7 +2983,7 @@ func (f *InitScriptExecutionDetailsStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *InitScriptExecutionDetailsStatus) Set(v string) error {
 	switch v {
-	case `FAILED_EXECUTION`, `FAILED_FETCH`, `NOT_EXECUTED`, `SKIPPED`, `SUCCEEDED`, `UNKNOWN`:
+	case ``, `FAILED_EXECUTION`, `FAILED_FETCH`, `NOT_EXECUTED`, `SKIPPED`, `SUCCEEDED`, `UNKNOWN`:
 		*f = InitScriptExecutionDetailsStatus(v)
 		return nil
 	default:
@@ -3222,7 +3222,7 @@ func (f *InstancePoolAwsAttributesAvailability) String() string {
 // Set raw string value and validate it against allowed values
 func (f *InstancePoolAwsAttributesAvailability) Set(v string) error {
 	switch v {
-	case `ON_DEMAND`, `SPOT`:
+	case ``, `ON_DEMAND`, `SPOT`:
 		*f = InstancePoolAwsAttributesAvailability(v)
 		return nil
 	default:
@@ -3274,7 +3274,7 @@ func (f *InstancePoolAzureAttributesAvailability) String() string {
 // Set raw string value and validate it against allowed values
 func (f *InstancePoolAzureAttributesAvailability) Set(v string) error {
 	switch v {
-	case `ON_DEMAND_AZURE`, `SPOT_AZURE`:
+	case ``, `ON_DEMAND_AZURE`, `SPOT_AZURE`:
 		*f = InstancePoolAzureAttributesAvailability(v)
 		return nil
 	default:
@@ -3352,7 +3352,7 @@ func (f *InstancePoolPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *InstancePoolPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_ATTACH_TO`, `CAN_MANAGE`:
+	case ``, `CAN_ATTACH_TO`, `CAN_MANAGE`:
 		*f = InstancePoolPermissionLevel(v)
 		return nil
 	default:
@@ -3422,7 +3422,7 @@ func (f *InstancePoolState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *InstancePoolState) Set(v string) error {
 	switch v {
-	case `ACTIVE`, `DELETED`, `STOPPED`:
+	case ``, `ACTIVE`, `DELETED`, `STOPPED`:
 		*f = InstancePoolState(v)
 		return nil
 	default:
@@ -3511,7 +3511,7 @@ func (f *Language) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Language) Set(v string) error {
 	switch v {
-	case `python`, `scala`, `sql`:
+	case ``, `python`, `scala`, `sql`:
 		*f = Language(v)
 		return nil
 	default:
@@ -3610,7 +3610,7 @@ func (f *LibraryFullStatusStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *LibraryFullStatusStatus) Set(v string) error {
 	switch v {
-	case `FAILED`, `INSTALLED`, `INSTALLING`, `PENDING`, `RESOLVING`, `SKIPPED`, `UNINSTALL_ON_RESTART`:
+	case ``, `FAILED`, `INSTALLED`, `INSTALLING`, `PENDING`, `RESOLVING`, `SKIPPED`, `UNINSTALL_ON_RESTART`:
 		*f = LibraryFullStatusStatus(v)
 		return nil
 	default:
@@ -3753,7 +3753,7 @@ func (f *ListSortColumn) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListSortColumn) Set(v string) error {
 	switch v {
-	case `POLICY_CREATION_TIME`, `POLICY_NAME`:
+	case ``, `POLICY_CREATION_TIME`, `POLICY_NAME`:
 		*f = ListSortColumn(v)
 		return nil
 	default:
@@ -3780,7 +3780,7 @@ func (f *ListSortOrder) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListSortOrder) Set(v string) error {
 	switch v {
-	case `ASC`, `DESC`:
+	case ``, `ASC`, `DESC`:
 		*f = ListSortOrder(v)
 		return nil
 	default:
@@ -4153,7 +4153,7 @@ func (f *ResultType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ResultType) Set(v string) error {
 	switch v {
-	case `error`, `image`, `images`, `table`, `text`:
+	case ``, `error`, `image`, `images`, `table`, `text`:
 		*f = ResultType(v)
 		return nil
 	default:
@@ -4218,7 +4218,7 @@ func (f *RuntimeEngine) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RuntimeEngine) Set(v string) error {
 	switch v {
-	case `NULL`, `PHOTON`, `STANDARD`:
+	case ``, `NULL`, `PHOTON`, `STANDARD`:
 		*f = RuntimeEngine(v)
 		return nil
 	default:
@@ -4380,7 +4380,7 @@ func (f *State) String() string {
 // Set raw string value and validate it against allowed values
 func (f *State) Set(v string) error {
 	switch v {
-	case `ERROR`, `PENDING`, `RESIZING`, `RESTARTING`, `RUNNING`, `TERMINATED`, `TERMINATING`, `UNKNOWN`:
+	case ``, `ERROR`, `PENDING`, `RESIZING`, `RESTARTING`, `RUNNING`, `TERMINATED`, `TERMINATING`, `UNKNOWN`:
 		*f = State(v)
 		return nil
 	default:
@@ -4572,7 +4572,7 @@ func (f *TerminationReasonCode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TerminationReasonCode) Set(v string) error {
 	switch v {
-	case `ABUSE_DETECTED`, `ATTACH_PROJECT_FAILURE`, `AWS_AUTHORIZATION_FAILURE`, `AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE`, `AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE`, `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE`, `AWS_REQUEST_LIMIT_EXCEEDED`, `AWS_UNSUPPORTED_FAILURE`, `AZURE_BYOK_KEY_PERMISSION_FAILURE`, `AZURE_EPHEMERAL_DISK_FAILURE`, `AZURE_INVALID_DEPLOYMENT_TEMPLATE`, `AZURE_OPERATION_NOT_ALLOWED_EXCEPTION`, `AZURE_QUOTA_EXCEEDED_EXCEPTION`, `AZURE_RESOURCE_MANAGER_THROTTLING`, `AZURE_RESOURCE_PROVIDER_THROTTLING`, `AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE`, `AZURE_VM_EXTENSION_FAILURE`, `AZURE_VNET_CONFIGURATION_FAILURE`, `BOOTSTRAP_TIMEOUT`, `BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION`, `CLOUD_PROVIDER_DISK_SETUP_FAILURE`, `CLOUD_PROVIDER_LAUNCH_FAILURE`, `CLOUD_PROVIDER_RESOURCE_STOCKOUT`, `CLOUD_PROVIDER_SHUTDOWN`, `COMMUNICATION_LOST`, `CONTAINER_LAUNCH_FAILURE`, `CONTROL_PLANE_REQUEST_FAILURE`, `DATABASE_CONNECTION_FAILURE`, `DBFS_COMPONENT_UNHEALTHY`, `DOCKER_IMAGE_PULL_FAILURE`, `DRIVER_UNREACHABLE`, `DRIVER_UNRESPONSIVE`, `EXECUTION_COMPONENT_UNHEALTHY`, `GCP_QUOTA_EXCEEDED`, `GCP_SERVICE_ACCOUNT_DELETED`, `GLOBAL_INIT_SCRIPT_FAILURE`, `HIVE_METASTORE_PROVISIONING_FAILURE`, `IMAGE_PULL_PERMISSION_DENIED`, `INACTIVITY`, `INIT_SCRIPT_FAILURE`, `INSTANCE_POOL_CLUSTER_FAILURE`, `INSTANCE_UNREACHABLE`, `INTERNAL_ERROR`, `INVALID_ARGUMENT`, `INVALID_SPARK_IMAGE`, `IP_EXHAUSTION_FAILURE`, `JOB_FINISHED`, `K8S_AUTOSCALING_FAILURE`, `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`, `METASTORE_COMPONENT_UNHEALTHY`, `NEPHOS_RESOURCE_MANAGEMENT`, `NETWORK_CONFIGURATION_FAILURE`, `NFS_MOUNT_FAILURE`, `NPIP_TUNNEL_SETUP_FAILURE`, `NPIP_TUNNEL_TOKEN_FAILURE`, `REQUEST_REJECTED`, `REQUEST_THROTTLED`, `SECRET_RESOLUTION_ERROR`, `SECURITY_DAEMON_REGISTRATION_EXCEPTION`, `SELF_BOOTSTRAP_FAILURE`, `SKIPPED_SLOW_NODES`, `SLOW_IMAGE_DOWNLOAD`, `SPARK_ERROR`, `SPARK_IMAGE_DOWNLOAD_FAILURE`, `SPARK_STARTUP_FAILURE`, `SPOT_INSTANCE_TERMINATION`, `STORAGE_DOWNLOAD_FAILURE`, `STS_CLIENT_SETUP_FAILURE`, `SUBNET_EXHAUSTED_FAILURE`, `TEMPORARILY_UNAVAILABLE`, `TRIAL_EXPIRED`, `UNEXPECTED_LAUNCH_FAILURE`, `UNKNOWN`, `UNSUPPORTED_INSTANCE_TYPE`, `UPDATE_INSTANCE_PROFILE_FAILURE`, `USER_REQUEST`, `WORKER_SETUP_FAILURE`, `WORKSPACE_CANCELLED_ERROR`, `WORKSPACE_CONFIGURATION_ERROR`:
+	case ``, `ABUSE_DETECTED`, `ATTACH_PROJECT_FAILURE`, `AWS_AUTHORIZATION_FAILURE`, `AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE`, `AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE`, `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE`, `AWS_REQUEST_LIMIT_EXCEEDED`, `AWS_UNSUPPORTED_FAILURE`, `AZURE_BYOK_KEY_PERMISSION_FAILURE`, `AZURE_EPHEMERAL_DISK_FAILURE`, `AZURE_INVALID_DEPLOYMENT_TEMPLATE`, `AZURE_OPERATION_NOT_ALLOWED_EXCEPTION`, `AZURE_QUOTA_EXCEEDED_EXCEPTION`, `AZURE_RESOURCE_MANAGER_THROTTLING`, `AZURE_RESOURCE_PROVIDER_THROTTLING`, `AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE`, `AZURE_VM_EXTENSION_FAILURE`, `AZURE_VNET_CONFIGURATION_FAILURE`, `BOOTSTRAP_TIMEOUT`, `BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION`, `CLOUD_PROVIDER_DISK_SETUP_FAILURE`, `CLOUD_PROVIDER_LAUNCH_FAILURE`, `CLOUD_PROVIDER_RESOURCE_STOCKOUT`, `CLOUD_PROVIDER_SHUTDOWN`, `COMMUNICATION_LOST`, `CONTAINER_LAUNCH_FAILURE`, `CONTROL_PLANE_REQUEST_FAILURE`, `DATABASE_CONNECTION_FAILURE`, `DBFS_COMPONENT_UNHEALTHY`, `DOCKER_IMAGE_PULL_FAILURE`, `DRIVER_UNREACHABLE`, `DRIVER_UNRESPONSIVE`, `EXECUTION_COMPONENT_UNHEALTHY`, `GCP_QUOTA_EXCEEDED`, `GCP_SERVICE_ACCOUNT_DELETED`, `GLOBAL_INIT_SCRIPT_FAILURE`, `HIVE_METASTORE_PROVISIONING_FAILURE`, `IMAGE_PULL_PERMISSION_DENIED`, `INACTIVITY`, `INIT_SCRIPT_FAILURE`, `INSTANCE_POOL_CLUSTER_FAILURE`, `INSTANCE_UNREACHABLE`, `INTERNAL_ERROR`, `INVALID_ARGUMENT`, `INVALID_SPARK_IMAGE`, `IP_EXHAUSTION_FAILURE`, `JOB_FINISHED`, `K8S_AUTOSCALING_FAILURE`, `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`, `METASTORE_COMPONENT_UNHEALTHY`, `NEPHOS_RESOURCE_MANAGEMENT`, `NETWORK_CONFIGURATION_FAILURE`, `NFS_MOUNT_FAILURE`, `NPIP_TUNNEL_SETUP_FAILURE`, `NPIP_TUNNEL_TOKEN_FAILURE`, `REQUEST_REJECTED`, `REQUEST_THROTTLED`, `SECRET_RESOLUTION_ERROR`, `SECURITY_DAEMON_REGISTRATION_EXCEPTION`, `SELF_BOOTSTRAP_FAILURE`, `SKIPPED_SLOW_NODES`, `SLOW_IMAGE_DOWNLOAD`, `SPARK_ERROR`, `SPARK_IMAGE_DOWNLOAD_FAILURE`, `SPARK_STARTUP_FAILURE`, `SPOT_INSTANCE_TERMINATION`, `STORAGE_DOWNLOAD_FAILURE`, `STS_CLIENT_SETUP_FAILURE`, `SUBNET_EXHAUSTED_FAILURE`, `TEMPORARILY_UNAVAILABLE`, `TRIAL_EXPIRED`, `UNEXPECTED_LAUNCH_FAILURE`, `UNKNOWN`, `UNSUPPORTED_INSTANCE_TYPE`, `UPDATE_INSTANCE_PROFILE_FAILURE`, `USER_REQUEST`, `WORKER_SETUP_FAILURE`, `WORKSPACE_CANCELLED_ERROR`, `WORKSPACE_CONFIGURATION_ERROR`:
 		*f = TerminationReasonCode(v)
 		return nil
 	default:
@@ -4604,7 +4604,7 @@ func (f *TerminationReasonType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TerminationReasonType) Set(v string) error {
 	switch v {
-	case `CLIENT_ERROR`, `CLOUD_FAILURE`, `SERVICE_FAULT`, `SUCCESS`:
+	case ``, `CLIENT_ERROR`, `CLOUD_FAILURE`, `SERVICE_FAULT`, `SUCCESS`:
 		*f = TerminationReasonType(v)
 		return nil
 	default:

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -246,7 +246,7 @@ func (f *GetSortOrder) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GetSortOrder) Set(v string) error {
 	switch v {
-	case `ascending`, `descending`:
+	case ``, `ascending`, `descending`:
 		*f = GetSortOrder(v)
 		return nil
 	default:
@@ -322,7 +322,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 	// Container for the group identifier. Workspace local versus account.
@@ -355,7 +355,7 @@ func (f *GroupSchema) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GroupSchema) Set(v string) error {
 	switch v {
-	case `urn:ietf:params:scim:schemas:core:2.0:Group`:
+	case ``, `urn:ietf:params:scim:schemas:core:2.0:Group`:
 		*f = GroupSchema(v)
 		return nil
 	default:
@@ -541,7 +541,7 @@ func (f *ListResponseSchema) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListResponseSchema) Set(v string) error {
 	switch v {
-	case `urn:ietf:params:scim:api:messages:2.0:ListResponse`:
+	case ``, `urn:ietf:params:scim:api:messages:2.0:ListResponse`:
 		*f = ListResponseSchema(v)
 		return nil
 	default:
@@ -626,7 +626,7 @@ func (f *ListSortOrder) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListSortOrder) Set(v string) error {
 	switch v {
-	case `ascending`, `descending`:
+	case ``, `ascending`, `descending`:
 		*f = ListSortOrder(v)
 		return nil
 	default:
@@ -825,7 +825,7 @@ func (f *PasswordPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PasswordPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_USE`:
+	case ``, `CAN_USE`:
 		*f = PasswordPermissionLevel(v)
 		return nil
 	default:
@@ -912,7 +912,7 @@ func (f *PatchOp) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PatchOp) Set(v string) error {
 	switch v {
-	case `add`, `remove`, `replace`:
+	case ``, `add`, `remove`, `replace`:
 		*f = PatchOp(v)
 		return nil
 	default:
@@ -937,7 +937,7 @@ func (f *PatchSchema) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PatchSchema) Set(v string) error {
 	switch v {
-	case `urn:ietf:params:scim:api:messages:2.0:PatchOp`:
+	case ``, `urn:ietf:params:scim:api:messages:2.0:PatchOp`:
 		*f = PatchSchema(v)
 		return nil
 	default:
@@ -1033,7 +1033,7 @@ func (f *PermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_ATTACH_TO`, `CAN_BIND`, `CAN_EDIT`, `CAN_EDIT_METADATA`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_RUN`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`, `CAN_RESTART`, `CAN_RUN`, `CAN_USE`, `CAN_VIEW`, `CAN_VIEW_METADATA`, `IS_OWNER`:
+	case ``, `CAN_ATTACH_TO`, `CAN_BIND`, `CAN_EDIT`, `CAN_EDIT_METADATA`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_RUN`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`, `CAN_RESTART`, `CAN_RUN`, `CAN_USE`, `CAN_VIEW`, `CAN_VIEW_METADATA`, `IS_OWNER`:
 		*f = PermissionLevel(v)
 		return nil
 	default:
@@ -1179,7 +1179,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 	// Corresponds to AWS instance profile/arn role.
 	Roles []ComplexValue `json:"roles,omitempty"`
 	// The schema of the List response.
@@ -1208,7 +1208,7 @@ func (f *ServicePrincipalSchema) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ServicePrincipalSchema) Set(v string) error {
 	switch v {
-	case `urn:ietf:params:scim:schemas:core:2.0:ServicePrincipal`:
+	case ``, `urn:ietf:params:scim:schemas:core:2.0:ServicePrincipal`:
 		*f = ServicePrincipalSchema(v)
 		return nil
 	default:
@@ -1293,7 +1293,7 @@ func (f *UserSchema) String() string {
 // Set raw string value and validate it against allowed values
 func (f *UserSchema) Set(v string) error {
 	switch v {
-	case `urn:ietf:params:scim:schemas:core:2.0:User`:
+	case ``, `urn:ietf:params:scim:schemas:core:2.0:User`:
 		*f = UserSchema(v)
 		return nil
 	default:
@@ -1322,7 +1322,7 @@ func (f *WorkspacePermission) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WorkspacePermission) Set(v string) error {
 	switch v {
-	case `ADMIN`, `UNKNOWN`, `USER`:
+	case ``, `ADMIN`, `UNKNOWN`, `USER`:
 		*f = WorkspacePermission(v)
 		return nil
 	default:

--- a/service/jobs/model.go
+++ b/service/jobs/model.go
@@ -304,7 +304,7 @@ func (f *ConditionTaskOp) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ConditionTaskOp) Set(v string) error {
 	switch v {
-	case `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`:
+	case ``, `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`:
 		*f = ConditionTaskOp(v)
 		return nil
 	default:
@@ -455,7 +455,7 @@ func (f *CreateJobEditMode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreateJobEditMode) Set(v string) error {
 	switch v {
-	case `EDITABLE`, `UI_LOCKED`:
+	case ``, `EDITABLE`, `UI_LOCKED`:
 		*f = CreateJobEditMode(v)
 		return nil
 	default:
@@ -622,7 +622,7 @@ func (f *Format) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Format) Set(v string) error {
 	switch v {
-	case `MULTI_TASK`, `SINGLE_TASK`:
+	case ``, `MULTI_TASK`, `SINGLE_TASK`:
 		*f = Format(v)
 		return nil
 	default:
@@ -712,7 +712,7 @@ func (f *GitProvider) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GitProvider) Set(v string) error {
 	switch v {
-	case `awsCodeCommit`, `azureDevOpsServices`, `bitbucketCloud`, `bitbucketServer`, `gitHub`, `gitHubEnterprise`, `gitLab`, `gitLabEnterpriseEdition`:
+	case ``, `awsCodeCommit`, `azureDevOpsServices`, `bitbucketCloud`, `bitbucketServer`, `gitHub`, `gitHubEnterprise`, `gitLab`, `gitLabEnterpriseEdition`:
 		*f = GitProvider(v)
 		return nil
 	default:
@@ -919,7 +919,7 @@ func (f *JobDeploymentKind) String() string {
 // Set raw string value and validate it against allowed values
 func (f *JobDeploymentKind) Set(v string) error {
 	switch v {
-	case `BUNDLE`:
+	case ``, `BUNDLE`:
 		*f = JobDeploymentKind(v)
 		return nil
 	default:
@@ -1052,7 +1052,7 @@ func (f *JobPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *JobPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_MANAGE`, `CAN_MANAGE_RUN`, `CAN_VIEW`, `IS_OWNER`:
+	case ``, `CAN_MANAGE`, `CAN_MANAGE_RUN`, `CAN_VIEW`, `IS_OWNER`:
 		*f = JobPermissionLevel(v)
 		return nil
 	default:
@@ -1260,7 +1260,7 @@ func (f *JobSettingsEditMode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *JobSettingsEditMode) Set(v string) error {
 	switch v {
-	case `EDITABLE`, `UI_LOCKED`:
+	case ``, `EDITABLE`, `UI_LOCKED`:
 		*f = JobSettingsEditMode(v)
 		return nil
 	default:
@@ -1319,7 +1319,7 @@ func (f *JobSourceDirtyState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *JobSourceDirtyState) Set(v string) error {
 	switch v {
-	case `DISCONNECTED`, `NOT_SYNCED`:
+	case ``, `DISCONNECTED`, `NOT_SYNCED`:
 		*f = JobSourceDirtyState(v)
 		return nil
 	default:
@@ -1346,7 +1346,7 @@ func (f *JobsHealthMetric) String() string {
 // Set raw string value and validate it against allowed values
 func (f *JobsHealthMetric) Set(v string) error {
 	switch v {
-	case `RUN_DURATION_SECONDS`:
+	case ``, `RUN_DURATION_SECONDS`:
 		*f = JobsHealthMetric(v)
 		return nil
 	default:
@@ -1373,7 +1373,7 @@ func (f *JobsHealthOperator) String() string {
 // Set raw string value and validate it against allowed values
 func (f *JobsHealthOperator) Set(v string) error {
 	switch v {
-	case `GREATER_THAN`:
+	case ``, `GREATER_THAN`:
 		*f = JobsHealthOperator(v)
 		return nil
 	default:
@@ -1563,7 +1563,7 @@ func (f *ListRunsRunType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListRunsRunType) Set(v string) error {
 	switch v {
-	case `JOB_RUN`, `SUBMIT_RUN`, `WORKFLOW_RUN`:
+	case ``, `JOB_RUN`, `SUBMIT_RUN`, `WORKFLOW_RUN`:
 		*f = ListRunsRunType(v)
 		return nil
 	default:
@@ -1650,7 +1650,7 @@ func (f *PauseStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PauseStatus) Set(v string) error {
 	switch v {
-	case `PAUSED`, `UNPAUSED`:
+	case ``, `PAUSED`, `UNPAUSED`:
 		*f = PauseStatus(v)
 		return nil
 	default:
@@ -1770,7 +1770,7 @@ func (f *RepairHistoryItemType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RepairHistoryItemType) Set(v string) error {
 	switch v {
-	case `ORIGINAL`, `REPAIR`:
+	case ``, `ORIGINAL`, `REPAIR`:
 		*f = RepairHistoryItemType(v)
 		return nil
 	default:
@@ -2164,7 +2164,7 @@ func (f *RunConditionTaskOp) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunConditionTaskOp) Set(v string) error {
 	switch v {
-	case `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`:
+	case ``, `EQUAL_TO`, `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`, `NOT_EQUAL`:
 		*f = RunConditionTaskOp(v)
 		return nil
 	default:
@@ -2215,7 +2215,7 @@ func (f *RunIf) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunIf) Set(v string) error {
 	switch v {
-	case `ALL_DONE`, `ALL_FAILED`, `ALL_SUCCESS`, `AT_LEAST_ONE_FAILED`, `AT_LEAST_ONE_SUCCESS`, `NONE_FAILED`:
+	case ``, `ALL_DONE`, `ALL_FAILED`, `ALL_SUCCESS`, `AT_LEAST_ONE_FAILED`, `AT_LEAST_ONE_SUCCESS`, `NONE_FAILED`:
 		*f = RunIf(v)
 		return nil
 	default:
@@ -2308,7 +2308,7 @@ func (f *RunLifeCycleState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunLifeCycleState) Set(v string) error {
 	switch v {
-	case `BLOCKED`, `INTERNAL_ERROR`, `PENDING`, `QUEUED`, `RUNNING`, `SKIPPED`, `TERMINATED`, `TERMINATING`, `WAITING_FOR_RETRY`:
+	case ``, `BLOCKED`, `INTERNAL_ERROR`, `PENDING`, `QUEUED`, `RUNNING`, `SKIPPED`, `TERMINATED`, `TERMINATING`, `WAITING_FOR_RETRY`:
 		*f = RunLifeCycleState(v)
 		return nil
 	default:
@@ -2638,7 +2638,7 @@ func (f *RunResultState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunResultState) Set(v string) error {
 	switch v {
-	case `CANCELED`, `EXCLUDED`, `FAILED`, `MAXIMUM_CONCURRENT_RUNS_REACHED`, `SUCCESS`, `SUCCESS_WITH_FAILURES`, `TIMEDOUT`, `UPSTREAM_CANCELED`, `UPSTREAM_FAILED`:
+	case ``, `CANCELED`, `EXCLUDED`, `FAILED`, `MAXIMUM_CONCURRENT_RUNS_REACHED`, `SUCCESS`, `SUCCESS_WITH_FAILURES`, `TIMEDOUT`, `UPSTREAM_CANCELED`, `UPSTREAM_FAILED`:
 		*f = RunResultState(v)
 		return nil
 	default:
@@ -2847,7 +2847,7 @@ func (f *RunType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunType) Set(v string) error {
 	switch v {
-	case `JOB_RUN`, `SUBMIT_RUN`, `WORKFLOW_RUN`:
+	case ``, `JOB_RUN`, `SUBMIT_RUN`, `WORKFLOW_RUN`:
 		*f = RunType(v)
 		return nil
 	default:
@@ -2874,7 +2874,7 @@ func (f *Source) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Source) Set(v string) error {
 	switch v {
-	case `GIT`, `WORKSPACE`:
+	case ``, `GIT`, `WORKSPACE`:
 		*f = Source(v)
 		return nil
 	default:
@@ -3001,7 +3001,7 @@ func (f *SqlAlertState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SqlAlertState) Set(v string) error {
 	switch v {
-	case `OK`, `TRIGGERED`, `UNKNOWN`:
+	case ``, `OK`, `TRIGGERED`, `UNKNOWN`:
 		*f = SqlAlertState(v)
 		return nil
 	default:
@@ -3079,7 +3079,7 @@ func (f *SqlDashboardWidgetOutputStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SqlDashboardWidgetOutputStatus) Set(v string) error {
 	switch v {
-	case `CANCELLED`, `FAILED`, `PENDING`, `RUNNING`, `SUCCESS`:
+	case ``, `CANCELLED`, `FAILED`, `PENDING`, `RUNNING`, `SUCCESS`:
 		*f = SqlDashboardWidgetOutputStatus(v)
 		return nil
 	default:
@@ -3684,7 +3684,7 @@ func (f *TriggerType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TriggerType) Set(v string) error {
 	switch v {
-	case `FILE_ARRIVAL`, `ONE_TIME`, `PERIODIC`, `RETRY`, `RUN_JOB_TASK`:
+	case ``, `FILE_ARRIVAL`, `ONE_TIME`, `PERIODIC`, `RETRY`, `RUN_JOB_TASK`:
 		*f = TriggerType(v)
 		return nil
 	default:
@@ -3756,7 +3756,7 @@ func (f *ViewType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ViewType) Set(v string) error {
 	switch v {
-	case `DASHBOARD`, `NOTEBOOK`:
+	case ``, `DASHBOARD`, `NOTEBOOK`:
 		*f = ViewType(v)
 		return nil
 	default:
@@ -3790,7 +3790,7 @@ func (f *ViewsToExport) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ViewsToExport) Set(v string) error {
 	switch v {
-	case `ALL`, `CODE`, `DASHBOARDS`:
+	case ``, `ALL`, `CODE`, `DASHBOARDS`:
 		*f = ViewsToExport(v)
 		return nil
 	default:

--- a/service/ml/model.go
+++ b/service/ml/model.go
@@ -102,7 +102,7 @@ func (f *ActivityAction) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ActivityAction) Set(v string) error {
 	switch v {
-	case `APPROVE_TRANSITION_REQUEST`, `CANCEL_TRANSITION_REQUEST`, `REJECT_TRANSITION_REQUEST`:
+	case ``, `APPROVE_TRANSITION_REQUEST`, `CANCEL_TRANSITION_REQUEST`, `REJECT_TRANSITION_REQUEST`:
 		*f = ActivityAction(v)
 		return nil
 	default:
@@ -159,7 +159,7 @@ func (f *ActivityType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ActivityType) Set(v string) error {
 	switch v {
-	case `APPLIED_TRANSITION`, `APPROVED_REQUEST`, `CANCELLED_REQUEST`, `NEW_COMMENT`, `REJECTED_REQUEST`, `REQUESTED_TRANSITION`, `SYSTEM_TRANSITION`:
+	case ``, `APPLIED_TRANSITION`, `APPROVED_REQUEST`, `CANCELLED_REQUEST`, `NEW_COMMENT`, `REJECTED_REQUEST`, `REQUESTED_TRANSITION`, `SYSTEM_TRANSITION`:
 		*f = ActivityType(v)
 		return nil
 	default:
@@ -229,7 +229,7 @@ func (f *CommentActivityAction) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CommentActivityAction) Set(v string) error {
 	switch v {
-	case `DELETE_COMMENT`, `EDIT_COMMENT`:
+	case ``, `DELETE_COMMENT`, `EDIT_COMMENT`:
 		*f = CommentActivityAction(v)
 		return nil
 	default:
@@ -692,7 +692,7 @@ func (f *DeleteTransitionRequestStage) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DeleteTransitionRequestStage) Set(v string) error {
 	switch v {
-	case `Archived`, `None`, `Production`, `Staging`:
+	case ``, `Archived`, `None`, `Production`, `Staging`:
 		*f = DeleteTransitionRequestStage(v)
 		return nil
 	default:
@@ -829,7 +829,7 @@ func (f *ExperimentPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ExperimentPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_EDIT`, `CAN_MANAGE`, `CAN_READ`:
+	case ``, `CAN_EDIT`, `CAN_MANAGE`, `CAN_READ`:
 		*f = ExperimentPermissionLevel(v)
 		return nil
 	default:
@@ -1710,7 +1710,7 @@ func (f *ModelVersionStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ModelVersionStatus) Set(v string) error {
 	switch v {
-	case `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
+	case ``, `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
 		*f = ModelVersionStatus(v)
 		return nil
 	default:
@@ -1779,7 +1779,7 @@ func (f *PermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_EDIT`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`:
+	case ``, `CAN_EDIT`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`:
 		*f = PermissionLevel(v)
 		return nil
 	default:
@@ -1876,7 +1876,7 @@ func (f *RegisteredModelPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RegisteredModelPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_EDIT`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`:
+	case ``, `CAN_EDIT`, `CAN_MANAGE`, `CAN_MANAGE_PRODUCTION_VERSIONS`, `CAN_MANAGE_STAGING_VERSIONS`, `CAN_READ`:
 		*f = RegisteredModelPermissionLevel(v)
 		return nil
 	default:
@@ -2033,7 +2033,7 @@ func (f *RegistryWebhookEvent) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RegistryWebhookEvent) Set(v string) error {
 	switch v {
-	case `COMMENT_CREATED`, `MODEL_VERSION_CREATED`, `MODEL_VERSION_TAG_SET`, `MODEL_VERSION_TRANSITIONED_STAGE`, `MODEL_VERSION_TRANSITIONED_TO_ARCHIVED`, `MODEL_VERSION_TRANSITIONED_TO_PRODUCTION`, `MODEL_VERSION_TRANSITIONED_TO_STAGING`, `REGISTERED_MODEL_CREATED`, `TRANSITION_REQUEST_CREATED`, `TRANSITION_REQUEST_TO_ARCHIVED_CREATED`, `TRANSITION_REQUEST_TO_PRODUCTION_CREATED`, `TRANSITION_REQUEST_TO_STAGING_CREATED`:
+	case ``, `COMMENT_CREATED`, `MODEL_VERSION_CREATED`, `MODEL_VERSION_TAG_SET`, `MODEL_VERSION_TRANSITIONED_STAGE`, `MODEL_VERSION_TRANSITIONED_TO_ARCHIVED`, `MODEL_VERSION_TRANSITIONED_TO_PRODUCTION`, `MODEL_VERSION_TRANSITIONED_TO_STAGING`, `REGISTERED_MODEL_CREATED`, `TRANSITION_REQUEST_CREATED`, `TRANSITION_REQUEST_TO_ARCHIVED_CREATED`, `TRANSITION_REQUEST_TO_PRODUCTION_CREATED`, `TRANSITION_REQUEST_TO_STAGING_CREATED`:
 		*f = RegistryWebhookEvent(v)
 		return nil
 	default:
@@ -2074,7 +2074,7 @@ func (f *RegistryWebhookStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RegistryWebhookStatus) Set(v string) error {
 	switch v {
-	case `ACTIVE`, `DISABLED`, `TEST_MODE`:
+	case ``, `ACTIVE`, `DISABLED`, `TEST_MODE`:
 		*f = RegistryWebhookStatus(v)
 		return nil
 	default:
@@ -2265,7 +2265,7 @@ func (f *RunInfoStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunInfoStatus) Set(v string) error {
 	switch v {
-	case `FAILED`, `FINISHED`, `KILLED`, `RUNNING`, `SCHEDULED`:
+	case ``, `FAILED`, `FINISHED`, `KILLED`, `RUNNING`, `SCHEDULED`:
 		*f = RunInfoStatus(v)
 		return nil
 	default:
@@ -2364,7 +2364,7 @@ func (f *SearchExperimentsViewType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SearchExperimentsViewType) Set(v string) error {
 	switch v {
-	case `ACTIVE_ONLY`, `ALL`, `DELETED_ONLY`:
+	case ``, `ACTIVE_ONLY`, `ALL`, `DELETED_ONLY`:
 		*f = SearchExperimentsViewType(v)
 		return nil
 	default:
@@ -2541,7 +2541,7 @@ func (f *SearchRunsRunViewType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SearchRunsRunViewType) Set(v string) error {
 	switch v {
-	case `ACTIVE_ONLY`, `ALL`, `DELETED_ONLY`:
+	case ``, `ACTIVE_ONLY`, `ALL`, `DELETED_ONLY`:
 		*f = SearchRunsRunViewType(v)
 		return nil
 	default:
@@ -2652,7 +2652,7 @@ func (f *Stage) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Stage) Set(v string) error {
 	switch v {
-	case `Archived`, `None`, `Production`, `Staging`:
+	case ``, `Archived`, `None`, `Production`, `Staging`:
 		*f = Stage(v)
 		return nil
 	default:
@@ -2692,7 +2692,7 @@ func (f *Status) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Status) Set(v string) error {
 	switch v {
-	case `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
+	case ``, `FAILED_REGISTRATION`, `PENDING_REGISTRATION`, `READY`:
 		*f = Status(v)
 		return nil
 	default:
@@ -2984,7 +2984,7 @@ func (f *UpdateRunStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *UpdateRunStatus) Set(v string) error {
 	switch v {
-	case `FAILED`, `FINISHED`, `KILLED`, `RUNNING`, `SCHEDULED`:
+	case ``, `FAILED`, `FINISHED`, `KILLED`, `RUNNING`, `SCHEDULED`:
 		*f = UpdateRunStatus(v)
 		return nil
 	default:

--- a/service/ml/model_registry_usage_test.go
+++ b/service/ml/model_registry_usage_test.go
@@ -75,23 +75,6 @@ func ExampleModelRegistryAPI_CreateModel_modelVersionComments() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModel_modelVersions() {
-	ctx := context.Background()
-	w, err := databricks.NewWorkspaceClient()
-	if err != nil {
-		panic(err)
-	}
-
-	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
-		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", model)
-
-}
-
 func ExampleModelRegistryAPI_CreateModel_models() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
@@ -109,7 +92,7 @@ func ExampleModelRegistryAPI_CreateModel_models() {
 
 }
 
-func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
+func ExampleModelRegistryAPI_CreateModel_modelVersions() {
 	ctx := context.Background()
 	w, err := databricks.NewWorkspaceClient()
 	if err != nil {
@@ -123,15 +106,6 @@ func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", model)
-
-	created, err := w.ModelRegistry.CreateModelVersion(ctx, ml.CreateModelVersionRequest{
-		Name:   model.RegisteredModel.Name,
-		Source: "dbfs:/tmp",
-	})
-	if err != nil {
-		panic(err)
-	}
-	logger.Infof(ctx, "found %v", created)
 
 }
 
@@ -158,6 +132,32 @@ func ExampleModelRegistryAPI_CreateModelVersion_modelVersionComments() {
 		panic(err)
 	}
 	logger.Infof(ctx, "found %v", mv)
+
+}
+
+func ExampleModelRegistryAPI_CreateModelVersion_modelVersions() {
+	ctx := context.Background()
+	w, err := databricks.NewWorkspaceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	model, err := w.ModelRegistry.CreateModel(ctx, ml.CreateModelRequest{
+		Name: fmt.Sprintf("sdk-%x", time.Now().UnixNano()),
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", model)
+
+	created, err := w.ModelRegistry.CreateModelVersion(ctx, ml.CreateModelVersionRequest{
+		Name:   model.RegisteredModel.Name,
+		Source: "dbfs:/tmp",
+	})
+	if err != nil {
+		panic(err)
+	}
+	logger.Infof(ctx, "found %v", created)
 
 }
 

--- a/service/pipelines/model.go
+++ b/service/pipelines/model.go
@@ -223,7 +223,7 @@ func (f *EventLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EventLevel) Set(v string) error {
 	switch v {
-	case `ERROR`, `INFO`, `METRICS`, `WARN`:
+	case ``, `ERROR`, `INFO`, `METRICS`, `WARN`:
 		*f = EventLevel(v)
 		return nil
 	default:
@@ -332,7 +332,7 @@ func (f *GetPipelineResponseHealth) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GetPipelineResponseHealth) Set(v string) error {
 	switch v {
-	case `HEALTHY`, `UNHEALTHY`:
+	case ``, `HEALTHY`, `UNHEALTHY`:
 		*f = GetPipelineResponseHealth(v)
 		return nil
 	default:
@@ -526,7 +526,7 @@ func (f *MaturityLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *MaturityLevel) Set(v string) error {
 	switch v {
-	case `DEPRECATED`, `EVOLVING`, `STABLE`:
+	case ``, `DEPRECATED`, `EVOLVING`, `STABLE`:
 		*f = MaturityLevel(v)
 		return nil
 	default:
@@ -851,7 +851,7 @@ func (f *PipelinePermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PipelinePermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_MANAGE`, `CAN_RUN`, `CAN_VIEW`, `IS_OWNER`:
+	case ``, `CAN_MANAGE`, `CAN_RUN`, `CAN_VIEW`, `IS_OWNER`:
 		*f = PipelinePermissionLevel(v)
 		return nil
 	default:
@@ -986,7 +986,7 @@ func (f *PipelineState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PipelineState) Set(v string) error {
 	switch v {
-	case `DELETED`, `DEPLOYING`, `FAILED`, `IDLE`, `RECOVERING`, `RESETTING`, `RUNNING`, `STARTING`, `STOPPING`:
+	case ``, `DELETED`, `DEPLOYING`, `FAILED`, `IDLE`, `RECOVERING`, `RESETTING`, `RUNNING`, `STARTING`, `STOPPING`:
 		*f = PipelineState(v)
 		return nil
 	default:
@@ -1146,7 +1146,7 @@ func (f *StartUpdateCause) String() string {
 // Set raw string value and validate it against allowed values
 func (f *StartUpdateCause) Set(v string) error {
 	switch v {
-	case `API_CALL`, `JOB_TASK`, `RETRY_ON_FAILURE`, `SCHEMA_CHANGE`, `SERVICE_UPGRADE`, `USER_ACTION`:
+	case ``, `API_CALL`, `JOB_TASK`, `RETRY_ON_FAILURE`, `SCHEMA_CHANGE`, `SERVICE_UPGRADE`, `USER_ACTION`:
 		*f = StartUpdateCause(v)
 		return nil
 	default:
@@ -1241,7 +1241,7 @@ func (f *UpdateInfoCause) String() string {
 // Set raw string value and validate it against allowed values
 func (f *UpdateInfoCause) Set(v string) error {
 	switch v {
-	case `API_CALL`, `JOB_TASK`, `RETRY_ON_FAILURE`, `SCHEMA_CHANGE`, `SERVICE_UPGRADE`, `USER_ACTION`:
+	case ``, `API_CALL`, `JOB_TASK`, `RETRY_ON_FAILURE`, `SCHEMA_CHANGE`, `SERVICE_UPGRADE`, `USER_ACTION`:
 		*f = UpdateInfoCause(v)
 		return nil
 	default:
@@ -1287,7 +1287,7 @@ func (f *UpdateInfoState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *UpdateInfoState) Set(v string) error {
 	switch v {
-	case `CANCELED`, `COMPLETED`, `CREATED`, `FAILED`, `INITIALIZING`, `QUEUED`, `RESETTING`, `RUNNING`, `SETTING_UP_TABLES`, `STOPPING`, `WAITING_FOR_RESOURCES`:
+	case ``, `CANCELED`, `COMPLETED`, `CREATED`, `FAILED`, `INITIALIZING`, `QUEUED`, `RESETTING`, `RUNNING`, `SETTING_UP_TABLES`, `STOPPING`, `WAITING_FOR_RESOURCES`:
 		*f = UpdateInfoState(v)
 		return nil
 	default:
@@ -1350,7 +1350,7 @@ func (f *UpdateStateInfoState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *UpdateStateInfoState) Set(v string) error {
 	switch v {
-	case `CANCELED`, `COMPLETED`, `CREATED`, `FAILED`, `INITIALIZING`, `QUEUED`, `RESETTING`, `RUNNING`, `SETTING_UP_TABLES`, `STOPPING`, `WAITING_FOR_RESOURCES`:
+	case ``, `CANCELED`, `COMPLETED`, `CREATED`, `FAILED`, `INITIALIZING`, `QUEUED`, `RESETTING`, `RUNNING`, `SETTING_UP_TABLES`, `STOPPING`, `WAITING_FOR_RESOURCES`:
 		*f = UpdateStateInfoState(v)
 		return nil
 	default:

--- a/service/provisioning/model.go
+++ b/service/provisioning/model.go
@@ -422,7 +422,7 @@ func (f *EndpointUseCase) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EndpointUseCase) Set(v string) error {
 	switch v {
-	case `DATAPLANE_RELAY_ACCESS`, `WORKSPACE_ACCESS`:
+	case ``, `DATAPLANE_RELAY_ACCESS`, `WORKSPACE_ACCESS`:
 		*f = EndpointUseCase(v)
 		return nil
 	default:
@@ -457,7 +457,7 @@ func (f *ErrorType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ErrorType) Set(v string) error {
 	switch v {
-	case `credentials`, `networkAcl`, `securityGroup`, `subnet`, `vpc`:
+	case ``, `credentials`, `networkAcl`, `securityGroup`, `subnet`, `vpc`:
 		*f = ErrorType(v)
 		return nil
 	default:
@@ -661,7 +661,7 @@ func (f *GkeConfigConnectivityType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GkeConfigConnectivityType) Set(v string) error {
 	switch v {
-	case `PRIVATE_NODE_PUBLIC_MASTER`, `PUBLIC_NODE_PUBLIC_MASTER`:
+	case ``, `PRIVATE_NODE_PUBLIC_MASTER`, `PUBLIC_NODE_PUBLIC_MASTER`:
 		*f = GkeConfigConnectivityType(v)
 		return nil
 	default:
@@ -694,7 +694,7 @@ func (f *KeyUseCase) String() string {
 // Set raw string value and validate it against allowed values
 func (f *KeyUseCase) Set(v string) error {
 	switch v {
-	case `MANAGED_SERVICES`, `STORAGE`:
+	case ``, `MANAGED_SERVICES`, `STORAGE`:
 		*f = KeyUseCase(v)
 		return nil
 	default:
@@ -828,7 +828,7 @@ func (f *PricingTier) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PricingTier) Set(v string) error {
 	switch v {
-	case `COMMUNITY_EDITION`, `DEDICATED`, `ENTERPRISE`, `PREMIUM`, `STANDARD`, `UNKNOWN`:
+	case ``, `COMMUNITY_EDITION`, `DEDICATED`, `ENTERPRISE`, `PREMIUM`, `STANDARD`, `UNKNOWN`:
 		*f = PricingTier(v)
 		return nil
 	default:
@@ -861,7 +861,7 @@ func (f *PrivateAccessLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PrivateAccessLevel) Set(v string) error {
 	switch v {
-	case `ACCOUNT`, `ENDPOINT`:
+	case ``, `ACCOUNT`, `ENDPOINT`:
 		*f = PrivateAccessLevel(v)
 		return nil
 	default:
@@ -1132,7 +1132,7 @@ func (f *VpcStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *VpcStatus) Set(v string) error {
 	switch v {
-	case `BROKEN`, `UNATTACHED`, `VALID`, `WARNED`:
+	case ``, `BROKEN`, `UNATTACHED`, `VALID`, `WARNED`:
 		*f = VpcStatus(v)
 		return nil
 	default:
@@ -1160,7 +1160,7 @@ func (f *WarningType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WarningType) Set(v string) error {
 	switch v {
-	case `securityGroup`, `subnet`:
+	case ``, `securityGroup`, `subnet`:
 		*f = WarningType(v)
 		return nil
 	default:
@@ -1300,7 +1300,7 @@ func (f *WorkspaceStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WorkspaceStatus) Set(v string) error {
 	switch v {
-	case `BANNED`, `CANCELLING`, `FAILED`, `NOT_PROVISIONED`, `PROVISIONING`, `RUNNING`:
+	case ``, `BANNED`, `CANCELLING`, `FAILED`, `NOT_PROVISIONED`, `PROVISIONING`, `RUNNING`:
 		*f = WorkspaceStatus(v)
 		return nil
 	default:

--- a/service/serving/model.go
+++ b/service/serving/model.go
@@ -186,7 +186,7 @@ func (f *DeploymentStatusState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *DeploymentStatusState) Set(v string) error {
 	switch v {
-	case `DEPLOYING`, `DEPLOYMENT_STATE_UNSPECIFIED`, `FAILURE`, `SUCCESS`:
+	case ``, `DEPLOYING`, `DEPLOYMENT_STATE_UNSPECIFIED`, `FAILURE`, `SUCCESS`:
 		*f = DeploymentStatusState(v)
 		return nil
 	default:
@@ -292,7 +292,7 @@ func (f *EndpointStateConfigUpdate) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EndpointStateConfigUpdate) Set(v string) error {
 	switch v {
-	case `IN_PROGRESS`, `NOT_UPDATING`, `UPDATE_FAILED`:
+	case ``, `IN_PROGRESS`, `NOT_UPDATING`, `UPDATE_FAILED`:
 		*f = EndpointStateConfigUpdate(v)
 		return nil
 	default:
@@ -323,7 +323,7 @@ func (f *EndpointStateReady) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EndpointStateReady) Set(v string) error {
 	switch v {
-	case `NOT_READY`, `READY`:
+	case ``, `NOT_READY`, `READY`:
 		*f = EndpointStateReady(v)
 		return nil
 	default:
@@ -693,7 +693,7 @@ func (f *ServedModelStateDeployment) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ServedModelStateDeployment) Set(v string) error {
 	switch v {
-	case `DEPLOYMENT_ABORTED`, `DEPLOYMENT_CREATING`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_READY`, `DEPLOYMENT_RECOVERING`:
+	case ``, `DEPLOYMENT_ABORTED`, `DEPLOYMENT_CREATING`, `DEPLOYMENT_FAILED`, `DEPLOYMENT_READY`, `DEPLOYMENT_RECOVERING`:
 		*f = ServedModelStateDeployment(v)
 		return nil
 	default:
@@ -838,7 +838,7 @@ func (f *ServingEndpointDetailedPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ServingEndpointDetailedPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_MANAGE`, `CAN_QUERY`, `CAN_VIEW`:
+	case ``, `CAN_MANAGE`, `CAN_QUERY`, `CAN_VIEW`:
 		*f = ServingEndpointDetailedPermissionLevel(v)
 		return nil
 	default:
@@ -886,7 +886,7 @@ func (f *ServingEndpointPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ServingEndpointPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_MANAGE`, `CAN_QUERY`, `CAN_VIEW`:
+	case ``, `CAN_MANAGE`, `CAN_QUERY`, `CAN_VIEW`:
 		*f = ServingEndpointPermissionLevel(v)
 		return nil
 	default:

--- a/service/settings/model.go
+++ b/service/settings/model.go
@@ -124,7 +124,7 @@ func (f *CreatePrivateEndpointRuleRequestGroupId) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreatePrivateEndpointRuleRequestGroupId) Set(v string) error {
 	switch v {
-	case `blob`, `dfs`, `mysqlServer`, `sqlServer`:
+	case ``, `blob`, `dfs`, `mysqlServer`, `sqlServer`:
 		*f = CreatePrivateEndpointRuleRequestGroupId(v)
 		return nil
 	default:
@@ -557,7 +557,7 @@ func (f *ListType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListType) Set(v string) error {
 	switch v {
-	case `ALLOW`, `BLOCK`:
+	case ``, `ALLOW`, `BLOCK`:
 		*f = ListType(v)
 		return nil
 	default:
@@ -650,7 +650,7 @@ func (f *NccAzurePrivateEndpointRuleConnectionState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *NccAzurePrivateEndpointRuleConnectionState) Set(v string) error {
 	switch v {
-	case `DISCONNECTED`, `ESTABLISHED`, `INIT`, `PENDING`, `REJECTED`:
+	case ``, `DISCONNECTED`, `ESTABLISHED`, `INIT`, `PENDING`, `REJECTED`:
 		*f = NccAzurePrivateEndpointRuleConnectionState(v)
 		return nil
 	default:
@@ -684,7 +684,7 @@ func (f *NccAzurePrivateEndpointRuleGroupId) String() string {
 // Set raw string value and validate it against allowed values
 func (f *NccAzurePrivateEndpointRuleGroupId) Set(v string) error {
 	switch v {
-	case `blob`, `dfs`, `mysqlServer`, `sqlServer`:
+	case ``, `blob`, `dfs`, `mysqlServer`, `sqlServer`:
 		*f = NccAzurePrivateEndpointRuleGroupId(v)
 		return nil
 	default:
@@ -827,7 +827,7 @@ func (f *PersonalComputeMessageEnum) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PersonalComputeMessageEnum) Set(v string) error {
 	switch v {
-	case `DELEGATE`, `ON`:
+	case ``, `DELEGATE`, `ON`:
 		*f = PersonalComputeMessageEnum(v)
 		return nil
 	default:
@@ -1079,7 +1079,7 @@ func (f *TokenPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TokenPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_USE`:
+	case ``, `CAN_USE`:
 		*f = TokenPermissionLevel(v)
 		return nil
 	default:
@@ -1144,7 +1144,7 @@ func (f *TokenType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TokenType) Set(v string) error {
 	switch v {
-	case `AZURE_ACTIVE_DIRECTORY_TOKEN`:
+	case ``, `AZURE_ACTIVE_DIRECTORY_TOKEN`:
 		*f = TokenType(v)
 		return nil
 	default:

--- a/service/sharing/model.go
+++ b/service/sharing/model.go
@@ -26,7 +26,7 @@ func (f *AuthenticationType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *AuthenticationType) Set(v string) error {
 	switch v {
-	case `DATABRICKS`, `TOKEN`:
+	case ``, `DATABRICKS`, `TOKEN`:
 		*f = AuthenticationType(v)
 		return nil
 	default:
@@ -325,7 +325,7 @@ func (f *ColumnTypeName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ColumnTypeName) Set(v string) error {
 	switch v {
-	case `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TABLE_TYPE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `USER_DEFINED_TYPE`:
+	case ``, `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TABLE_TYPE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `USER_DEFINED_TYPE`:
 		*f = ColumnTypeName(v)
 		return nil
 	default:
@@ -658,7 +658,7 @@ func (f *PartitionValueOp) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PartitionValueOp) Set(v string) error {
 	switch v {
-	case `EQUAL`, `LIKE`:
+	case ``, `EQUAL`, `LIKE`:
 		*f = PartitionValueOp(v)
 		return nil
 	default:
@@ -763,7 +763,7 @@ func (f *Privilege) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Privilege) Set(v string) error {
 	switch v {
-	case `ALL_PRIVILEGES`, `APPLY_TAG`, `CREATE`, `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `CREATE_EXTERNAL_VOLUME`, `CREATE_FOREIGN_CATALOG`, `CREATE_FUNCTION`, `CREATE_MANAGED_STORAGE`, `CREATE_MATERIALIZED_VIEW`, `CREATE_MODEL`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SCHEMA`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `CREATE_TABLE`, `CREATE_VIEW`, `CREATE_VOLUME`, `EXECUTE`, `MANAGE_ALLOWLIST`, `MODIFY`, `READ_FILES`, `READ_PRIVATE_FILES`, `READ_VOLUME`, `REFRESH`, `SELECT`, `SET_SHARE_PERMISSION`, `USAGE`, `USE_CATALOG`, `USE_CONNECTION`, `USE_MARKETPLACE_ASSETS`, `USE_PROVIDER`, `USE_RECIPIENT`, `USE_SCHEMA`, `USE_SHARE`, `WRITE_FILES`, `WRITE_PRIVATE_FILES`, `WRITE_VOLUME`:
+	case ``, `ALL_PRIVILEGES`, `APPLY_TAG`, `CREATE`, `CREATE_CATALOG`, `CREATE_CONNECTION`, `CREATE_EXTERNAL_LOCATION`, `CREATE_EXTERNAL_TABLE`, `CREATE_EXTERNAL_VOLUME`, `CREATE_FOREIGN_CATALOG`, `CREATE_FUNCTION`, `CREATE_MANAGED_STORAGE`, `CREATE_MATERIALIZED_VIEW`, `CREATE_MODEL`, `CREATE_PROVIDER`, `CREATE_RECIPIENT`, `CREATE_SCHEMA`, `CREATE_SHARE`, `CREATE_STORAGE_CREDENTIAL`, `CREATE_TABLE`, `CREATE_VIEW`, `CREATE_VOLUME`, `EXECUTE`, `MANAGE_ALLOWLIST`, `MODIFY`, `READ_FILES`, `READ_PRIVATE_FILES`, `READ_VOLUME`, `REFRESH`, `SELECT`, `SET_SHARE_PERMISSION`, `USAGE`, `USE_CATALOG`, `USE_CONNECTION`, `USE_MARKETPLACE_ASSETS`, `USE_PROVIDER`, `USE_RECIPIENT`, `USE_SCHEMA`, `USE_SHARE`, `WRITE_FILES`, `WRITE_PRIVATE_FILES`, `WRITE_VOLUME`:
 		*f = Privilege(v)
 		return nil
 	default:
@@ -1132,7 +1132,7 @@ func (f *SharedDataObjectHistoryDataSharingStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SharedDataObjectHistoryDataSharingStatus) Set(v string) error {
 	switch v {
-	case `DISABLED`, `ENABLED`:
+	case ``, `DISABLED`, `ENABLED`:
 		*f = SharedDataObjectHistoryDataSharingStatus(v)
 		return nil
 	default:
@@ -1160,7 +1160,7 @@ func (f *SharedDataObjectStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SharedDataObjectStatus) Set(v string) error {
 	switch v {
-	case `ACTIVE`, `PERMISSION_DENIED`:
+	case ``, `ACTIVE`, `PERMISSION_DENIED`:
 		*f = SharedDataObjectStatus(v)
 		return nil
 	default:
@@ -1197,7 +1197,7 @@ func (f *SharedDataObjectUpdateAction) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SharedDataObjectUpdateAction) Set(v string) error {
 	switch v {
-	case `ADD`, `REMOVE`, `UPDATE`:
+	case ``, `ADD`, `REMOVE`, `UPDATE`:
 		*f = SharedDataObjectUpdateAction(v)
 		return nil
 	default:

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -123,7 +123,7 @@ func (f *AlertOptionsEmptyResultState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *AlertOptionsEmptyResultState) Set(v string) error {
 	switch v {
-	case `ok`, `triggered`, `unknown`:
+	case ``, `ok`, `triggered`, `unknown`:
 		*f = AlertOptionsEmptyResultState(v)
 		return nil
 	default:
@@ -204,7 +204,7 @@ func (f *AlertState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *AlertState) Set(v string) error {
 	switch v {
-	case `ok`, `triggered`, `unknown`:
+	case ``, `ok`, `triggered`, `unknown`:
 		*f = AlertState(v)
 		return nil
 	default:
@@ -300,7 +300,7 @@ func (f *ChannelName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ChannelName) Set(v string) error {
 	switch v {
-	case `CHANNEL_NAME_CURRENT`, `CHANNEL_NAME_CUSTOM`, `CHANNEL_NAME_PREVIEW`, `CHANNEL_NAME_PREVIOUS`, `CHANNEL_NAME_UNSPECIFIED`:
+	case ``, `CHANNEL_NAME_CURRENT`, `CHANNEL_NAME_CUSTOM`, `CHANNEL_NAME_PREVIEW`, `CHANNEL_NAME_PREVIOUS`, `CHANNEL_NAME_UNSPECIFIED`:
 		*f = ChannelName(v)
 		return nil
 	default:
@@ -393,7 +393,7 @@ func (f *ColumnInfoTypeName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ColumnInfoTypeName) Set(v string) error {
 	switch v {
-	case `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TIMESTAMP`, `USER_DEFINED_TYPE`:
+	case ``, `ARRAY`, `BINARY`, `BOOLEAN`, `BYTE`, `CHAR`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `INTERVAL`, `LONG`, `MAP`, `NULL`, `SHORT`, `STRING`, `STRUCT`, `TIMESTAMP`, `USER_DEFINED_TYPE`:
 		*f = ColumnInfoTypeName(v)
 		return nil
 	default:
@@ -579,7 +579,7 @@ func (f *CreateWarehouseRequestWarehouseType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *CreateWarehouseRequestWarehouseType) Set(v string) error {
 	switch v {
-	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
+	case ``, `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*f = CreateWarehouseRequestWarehouseType(v)
 		return nil
 	default:
@@ -814,7 +814,7 @@ func (f *Disposition) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Disposition) Set(v string) error {
 	switch v {
-	case `EXTERNAL_LINKS`, `INLINE`:
+	case ``, `EXTERNAL_LINKS`, `INLINE`:
 		*f = Disposition(v)
 		return nil
 	default:
@@ -944,7 +944,7 @@ func (f *EditWarehouseRequestWarehouseType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EditWarehouseRequestWarehouseType) Set(v string) error {
 	switch v {
-	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
+	case ``, `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*f = EditWarehouseRequestWarehouseType(v)
 		return nil
 	default:
@@ -1104,7 +1104,7 @@ func (f *EndpointInfoWarehouseType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *EndpointInfoWarehouseType) Set(v string) error {
 	switch v {
-	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
+	case ``, `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*f = EndpointInfoWarehouseType(v)
 		return nil
 	default:
@@ -1317,7 +1317,7 @@ func (f *ExecuteStatementRequestOnWaitTimeout) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ExecuteStatementRequestOnWaitTimeout) Set(v string) error {
 	switch v {
-	case `CANCEL`, `CONTINUE`:
+	case ``, `CANCEL`, `CONTINUE`:
 		*f = ExecuteStatementRequestOnWaitTimeout(v)
 		return nil
 	default:
@@ -1413,7 +1413,7 @@ func (f *Format) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Format) Set(v string) error {
 	switch v {
-	case `ARROW_STREAM`, `CSV`, `JSON_ARRAY`:
+	case ``, `ARROW_STREAM`, `CSV`, `JSON_ARRAY`:
 		*f = Format(v)
 		return nil
 	default:
@@ -1636,7 +1636,7 @@ func (f *GetWarehouseResponseWarehouseType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GetWarehouseResponseWarehouseType) Set(v string) error {
 	switch v {
-	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
+	case ``, `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*f = GetWarehouseResponseWarehouseType(v)
 		return nil
 	default:
@@ -1704,7 +1704,7 @@ func (f *GetWorkspaceWarehouseConfigResponseSecurityPolicy) String() string {
 // Set raw string value and validate it against allowed values
 func (f *GetWorkspaceWarehouseConfigResponseSecurityPolicy) Set(v string) error {
 	switch v {
-	case `DATA_ACCESS_CONTROL`, `NONE`, `PASSTHROUGH`:
+	case ``, `DATA_ACCESS_CONTROL`, `NONE`, `PASSTHROUGH`:
 		*f = GetWorkspaceWarehouseConfigResponseSecurityPolicy(v)
 		return nil
 	default:
@@ -1753,7 +1753,7 @@ func (f *ListOrder) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ListOrder) Set(v string) error {
 	switch v {
-	case `created_at`, `name`:
+	case ``, `created_at`, `name`:
 		*f = ListOrder(v)
 		return nil
 	default:
@@ -1904,7 +1904,7 @@ func (f *ObjectType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ObjectType) Set(v string) error {
 	switch v {
-	case `alert`, `dashboard`, `data_source`, `query`:
+	case ``, `alert`, `dashboard`, `data_source`, `query`:
 		*f = ObjectType(v)
 		return nil
 	default:
@@ -1936,7 +1936,7 @@ func (f *ObjectTypePlural) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ObjectTypePlural) Set(v string) error {
 	switch v {
-	case `alerts`, `dashboards`, `data_sources`, `queries`:
+	case ``, `alerts`, `dashboards`, `data_sources`, `queries`:
 		*f = ObjectTypePlural(v)
 		return nil
 	default:
@@ -1986,7 +1986,7 @@ func (f *OwnableObjectType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *OwnableObjectType) Set(v string) error {
 	switch v {
-	case `alert`, `dashboard`, `query`:
+	case ``, `alert`, `dashboard`, `query`:
 		*f = OwnableObjectType(v)
 		return nil
 	default:
@@ -2038,7 +2038,7 @@ func (f *ParameterType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ParameterType) Set(v string) error {
 	switch v {
-	case `datetime`, `number`, `text`:
+	case ``, `datetime`, `number`, `text`:
 		*f = ParameterType(v)
 		return nil
 	default:
@@ -2072,7 +2072,7 @@ func (f *PermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_MANAGE`, `CAN_RUN`, `CAN_VIEW`:
+	case ``, `CAN_MANAGE`, `CAN_RUN`, `CAN_VIEW`:
 		*f = PermissionLevel(v)
 		return nil
 	default:
@@ -2108,7 +2108,7 @@ func (f *PlansState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *PlansState) Set(v string) error {
 	switch v {
-	case `EMPTY`, `EXISTS`, `IGNORED_LARGE_PLANS_SIZE`, `IGNORED_SMALL_DURATION`, `IGNORED_SPARK_PLAN_TYPE`, `UNKNOWN`:
+	case ``, `EMPTY`, `EXISTS`, `IGNORED_LARGE_PLANS_SIZE`, `IGNORED_SMALL_DURATION`, `IGNORED_SPARK_PLAN_TYPE`, `UNKNOWN`:
 		*f = PlansState(v)
 		return nil
 	default:
@@ -2505,7 +2505,7 @@ func (f *QueryStatementType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *QueryStatementType) Set(v string) error {
 	switch v {
-	case `ALTER`, `ANALYZE`, `COPY`, `CREATE`, `DELETE`, `DESCRIBE`, `DROP`, `EXPLAIN`, `GRANT`, `INSERT`, `MERGE`, `OPTIMIZE`, `OTHER`, `REFRESH`, `REPLACE`, `REVOKE`, `SELECT`, `SET`, `SHOW`, `TRUNCATE`, `UPDATE`, `USE`:
+	case ``, `ALTER`, `ANALYZE`, `COPY`, `CREATE`, `DELETE`, `DESCRIBE`, `DROP`, `EXPLAIN`, `GRANT`, `INSERT`, `MERGE`, `OPTIMIZE`, `OTHER`, `REFRESH`, `REPLACE`, `REVOKE`, `SELECT`, `SET`, `SHOW`, `TRUNCATE`, `UPDATE`, `USE`:
 		*f = QueryStatementType(v)
 		return nil
 	default:
@@ -2547,7 +2547,7 @@ func (f *QueryStatus) String() string {
 // Set raw string value and validate it against allowed values
 func (f *QueryStatus) Set(v string) error {
 	switch v {
-	case `CANCELED`, `FAILED`, `FINISHED`, `QUEUED`, `RUNNING`:
+	case ``, `CANCELED`, `FAILED`, `FINISHED`, `QUEUED`, `RUNNING`:
 		*f = QueryStatus(v)
 		return nil
 	default:
@@ -2681,7 +2681,7 @@ func (f *RunAsRole) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RunAsRole) Set(v string) error {
 	switch v {
-	case `owner`, `viewer`:
+	case ``, `owner`, `viewer`:
 		*f = RunAsRole(v)
 		return nil
 	default:
@@ -2748,7 +2748,7 @@ func (f *ServiceErrorCode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ServiceErrorCode) Set(v string) error {
 	switch v {
-	case `ABORTED`, `ALREADY_EXISTS`, `BAD_REQUEST`, `CANCELLED`, `DEADLINE_EXCEEDED`, `INTERNAL_ERROR`, `IO_ERROR`, `NOT_FOUND`, `RESOURCE_EXHAUSTED`, `SERVICE_UNDER_MAINTENANCE`, `TEMPORARILY_UNAVAILABLE`, `UNAUTHENTICATED`, `UNKNOWN`, `WORKSPACE_TEMPORARILY_UNAVAILABLE`:
+	case ``, `ABORTED`, `ALREADY_EXISTS`, `BAD_REQUEST`, `CANCELLED`, `DEADLINE_EXCEEDED`, `INTERNAL_ERROR`, `IO_ERROR`, `NOT_FOUND`, `RESOURCE_EXHAUSTED`, `SERVICE_UNDER_MAINTENANCE`, `TEMPORARILY_UNAVAILABLE`, `UNAUTHENTICATED`, `UNKNOWN`, `WORKSPACE_TEMPORARILY_UNAVAILABLE`:
 		*f = ServiceErrorCode(v)
 		return nil
 	default:
@@ -2844,7 +2844,7 @@ func (f *SetWorkspaceWarehouseConfigRequestSecurityPolicy) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SetWorkspaceWarehouseConfigRequestSecurityPolicy) Set(v string) error {
 	switch v {
-	case `DATA_ACCESS_CONTROL`, `NONE`, `PASSTHROUGH`:
+	case ``, `DATA_ACCESS_CONTROL`, `NONE`, `PASSTHROUGH`:
 		*f = SetWorkspaceWarehouseConfigRequestSecurityPolicy(v)
 		return nil
 	default:
@@ -2874,7 +2874,7 @@ func (f *SpotInstancePolicy) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SpotInstancePolicy) Set(v string) error {
 	switch v {
-	case `COST_OPTIMIZED`, `POLICY_UNSPECIFIED`, `RELIABILITY_OPTIMIZED`:
+	case ``, `COST_OPTIMIZED`, `POLICY_UNSPECIFIED`, `RELIABILITY_OPTIMIZED`:
 		*f = SpotInstancePolicy(v)
 		return nil
 	default:
@@ -2916,7 +2916,7 @@ func (f *State) String() string {
 // Set raw string value and validate it against allowed values
 func (f *State) Set(v string) error {
 	switch v {
-	case `DELETED`, `DELETING`, `RUNNING`, `STARTING`, `STOPPED`, `STOPPING`:
+	case ``, `DELETED`, `DELETING`, `RUNNING`, `STARTING`, `STOPPED`, `STOPPING`:
 		*f = State(v)
 		return nil
 	default:
@@ -2990,7 +2990,7 @@ func (f *StatementState) String() string {
 // Set raw string value and validate it against allowed values
 func (f *StatementState) Set(v string) error {
 	switch v {
-	case `CANCELED`, `CLOSED`, `FAILED`, `PENDING`, `RUNNING`, `SUCCEEDED`:
+	case ``, `CANCELED`, `CLOSED`, `FAILED`, `PENDING`, `RUNNING`, `SUCCEEDED`:
 		*f = StatementState(v)
 		return nil
 	default:
@@ -3036,7 +3036,7 @@ func (f *Status) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Status) Set(v string) error {
 	switch v {
-	case `DEGRADED`, `FAILED`, `HEALTHY`, `STATUS_UNSPECIFIED`:
+	case ``, `DEGRADED`, `FAILED`, `HEALTHY`, `STATUS_UNSPECIFIED`:
 		*f = Status(v)
 		return nil
 	default:
@@ -3071,7 +3071,7 @@ func (f *SuccessMessage) String() string {
 // Set raw string value and validate it against allowed values
 func (f *SuccessMessage) Set(v string) error {
 	switch v {
-	case `Success`:
+	case ``, `Success`:
 		*f = SuccessMessage(v)
 		return nil
 	default:
@@ -3263,7 +3263,7 @@ func (f *TerminationReasonCode) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TerminationReasonCode) Set(v string) error {
 	switch v {
-	case `ABUSE_DETECTED`, `ATTACH_PROJECT_FAILURE`, `AWS_AUTHORIZATION_FAILURE`, `AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE`, `AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE`, `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE`, `AWS_REQUEST_LIMIT_EXCEEDED`, `AWS_UNSUPPORTED_FAILURE`, `AZURE_BYOK_KEY_PERMISSION_FAILURE`, `AZURE_EPHEMERAL_DISK_FAILURE`, `AZURE_INVALID_DEPLOYMENT_TEMPLATE`, `AZURE_OPERATION_NOT_ALLOWED_EXCEPTION`, `AZURE_QUOTA_EXCEEDED_EXCEPTION`, `AZURE_RESOURCE_MANAGER_THROTTLING`, `AZURE_RESOURCE_PROVIDER_THROTTLING`, `AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE`, `AZURE_VM_EXTENSION_FAILURE`, `AZURE_VNET_CONFIGURATION_FAILURE`, `BOOTSTRAP_TIMEOUT`, `BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION`, `CLOUD_PROVIDER_DISK_SETUP_FAILURE`, `CLOUD_PROVIDER_LAUNCH_FAILURE`, `CLOUD_PROVIDER_RESOURCE_STOCKOUT`, `CLOUD_PROVIDER_SHUTDOWN`, `COMMUNICATION_LOST`, `CONTAINER_LAUNCH_FAILURE`, `CONTROL_PLANE_REQUEST_FAILURE`, `DATABASE_CONNECTION_FAILURE`, `DBFS_COMPONENT_UNHEALTHY`, `DOCKER_IMAGE_PULL_FAILURE`, `DRIVER_UNREACHABLE`, `DRIVER_UNRESPONSIVE`, `EXECUTION_COMPONENT_UNHEALTHY`, `GCP_QUOTA_EXCEEDED`, `GCP_SERVICE_ACCOUNT_DELETED`, `GLOBAL_INIT_SCRIPT_FAILURE`, `HIVE_METASTORE_PROVISIONING_FAILURE`, `IMAGE_PULL_PERMISSION_DENIED`, `INACTIVITY`, `INIT_SCRIPT_FAILURE`, `INSTANCE_POOL_CLUSTER_FAILURE`, `INSTANCE_UNREACHABLE`, `INTERNAL_ERROR`, `INVALID_ARGUMENT`, `INVALID_SPARK_IMAGE`, `IP_EXHAUSTION_FAILURE`, `JOB_FINISHED`, `K8S_AUTOSCALING_FAILURE`, `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`, `METASTORE_COMPONENT_UNHEALTHY`, `NEPHOS_RESOURCE_MANAGEMENT`, `NETWORK_CONFIGURATION_FAILURE`, `NFS_MOUNT_FAILURE`, `NPIP_TUNNEL_SETUP_FAILURE`, `NPIP_TUNNEL_TOKEN_FAILURE`, `REQUEST_REJECTED`, `REQUEST_THROTTLED`, `SECRET_RESOLUTION_ERROR`, `SECURITY_DAEMON_REGISTRATION_EXCEPTION`, `SELF_BOOTSTRAP_FAILURE`, `SKIPPED_SLOW_NODES`, `SLOW_IMAGE_DOWNLOAD`, `SPARK_ERROR`, `SPARK_IMAGE_DOWNLOAD_FAILURE`, `SPARK_STARTUP_FAILURE`, `SPOT_INSTANCE_TERMINATION`, `STORAGE_DOWNLOAD_FAILURE`, `STS_CLIENT_SETUP_FAILURE`, `SUBNET_EXHAUSTED_FAILURE`, `TEMPORARILY_UNAVAILABLE`, `TRIAL_EXPIRED`, `UNEXPECTED_LAUNCH_FAILURE`, `UNKNOWN`, `UNSUPPORTED_INSTANCE_TYPE`, `UPDATE_INSTANCE_PROFILE_FAILURE`, `USER_REQUEST`, `WORKER_SETUP_FAILURE`, `WORKSPACE_CANCELLED_ERROR`, `WORKSPACE_CONFIGURATION_ERROR`:
+	case ``, `ABUSE_DETECTED`, `ATTACH_PROJECT_FAILURE`, `AWS_AUTHORIZATION_FAILURE`, `AWS_INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET_FAILURE`, `AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE`, `AWS_MAX_SPOT_INSTANCE_COUNT_EXCEEDED_FAILURE`, `AWS_REQUEST_LIMIT_EXCEEDED`, `AWS_UNSUPPORTED_FAILURE`, `AZURE_BYOK_KEY_PERMISSION_FAILURE`, `AZURE_EPHEMERAL_DISK_FAILURE`, `AZURE_INVALID_DEPLOYMENT_TEMPLATE`, `AZURE_OPERATION_NOT_ALLOWED_EXCEPTION`, `AZURE_QUOTA_EXCEEDED_EXCEPTION`, `AZURE_RESOURCE_MANAGER_THROTTLING`, `AZURE_RESOURCE_PROVIDER_THROTTLING`, `AZURE_UNEXPECTED_DEPLOYMENT_TEMPLATE_FAILURE`, `AZURE_VM_EXTENSION_FAILURE`, `AZURE_VNET_CONFIGURATION_FAILURE`, `BOOTSTRAP_TIMEOUT`, `BOOTSTRAP_TIMEOUT_CLOUD_PROVIDER_EXCEPTION`, `CLOUD_PROVIDER_DISK_SETUP_FAILURE`, `CLOUD_PROVIDER_LAUNCH_FAILURE`, `CLOUD_PROVIDER_RESOURCE_STOCKOUT`, `CLOUD_PROVIDER_SHUTDOWN`, `COMMUNICATION_LOST`, `CONTAINER_LAUNCH_FAILURE`, `CONTROL_PLANE_REQUEST_FAILURE`, `DATABASE_CONNECTION_FAILURE`, `DBFS_COMPONENT_UNHEALTHY`, `DOCKER_IMAGE_PULL_FAILURE`, `DRIVER_UNREACHABLE`, `DRIVER_UNRESPONSIVE`, `EXECUTION_COMPONENT_UNHEALTHY`, `GCP_QUOTA_EXCEEDED`, `GCP_SERVICE_ACCOUNT_DELETED`, `GLOBAL_INIT_SCRIPT_FAILURE`, `HIVE_METASTORE_PROVISIONING_FAILURE`, `IMAGE_PULL_PERMISSION_DENIED`, `INACTIVITY`, `INIT_SCRIPT_FAILURE`, `INSTANCE_POOL_CLUSTER_FAILURE`, `INSTANCE_UNREACHABLE`, `INTERNAL_ERROR`, `INVALID_ARGUMENT`, `INVALID_SPARK_IMAGE`, `IP_EXHAUSTION_FAILURE`, `JOB_FINISHED`, `K8S_AUTOSCALING_FAILURE`, `K8S_DBR_CLUSTER_LAUNCH_TIMEOUT`, `METASTORE_COMPONENT_UNHEALTHY`, `NEPHOS_RESOURCE_MANAGEMENT`, `NETWORK_CONFIGURATION_FAILURE`, `NFS_MOUNT_FAILURE`, `NPIP_TUNNEL_SETUP_FAILURE`, `NPIP_TUNNEL_TOKEN_FAILURE`, `REQUEST_REJECTED`, `REQUEST_THROTTLED`, `SECRET_RESOLUTION_ERROR`, `SECURITY_DAEMON_REGISTRATION_EXCEPTION`, `SELF_BOOTSTRAP_FAILURE`, `SKIPPED_SLOW_NODES`, `SLOW_IMAGE_DOWNLOAD`, `SPARK_ERROR`, `SPARK_IMAGE_DOWNLOAD_FAILURE`, `SPARK_STARTUP_FAILURE`, `SPOT_INSTANCE_TERMINATION`, `STORAGE_DOWNLOAD_FAILURE`, `STS_CLIENT_SETUP_FAILURE`, `SUBNET_EXHAUSTED_FAILURE`, `TEMPORARILY_UNAVAILABLE`, `TRIAL_EXPIRED`, `UNEXPECTED_LAUNCH_FAILURE`, `UNKNOWN`, `UNSUPPORTED_INSTANCE_TYPE`, `UPDATE_INSTANCE_PROFILE_FAILURE`, `USER_REQUEST`, `WORKER_SETUP_FAILURE`, `WORKSPACE_CANCELLED_ERROR`, `WORKSPACE_CONFIGURATION_ERROR`:
 		*f = TerminationReasonCode(v)
 		return nil
 	default:
@@ -3295,7 +3295,7 @@ func (f *TerminationReasonType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *TerminationReasonType) Set(v string) error {
 	switch v {
-	case `CLIENT_ERROR`, `CLOUD_FAILURE`, `SERVICE_FAULT`, `SUCCESS`:
+	case ``, `CLIENT_ERROR`, `CLOUD_FAILURE`, `SERVICE_FAULT`, `SUCCESS`:
 		*f = TerminationReasonType(v)
 		return nil
 	default:
@@ -3493,7 +3493,7 @@ func (f *WarehousePermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WarehousePermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_MANAGE`, `CAN_USE`, `IS_OWNER`:
+	case ``, `CAN_MANAGE`, `CAN_USE`, `IS_OWNER`:
 		*f = WarehousePermissionLevel(v)
 		return nil
 	default:
@@ -3581,7 +3581,7 @@ func (f *WarehouseTypePairWarehouseType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WarehouseTypePairWarehouseType) Set(v string) error {
 	switch v {
-	case `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
+	case ``, `CLASSIC`, `PRO`, `TYPE_UNSPECIFIED`:
 		*f = WarehouseTypePairWarehouseType(v)
 		return nil
 	default:

--- a/service/workspace/model.go
+++ b/service/workspace/model.go
@@ -33,7 +33,7 @@ func (f *AclPermission) String() string {
 // Set raw string value and validate it against allowed values
 func (f *AclPermission) Set(v string) error {
 	switch v {
-	case `MANAGE`, `READ`, `WRITE`:
+	case ``, `MANAGE`, `READ`, `WRITE`:
 		*f = AclPermission(v)
 		return nil
 	default:
@@ -243,7 +243,7 @@ func (f *ExportFormat) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ExportFormat) Set(v string) error {
 	switch v {
-	case `AUTO`, `DBC`, `HTML`, `JUPYTER`, `R_MARKDOWN`, `SOURCE`:
+	case ``, `AUTO`, `DBC`, `HTML`, `JUPYTER`, `R_MARKDOWN`, `SOURCE`:
 		*f = ExportFormat(v)
 		return nil
 	default:
@@ -471,7 +471,7 @@ func (f *ImportFormat) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ImportFormat) Set(v string) error {
 	switch v {
-	case `AUTO`, `DBC`, `HTML`, `JUPYTER`, `R_MARKDOWN`, `SOURCE`:
+	case ``, `AUTO`, `DBC`, `HTML`, `JUPYTER`, `R_MARKDOWN`, `SOURCE`:
 		*f = ImportFormat(v)
 		return nil
 	default:
@@ -504,7 +504,7 @@ func (f *Language) String() string {
 // Set raw string value and validate it against allowed values
 func (f *Language) Set(v string) error {
 	switch v {
-	case `PYTHON`, `R`, `SCALA`, `SQL`:
+	case ``, `PYTHON`, `R`, `SCALA`, `SQL`:
 		*f = Language(v)
 		return nil
 	default:
@@ -674,7 +674,7 @@ func (f *ObjectType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ObjectType) Set(v string) error {
 	switch v {
-	case `DIRECTORY`, `FILE`, `LIBRARY`, `NOTEBOOK`, `REPO`:
+	case ``, `DIRECTORY`, `FILE`, `LIBRARY`, `NOTEBOOK`, `REPO`:
 		*f = ObjectType(v)
 		return nil
 	default:
@@ -830,7 +830,7 @@ func (f *RepoPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *RepoPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_EDIT`, `CAN_MANAGE`, `CAN_READ`, `CAN_RUN`:
+	case ``, `CAN_EDIT`, `CAN_MANAGE`, `CAN_READ`, `CAN_RUN`:
 		*f = RepoPermissionLevel(v)
 		return nil
 	default:
@@ -897,7 +897,7 @@ func (f *ScopeBackendType) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ScopeBackendType) Set(v string) error {
 	switch v {
-	case `AZURE_KEYVAULT`, `DATABRICKS`:
+	case ``, `AZURE_KEYVAULT`, `DATABRICKS`:
 		*f = ScopeBackendType(v)
 		return nil
 	default:
@@ -1088,7 +1088,7 @@ func (f *WorkspaceObjectPermissionLevel) String() string {
 // Set raw string value and validate it against allowed values
 func (f *WorkspaceObjectPermissionLevel) Set(v string) error {
 	switch v {
-	case `CAN_EDIT`, `CAN_MANAGE`, `CAN_READ`, `CAN_RUN`:
+	case ``, `CAN_EDIT`, `CAN_MANAGE`, `CAN_READ`, `CAN_RUN`:
 		*f = WorkspaceObjectPermissionLevel(v)
 		return nil
 	default:


### PR DESCRIPTION
## Changes
WIP PR with the idea to support empty string in `Set()` methods for enums. This allows simpler setting of optional enum values, bypassing validation for optional fields in other structures.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

