### PR TITLE
Added `config.NewAzureCliTokenSource` and `config.NewAzureMsiTokenSource` constructors

### DIFF
--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -30,7 +30,7 @@ func (c AzureCliCredentials) Name() string {
 // implementing azureHostResolver for ensureWorkspaceUrl to work
 func (c AzureCliCredentials) tokenSourceFor(
 	ctx context.Context, cfg *Config, _, resource string) oauth2.TokenSource {
-	return &azureCliTokenSource{resource: resource}
+	return NewAzureCliTokenSource(resource)
 }
 
 // There are three scenarios:
@@ -82,6 +82,13 @@ func (c AzureCliCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 	}
 	logger.Infof(ctx, "Using Azure CLI authentication with AAD tokens")
 	return visitor, nil
+}
+
+// NewAzureCliTokenSource returns [oauth2.TokenSource] for a passwordless authentication via Azure CLI (`az login`)
+func NewAzureCliTokenSource(resource string) oauth2.TokenSource {
+	return &azureCliTokenSource{
+		resource: resource,
+	}
 }
 
 type azureCliTokenSource struct {

--- a/config/auth_azure_msi.go
+++ b/config/auth_azure_msi.go
@@ -49,10 +49,15 @@ func (c AzureMsiCredentials) Configure(ctx context.Context, cfg *Config) (func(*
 
 // implementing azureHostResolver for ensureWorkspaceUrl to work
 func (c AzureMsiCredentials) tokenSourceFor(_ context.Context, cfg *Config, _, resource string) oauth2.TokenSource {
-	return azureMsiTokenSource{
-		client:   cfg.refreshClient,
-		clientId: cfg.AzureClientID,
+	return NewAzureMsiTokenSource(cfg.refreshClient, resource, cfg.AzureClientID)
+}
+
+// NewAzureMsiTokenSource returns [oauth2.TokenSource] for a passwordless authentication via Azure Managed identity
+func NewAzureMsiTokenSource(client *httpclient.ApiClient, resource, clientId string) oauth2.TokenSource {
+	return &azureMsiTokenSource{
+		client:   client,
 		resource: resource,
+		clientId: clientId,
 	}
 }
 


### PR DESCRIPTION
## Changes
This PR exposes Azure CLI and Azure MSI token sources, that can be used externally to authenticate to services like Azure Resource Manager and Microsoft Graph, but still staying within the same testing ecosystem and without any extra dependencies.

## Tests
- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

