### PR TITLE
Use per-config refresh context for OAuth tokens

### DIFF
--- a/config/auth_azure_client_secret.go
+++ b/config/auth_azure_client_secret.go
@@ -47,11 +47,10 @@ func (c AzureClientSecretCredentials) Configure(ctx context.Context, cfg *Config
 		return nil, fmt.Errorf("resolve host: %w", err)
 	}
 	logger.Infof(ctx, "Generating AAD token for Service Principal (%s)", cfg.AzureClientID)
-	refreshCtx := context.Background()
 	env := cfg.Environment()
 	aadEndpoint := env.AzureActiveDirectoryEndpoint()
 	managementEndpoint := env.AzureServiceManagementEndpoint()
-	inner := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, aadEndpoint, env.AzureApplicationID))
-	management := azureReuseTokenSource(nil, c.tokenSourceFor(refreshCtx, cfg, aadEndpoint, managementEndpoint))
+	inner := azureReuseTokenSource(nil, c.tokenSourceFor(ctx, cfg, aadEndpoint, env.AzureApplicationID))
+	management := azureReuseTokenSource(nil, c.tokenSourceFor(ctx, cfg, aadEndpoint, managementEndpoint))
 	return azureVisitor(cfg, serviceToServiceVisitor(inner, management, xDatabricksAzureSpManagementToken)), nil
 }

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -328,6 +328,9 @@ func (c *ApiClient) RoundTrip(request *http.Request) (*http.Response, error) {
 			// DO NOT DECODE BODY, because it may contain sensitive payload,
 			// like Azure Service Principal in a multipart/form-data body.
 			DebugBytes: []byte("<http.RoundTripper>"),
+		}, func(r *http.Request) error {
+			r.Header = request.Header
+			return nil
 		}))
 	if err != nil {
 		return nil, err

--- a/httpclient/body_logger.go
+++ b/httpclient/body_logger.go
@@ -18,6 +18,7 @@ var redactKeys = map[string]bool{
 	"content":       true,
 	"access_token":  true,
 	"refresh_token": true,
+	"id_token":      true,
 	"token":         true,
 	"password":      true,
 }

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -38,6 +38,8 @@ func newResponseBody(data any, header http.Header, statusCode int, status string
 			ReadCloser: io.NopCloser(bytes.NewReader(v)),
 			DebugBytes: v,
 			Header:     header,
+			StatusCode: statusCode,
+			Status:     status,
 		}, nil
 	default:
 		return responseBody{}, errors.New("newResponseBody can only be called with io.ReadCloser or []byte")

--- a/internal/acceptance_test.go
+++ b/internal/acceptance_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -10,16 +9,20 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/internal/env"
+	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccDefaultCredentials(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
-		skipf(t)("Skipping workspace test on account level")
+func init() {
+	logger.DefaultLogger = &logger.SimpleLogger{
+		Level: logger.LevelDebug,
 	}
+}
+
+func TestAccDefaultCredentials(t *testing.T) {
+	workspaceTest(t)
 	w := databricks.Must(databricks.NewWorkspaceClient())
 	ctx := context.Background()
 	versions, err := w.Clusters.SparkVersions(ctx)
@@ -36,10 +39,7 @@ func TestAccDefaultCredentials(t *testing.T) {
 // TODO: add CredentialProviderChain
 
 func TestAccExplicitDatabricksCfg(t *testing.T) {
-	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
-	if os.Getenv("DATABRICKS_ACCOUNT_ID") != "" {
-		skipf(t)("Skipping workspace test on account level")
-	}
+	workspaceTest(t)
 	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{
 		Profile: GetEnvOrSkipTest(t, "DATABRICKS_CONFIG_PROFILE"),
 	}))
@@ -97,6 +97,7 @@ func TestAccExplicitAzureCliAuth(t *testing.T) {
 }
 
 func TestAccAzureErrorMappingForUnauthenticated(t *testing.T) {
+	workspaceTest(t)
 	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{
 		DebugHeaders:      true,
 		AzureTenantID:     GetEnvOrSkipTest(t, "ARM_TENANT_ID"),
@@ -110,6 +111,7 @@ func TestAccAzureErrorMappingForUnauthenticated(t *testing.T) {
 }
 
 func TestAccExplicitAzureSpnAuth(t *testing.T) {
+	workspaceTest(t)
 	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{
 		AzureTenantID:     GetEnvOrSkipTest(t, "ARM_TENANT_ID"),
 		AzureClientID:     GetEnvOrSkipTest(t, "ARM_CLIENT_ID"),


### PR DESCRIPTION
## Changes
This PR uses per-config refresh context for all oauth2 tokens, so that it's separate from the context coming in the first request (as before)

## Tests
- [x] `make test` passing
- [x] `make fmt` applied
- [x] azure env
- [x] gcp env

