### PR TITLE
Added 100% unit test coverage for `oauth-m2m`

### DIFF
--- a/config/auth_m2m_test.go
+++ b/config/auth_m2m_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
+)
+
+func TestM2mHappyFlow(t *testing.T) {
+	assertHeaders(t, &Config{
+		Host:         "a",
+		ClientID:     "b",
+		ClientSecret: "c",
+		HTTPTransport: fixtures.MappingTransport{
+			"GET /oidc/.well-known/oauth-authorization-server": {
+				Response: oauthAuthorizationServer{
+					AuthorizationEndpoint: "https://localhost:1234/dummy/auth",
+					TokenEndpoint:         "https://localhost:1234/dummy/token",
+				},
+			},
+		},
+	}, map[string]string{
+		"Authorization":                            "Bearer cde",
+		"X-Databricks-Azure-Sp-Management-Token":   "def",
+		"X-Databricks-Azure-Workspace-Resource-Id": "/a/b/c",
+	})
+}

--- a/config/auth_m2m_test.go
+++ b/config/auth_m2m_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
@@ -17,6 +18,13 @@ func TestM2mHappyFlow(t *testing.T) {
 					AuthorizationEndpoint: "https://localhost:1234/dummy/auth",
 					TokenEndpoint:         "https://localhost:1234/dummy/token",
 				},
+			},
+			"POST /dummy/token": {
+				ExpectedRequest: url.Values{
+					"grant_type": []string{"client_credentials"},
+					"scope":      []string{"all-apis"},
+				},
+				Response: `...`,
 			},
 		},
 	}, map[string]string{

--- a/httpclient/fixtures/fixture.go
+++ b/httpclient/fixtures/fixture.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -59,6 +60,15 @@ func (f HTTPFixture) AssertRequest(req *http.Request) error {
 	_, err := actualRequestBuf.ReadFrom(req.Body)
 	if err != nil {
 		return fmt.Errorf("read body: %w", err)
+	}
+	qs, ok := f.ExpectedRequest.(url.Values)
+	if ok {
+		expectedQS := qs.Encode()
+		actualQS := actualRequestBuf.String()
+		if expectedQS != actualQS {
+			return fmt.Errorf("want %s, got %s", expectedQS, actualQS)
+		}
+		return nil
 	}
 	// do pretty-priting, so that it's easier to debug failures
 	expectedRequestJSON, err := json.MarshalIndent(f.ExpectedRequest, "", "  ")

--- a/httpclient/fixtures/stub.go
+++ b/httpclient/fixtures/stub.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/databricks/databricks-sdk-go/openapi/code"
 )
@@ -34,6 +35,19 @@ func bodyStub(req *http.Request) (string, error) {
 	expectedRequest := ""
 	if actualRequestJSON.Len() == 0 {
 		return "", nil
+	}
+	contentType := req.Header.Get("Content-Type")
+	if contentType == "application/x-www-form-urlencoded" {
+		values, err := url.ParseQuery(actualRequestJSON.String())
+		if err != nil {
+			return "", fmt.Errorf("form: %w", err)
+		}
+		expectedRequest += "ExpectedRequest: url.Values{\n"
+		for k, v := range values {
+			expectedRequest += fmt.Sprintf("\t\t\t\"%s\": %#v,\n", k, v)
+		}
+		expectedRequest += "\t\t},\n\t\t"
+		return expectedRequest, nil
 	}
 	err = json.Unmarshal(actualRequestJSON.Bytes(), &receivedRequest)
 	if err != nil {


### PR DESCRIPTION
This PR adds coverage of client-secret oauth for databricks on aws