### PR TITLE
Consolidate usage of named sorting

### DIFF
--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -2,9 +2,9 @@ package code
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/databricks/databricks-sdk-go/openapi"
-	"golang.org/x/exp/slices"
 )
 
 // Field of a Type (Entity)
@@ -182,8 +182,8 @@ func (e *Entity) RequiredFields() (fields []*Field) {
 
 	// Path fields should always be first in required arguments order.
 	// We use stable sort to male sure we preserve the path arguments order
-	slices.SortStableFunc(fields, func(a, b *Field) bool {
-		return a.IsPath && !b.IsPath
+	sort.SliceStable(fields, func(a, b int) bool {
+		return fields[a].IsPath && !fields[b].IsPath
 	})
 	return
 }
@@ -225,9 +225,7 @@ func (e *Entity) NonRequiredFields() (fields []*Field) {
 		v.Of = e
 		fields = append(fields, v)
 	}
-	slices.SortFunc(fields, func(a, b *Field) bool {
-		return a.CamelName() < b.CamelName()
-	})
+	pascalNameSort(fields)
 	return
 }
 
@@ -237,9 +235,7 @@ func (e *Entity) Fields() (fields []*Field) {
 		v.Of = e
 		fields = append(fields, v)
 	}
-	slices.SortFunc(fields, func(a, b *Field) bool {
-		return a.CamelName() < b.CamelName()
-	})
+	pascalNameSort(fields)
 	return fields
 }
 
@@ -268,8 +264,8 @@ func (e *Entity) Enum() (enum []EnumEntry) {
 	for _, v := range e.enum {
 		enum = append(enum, v)
 	}
-	slices.SortFunc(enum, func(a, b EnumEntry) bool {
-		return a.Name < b.Name
+	sort.Slice(enum, func(i, j int) bool {
+		return enum[i].Name < enum[j].Name
 	})
 	return enum
 }

--- a/openapi/code/load.go
+++ b/openapi/code/load.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/openapi"
-	"golang.org/x/exp/slices"
 )
 
 type Batch struct {
@@ -73,9 +73,7 @@ func (b *Batch) Packages() (pkgs []*Package) {
 	}
 	// add some determinism into code generation for globally stable order in
 	// files like for workspaces/accounts clinets.
-	slices.SortFunc(pkgs, func(a, b *Package) bool {
-		return a.FullName() < b.FullName()
-	})
+	fullNameSort(pkgs)
 	return pkgs
 }
 
@@ -86,9 +84,7 @@ func (b *Batch) Types() (types []*Entity) {
 	}
 	// add some determinism into code generation for globally stable order in
 	// files like api.go and/or {{.Package.Name}}.py and clients.
-	slices.SortFunc(types, func(a, b *Entity) bool {
-		return a.FullName() < b.FullName()
-	})
+	fullNameSort(types)
 	return types
 }
 
@@ -116,11 +112,11 @@ func (b *Batch) Services() (services []*Service) {
 	}
 	// add some determinism into code generation for globally stable order in
 	// files like api.go and/or {{.Package.Name}}.py and clients.
-	slices.SortFunc(services, func(a, b *Service) bool {
+	sort.Slice(services, func(a, b int) bool {
 		// not using .FullName() here, as in "batch" context
 		// services have to be sorted globally, not only within a package.
 		// alternatively we may think on adding .ReverseFullName() to sort on.
-		return norm(a.Name) < norm(b.Name)
+		return norm(services[a].Name) < norm(services[b].Name)
 	})
 	return services
 }

--- a/openapi/code/named_sort.go
+++ b/openapi/code/named_sort.go
@@ -1,0 +1,25 @@
+package code
+
+import "sort"
+
+// github.com/databricks/databricks-sdk-go/httpclient/fixtures stub generator uses Named.PascalName() method to come up with
+// the best possible field name for generated copy-pastable stubs, though, when this library is attempted to be used together
+// with github.com/spf13/viper, we immediately get the following error related to a change in
+// golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e as:
+// .../entity.go:185:32: type func(a *Field, b *Field) bool of func(a, b *Field) bool {…} does not match inferred type
+// ...                        func(a *Field, b *Field) int for func(a E, b E) int,
+// because github.com/spf13/viper v0.17+ transitively depends on golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+
+// sorts slice predictably by NamesLikeThis
+func pascalNameSort[E interface{ PascalName() string }](things []E) {
+	sort.Slice(things, func(i, j int) bool {
+		return things[i].PascalName() < things[j].PascalName()
+	})
+}
+
+// sorts slice predictably by package_names_and.ClassNamesLikeThis
+func fullNameSort[E interface{ FullName() string }](things []E) {
+	sort.Slice(things, func(i, j int) bool {
+		return things[i].FullName() < things[j].FullName()
+	})
+}

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -36,9 +36,7 @@ func (pkg *Package) Services() (types []*Service) {
 	for _, v := range pkg.services {
 		types = append(types, v)
 	}
-	slices.SortFunc(types, func(a, b *Service) bool {
-		return a.PascalName() < b.PascalName()
-	})
+	pascalNameSort(types)
 	return types
 }
 
@@ -58,18 +56,14 @@ func (pkg *Package) Types() (types []*Entity) {
 	for _, v := range pkg.types {
 		types = append(types, v)
 	}
-	slices.SortFunc(types, func(a, b *Entity) bool {
-		return a.PascalName() < b.PascalName()
-	})
+	pascalNameSort(types)
 	return types
 }
 
 // EmptyTypes returns sorted list of types without fields
 func (pkg *Package) EmptyTypes() (types []*Named) {
 	types = append(types, pkg.emptyTypes...)
-	slices.SortFunc(types, func(a, b *Named) bool {
-		return a.PascalName() < b.PascalName()
-	})
+	pascalNameSort(types)
 	return types
 }
 
@@ -88,9 +82,7 @@ func (pkg *Package) ImportedEntities() (res []*Entity) {
 	for _, e := range pkg.extImports {
 		res = append(res, e)
 	}
-	slices.SortFunc(res, func(a, b *Entity) bool {
-		return a.FullName() < b.FullName()
-	})
+	fullNameSort(res)
 	return
 }
 

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/openapi"
-	"golang.org/x/exp/slices"
 )
 
 // Service represents specific Databricks API
@@ -36,9 +35,7 @@ func (svc *Service) Methods() (methods []*Method) {
 	for _, v := range svc.methods {
 		methods = append(methods, v)
 	}
-	slices.SortFunc(methods, func(a, b *Method) bool {
-		return a.CamelName() < b.CamelName()
-	})
+	pascalNameSort(methods)
 	return methods
 }
 
@@ -469,9 +466,7 @@ func (svc *Service) Waits() (waits []*Wait) {
 		waits = append(waits, wait)
 		seen[wait.Name] = true
 	}
-	slices.SortFunc(waits, func(a, b *Wait) bool {
-		return a.Name < b.Name
-	})
+	pascalNameSort(waits)
 	return waits
 }
 

--- a/openapi/code/wait.go
+++ b/openapi/code/wait.go
@@ -2,8 +2,7 @@ package code
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"sort"
 )
 
 // Wait represents a long-running operation, that requires multiple RPC calls
@@ -56,8 +55,8 @@ func (w *Wait) Binding() (binding []Binding) {
 		}
 		// ensure generated code is deterministic
 		// Java SDK relies on bind parameter order.
-		slices.SortFunc(binding, func(a, b Binding) bool {
-			return a.PollField.Name < b.PollField.Name
+		sort.Slice(binding, func(a, b int) bool {
+			return binding[a].PollField.Name < binding[b].PollField.Name
 		})
 	} else {
 		responseBind := true


### PR DESCRIPTION
## Changes

`github.com/databricks/databricks-sdk-go/httpclient/fixtures` stub generator uses Named.PascalName() method to come up with the best possible field name for generated copy-pastable stubs, though, when this library is attempted to be used together with github.com/spf13/viper, we immediately get the following error related to a change in golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e as:

```
.../entity.go:185:32: type func(a *Field, b *Field) bool of func(a, b *Field) bool {…} does not match inferred type
...                        func(a *Field, b *Field) int for func(a E, b E) int,
```
because github.com/spf13/viper v0.17+ transitively depends on golang.org/x/exp v0.0.0-20230905200255-921286631fa9

This PR keeps the sorting behavior but removes dependency on code that changed in the experimental slices package

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

