### PR TITLE
Improve debuggability of unexpected errors

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -172,7 +172,7 @@ func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byt
 	var errorBody APIErrorBody
 	err := json.Unmarshal(responseBody, &errorBody)
 	if err != nil {
-		errorBody = ParseNonJSONError(resp, requestBody, responseBody, err)
+		errorBody = parseUnknownError(resp, requestBody, responseBody, err)
 	}
 	if errorBody.API12Error != "" {
 		// API 1.2 has different response format, let's adapt
@@ -198,7 +198,7 @@ func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byt
 	}
 }
 
-func ParseNonJSONError(resp *http.Response, requestBody, responseBody []byte, err error) (errorBody APIErrorBody) {
+func parseUnknownError(resp *http.Response, requestBody, responseBody []byte, err error) (errorBody APIErrorBody) {
 	// this is most likely HTML... since un-marshalling JSON failed
 	// Status parts first in case html message is not as expected
 	statusParts := strings.SplitN(resp.Status, " ", 2)
@@ -214,7 +214,7 @@ func ParseNonJSONError(resp *http.Response, requestBody, responseBody []byte, er
 	messageMatches := messageRE.FindStringSubmatch(stringBody)
 	// No messages with <pre> </pre> format found so return a APIError
 	if len(messageMatches) < 2 {
-		errorBody.Message = MakeUnexpectedError(resp, err, nil, responseBody).Error()
+		errorBody.Message = MakeUnexpectedError(resp, err, requestBody, responseBody).Error()
 		return
 	}
 	errorBody.Message = strings.Trim(messageMatches[1], " .")

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -11,7 +11,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/databricks/databricks-sdk-go/common"
 	"github.com/databricks/databricks-sdk-go/logger"
+	"github.com/databricks/databricks-sdk-go/logger/httplog"
 )
 
 var (
@@ -149,28 +151,28 @@ func GenericIOError(ue *url.Error) *APIError {
 }
 
 // GetAPIError inspects HTTP errors from the Databricks API for known transient errors.
-func GetAPIError(ctx context.Context, resp *http.Response, body io.ReadCloser) error {
-	if resp.StatusCode == 429 {
+func GetAPIError(ctx context.Context, resp common.ResponseWrapper) error {
+	if resp.Response.StatusCode == 429 {
 		return TooManyRequests()
 	}
-	if resp.StatusCode >= 400 {
+	if resp.Response.StatusCode >= 400 {
 		// read in response body as it is actually an error
-		bodyBytes, err := io.ReadAll(body)
+		responseBodyBytes, err := io.ReadAll(resp.ReadCloser)
 		if err != nil {
-			return ReadError(resp.StatusCode, err)
+			return ReadError(resp.Response.StatusCode, err)
 		}
-		apiError := parseErrorFromResponse(resp, bodyBytes)
+		apiError := parseErrorFromResponse(resp.Response, resp.RequestBody.DebugBytes, responseBodyBytes)
 		return apiError
 	}
 	return nil
 }
 
-func parseErrorFromResponse(resp *http.Response, body []byte) *APIError {
+func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byte) *APIError {
 	// try to read in nicely formatted API error response
 	var errorBody APIErrorBody
-	err := json.Unmarshal(body, &errorBody)
+	err := json.Unmarshal(responseBody, &errorBody)
 	if err != nil {
-		errorBody = parseUnknownError(resp.Status, body, err)
+		errorBody = ParseNonJSONError(resp, requestBody, responseBody, err)
 	}
 	if errorBody.API12Error != "" {
 		// API 1.2 has different response format, let's adapt
@@ -196,10 +198,10 @@ func parseErrorFromResponse(resp *http.Response, body []byte) *APIError {
 	}
 }
 
-func parseUnknownError(status string, body []byte, err error) (errorBody APIErrorBody) {
+func ParseNonJSONError(resp *http.Response, requestBody, responseBody []byte, err error) (errorBody APIErrorBody) {
 	// this is most likely HTML... since un-marshalling JSON failed
 	// Status parts first in case html message is not as expected
-	statusParts := strings.SplitN(status, " ", 2)
+	statusParts := strings.SplitN(resp.Status, " ", 2)
 	if len(statusParts) < 2 {
 		errorBody.ErrorCode = "UNKNOWN"
 	} else {
@@ -207,23 +209,26 @@ func parseUnknownError(status string, body []byte, err error) (errorBody APIErro
 			strings.ToUpper(strings.Trim(statusParts[1], " .")),
 			" ", "_")
 	}
-	stringBody := string(body)
+	stringBody := string(responseBody)
 	messageRE := regexp.MustCompile(`<pre>(.*)</pre>`)
 	messageMatches := messageRE.FindStringSubmatch(stringBody)
 	// No messages with <pre> </pre> format found so return a APIError
 	if len(messageMatches) < 2 {
-		errorBody.Message = fmt.Sprintf("unexpected response from server (%s): %v (original: %s)",
-			status, err, stringBody)
+		errorBody.Message = MakeUnexpectedError(resp, err, nil, responseBody).Error()
 		return
 	}
 	errorBody.Message = strings.Trim(messageMatches[1], " .")
 	return
 }
 
-func makeError(response *http.Response, message string) error {
-	requestMetadata := map[string]string{
-		"host":   response.Request.Host,
-		"path":   response.Request.URL.Path,
-		"method": response.Request.Method,
+func MakeUnexpectedError(resp *http.Response, err error, requestBody, responseBody []byte) error {
+	rts := httplog.RoundTripStringer{
+		Response:           resp,
+		Err:                err,
+		RequestBody:        requestBody,
+		ResponseBody:       responseBody,
+		DebugHeaders:       true,
+		DebugTruncateBytes: 10 * 1024,
 	}
+	return fmt.Errorf("unexpected error handling request: %w. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\n%s", err, rts.String())
 }

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -223,12 +223,13 @@ func parseUnknownError(resp *http.Response, requestBody, responseBody []byte, er
 
 func MakeUnexpectedError(resp *http.Response, err error, requestBody, responseBody []byte) error {
 	rts := httplog.RoundTripStringer{
-		Response:           resp,
-		Err:                err,
-		RequestBody:        requestBody,
-		ResponseBody:       responseBody,
-		DebugHeaders:       true,
-		DebugTruncateBytes: 10 * 1024,
+		Response:                 resp,
+		Err:                      err,
+		RequestBody:              requestBody,
+		ResponseBody:             responseBody,
+		DebugHeaders:             true,
+		DebugTruncateBytes:       10 * 1024,
+		DebugAuthorizationHeader: false,
 	}
 	return fmt.Errorf("unexpected error handling request: %w. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\n```\n%s\n```", err, rts.String())
 }

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -212,8 +212,8 @@ func parseUnknownError(status string, body []byte, err error) (errorBody APIErro
 	messageMatches := messageRE.FindStringSubmatch(stringBody)
 	// No messages with <pre> </pre> format found so return a APIError
 	if len(messageMatches) < 2 {
-		errorBody.Message = fmt.Sprintf("Response from server (%s) %s: %v",
-			status, stringBody, err)
+		errorBody.Message = fmt.Sprintf("unexpected response from server (%s): %v (original: %s)",
+			status, err, stringBody)
 		return
 	}
 	errorBody.Message = strings.Trim(messageMatches[1], " .")

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -219,3 +219,11 @@ func parseUnknownError(status string, body []byte, err error) (errorBody APIErro
 	errorBody.Message = strings.Trim(messageMatches[1], " .")
 	return
 }
+
+func makeError(response *http.Response, message string) error {
+	requestMetadata := map[string]string{
+		"host":   response.Request.Host,
+		"path":   response.Request.URL.Path,
+		"method": response.Request.Method,
+	}
+}

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -230,5 +230,5 @@ func MakeUnexpectedError(resp *http.Response, err error, requestBody, responseBo
 		DebugHeaders:       true,
 		DebugTruncateBytes: 10 * 1024,
 	}
-	return fmt.Errorf("unexpected error handling request: %w. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\n%s", err, rts.String())
+	return fmt.Errorf("unexpected error handling request: %w. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\n```\n%s\n```", err, rts.String())
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -259,19 +259,46 @@ func TestNonJSONResponseIncludedInError(t *testing.T) {
 	}
 	cases := []testCase{
 		{
-			statusCode:   400,
-			status:       "Bad Request",
-			errorMessage: "unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\nGET /a\n> * Host: \n> * Accept: application/json\n> * Authorization: Bearer token\n> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat\n<  Bad Request\n< <html><body>hello</body></html>\n",
+			statusCode: 400,
+			status:     "Bad Request",
+			errorMessage: `unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
+` + "```" + `
+GET /a
+> * Host: 
+> * Accept: application/json
+> * Authorization: Bearer token
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat
+< HTTP/2.0 Bad Request
+< <html><body>hello</body></html>
+` + "```",
 		},
 		{
-			statusCode:   500,
-			status:       "Internal Server Error",
-			errorMessage: "unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\nGET /a\n> * Host: \n> * Accept: application/json\n> * Authorization: Bearer token\n> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat\n<  Internal Server Error\n< <html><body>hello</body></html>\n",
+			statusCode: 500,
+			status:     "Internal Server Error",
+			errorMessage: `unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
+` + "```" + `
+GET /a
+> * Host: 
+> * Accept: application/json
+> * Authorization: Bearer token
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat
+< HTTP/2.0 Internal Server Error
+< <html><body>hello</body></html>
+` + "```",
 		},
 		{
-			statusCode:   200,
-			status:       "OK",
-			errorMessage: "unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\nGET /a\n> * Host: \n> * Accept: application/json\n> * Authorization: Bearer token\n> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat\n<  OK\n< <html><body>hello</body></html>\n",
+			statusCode: 200,
+			status:     "OK",
+			errorMessage: `unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
+` + "```" + `
+GET /a
+> * Host: 
+> * Accept: application/json
+> * Authorization: Bearer token
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat
+< HTTP/2.0 OK
+< <html><body>hello</body></html>
+` + "```",
 		},
 	}
 	for _, tc := range cases {
@@ -289,10 +316,10 @@ func testNonJSONResponseIncludedInError(t *testing.T, statusCode int, status, er
 		ConfigFile: "/dev/null",
 		HTTPTransport: hc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
-				StatusCode: statusCode,
-				Status:     status,
-				Body:       io.NopCloser(strings.NewReader(`<html><body>hello</body></html>`)),
-				Request:    r,
+				Proto:   "HTTP/2.0",
+				Status:  status,
+				Body:    io.NopCloser(strings.NewReader(`<html><body>hello</body></html>`)),
+				Request: r,
 			}, nil
 		}),
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -277,6 +277,7 @@ GET /a
 > * Authorization: REDACTED
 > * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/` + runtime.GOOS + ` auth/pat` + cicdHeader + `
 < HTTP/2.0 Bad Request
+< * Content-Type: text/html
 < <html><body>hello</body></html>
 ` + "```",
 		},
@@ -291,6 +292,7 @@ GET /a
 > * Authorization: REDACTED
 > * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/` + runtime.GOOS + ` auth/pat` + cicdHeader + `
 < HTTP/2.0 Internal Server Error
+< * Content-Type: text/html
 < <html><body>hello</body></html>
 ` + "```",
 		},
@@ -305,6 +307,7 @@ GET /a
 > * Authorization: REDACTED
 > * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/` + runtime.GOOS + ` auth/pat` + cicdHeader + `
 < HTTP/2.0 OK
+< * Content-Type: text/html
 < <html><body>hello</body></html>
 ` + "```",
 		},
@@ -328,6 +331,9 @@ func testNonJSONResponseIncludedInError(t *testing.T, statusCode int, status, er
 				Status:  status,
 				Body:    io.NopCloser(strings.NewReader(`<html><body>hello</body></html>`)),
 				Request: r,
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
 			}, nil
 		}),
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -275,7 +275,7 @@ GET /a
 > * Host: 
 > * Accept: application/json
 > * Authorization: REDACTED
-> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/` + runtime.GOOS + ` auth/pat` + cicdHeader + `
 < HTTP/2.0 Bad Request
 < <html><body>hello</body></html>
 ` + "```",
@@ -289,7 +289,7 @@ GET /a
 > * Host: 
 > * Accept: application/json
 > * Authorization: REDACTED
-> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/` + runtime.GOOS + ` auth/pat` + cicdHeader + `
 < HTTP/2.0 Internal Server Error
 < <html><body>hello</body></html>
 ` + "```",
@@ -303,7 +303,7 @@ GET /a
 > * Host: 
 > * Accept: application/json
 > * Authorization: REDACTED
-> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/` + runtime.GOOS + ` auth/pat` + cicdHeader + `
 < HTTP/2.0 OK
 < <html><body>hello</body></html>
 ` + "```",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,11 +7,14 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/useragent"
+	"github.com/databricks/databricks-sdk-go/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -252,6 +255,11 @@ func TestDoRemovesDoubleSlashesFromFilesAPI(t *testing.T) {
 }
 
 func TestNonJSONResponseIncludedInError(t *testing.T) {
+	cicdHeader := ""
+	if useragent.CiCdProvider() != "" {
+		cicdHeader = fmt.Sprintf(" cicd/%s", useragent.CiCdProvider())
+	}
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
 	type testCase struct {
 		statusCode   int
 		status       string
@@ -267,7 +275,7 @@ GET /a
 > * Host: 
 > * Accept: application/json
 > * Authorization: Bearer token
-> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
 < HTTP/2.0 Bad Request
 < <html><body>hello</body></html>
 ` + "```",
@@ -281,7 +289,7 @@ GET /a
 > * Host: 
 > * Accept: application/json
 > * Authorization: Bearer token
-> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
 < HTTP/2.0 Internal Server Error
 < <html><body>hello</body></html>
 ` + "```",
@@ -295,7 +303,7 @@ GET /a
 > * Host: 
 > * Accept: application/json
 > * Authorization: Bearer token
-> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat
+> * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
 < HTTP/2.0 OK
 < <html><body>hello</body></html>
 ` + "```",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -274,7 +274,7 @@ func TestNonJSONResponseIncludedInError(t *testing.T) {
 GET /a
 > * Host: 
 > * Accept: application/json
-> * Authorization: Bearer token
+> * Authorization: REDACTED
 > * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
 < HTTP/2.0 Bad Request
 < <html><body>hello</body></html>
@@ -288,7 +288,7 @@ GET /a
 GET /a
 > * Host: 
 > * Accept: application/json
-> * Authorization: Bearer token
+> * Authorization: REDACTED
 > * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
 < HTTP/2.0 Internal Server Error
 < <html><body>hello</body></html>
@@ -302,7 +302,7 @@ GET /a
 GET /a
 > * Host: 
 > * Accept: application/json
-> * Authorization: Bearer token
+> * Authorization: REDACTED
 > * User-Agent: unknown/0.0.0 databricks-sdk-go/` + version.Version + ` go/` + goVersion + ` os/darwin auth/pat` + cicdHeader + `
 < HTTP/2.0 OK
 < <html><body>hello</body></html>

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -261,17 +261,17 @@ func TestNonJSONResponseIncludedInError(t *testing.T) {
 		{
 			statusCode:   400,
 			status:       "Bad Request",
-			errorMessage: "unexpected response from server (Bad Request): invalid character '<' looking for beginning of value (original: <html><body>hello</body></html>)",
+			errorMessage: "unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\nGET /a\n> * Host: \n> * Accept: application/json\n> * Authorization: Bearer token\n> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat\n<  Bad Request\n< <html><body>hello</body></html>\n",
 		},
 		{
 			statusCode:   500,
 			status:       "Internal Server Error",
-			errorMessage: "unexpected response from server (Internal Server Error): invalid character '<' looking for beginning of value (original: <html><body>hello</body></html>)",
+			errorMessage: "unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\nGET /a\n> * Host: \n> * Accept: application/json\n> * Authorization: Bearer token\n> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat\n<  Internal Server Error\n< <html><body>hello</body></html>\n",
 		},
 		{
 			statusCode:   200,
 			status:       "OK",
-			errorMessage: `failed to unmarshal response body: invalid character '<' looking for beginning of value (original: <html><body>hello</body></html>)`,
+			errorMessage: "unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\nGET /a\n> * Host: \n> * Accept: application/json\n> * Authorization: Bearer token\n> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.27.0 go/1.21.3 os/darwin auth/pat\n<  OK\n< <html><body>hello</body></html>\n",
 		},
 	}
 	for _, tc := range cases {

--- a/common/request.go
+++ b/common/request.go
@@ -1,0 +1,71 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Represents a request body.
+//
+// If the provided request data is an io.Reader, DebugBytes is set to
+// "<io.Reader>". Otherwise, DebugBytes is set to the marshaled JSON
+// representation of the request data, and ReadCloser is set to a new
+// io.ReadCloser that reads from DebugBytes.
+//
+// Request bodies are never closed by the client, hence only accepting
+// io.Reader.
+type RequestBody struct {
+	Reader      io.Reader
+	ContentType string
+	DebugBytes  []byte
+}
+
+func NewRequestBody(data any) (RequestBody, error) {
+	switch v := data.(type) {
+	case io.Reader:
+		return RequestBody{
+			Reader:     v,
+			DebugBytes: []byte("<io.Reader>"),
+		}, nil
+	case string:
+		return RequestBody{
+			Reader:     strings.NewReader(v),
+			DebugBytes: []byte(v),
+		}, nil
+	case []byte:
+		return RequestBody{
+			Reader:     bytes.NewReader(v),
+			DebugBytes: v,
+		}, nil
+	default:
+		bs, err := json.Marshal(data)
+		if err != nil {
+			return RequestBody{}, fmt.Errorf("request marshal failure: %w", err)
+		}
+		return RequestBody{
+			Reader:      bytes.NewReader(bs),
+			ContentType: "application/json",
+			DebugBytes:  bs,
+		}, nil
+	}
+}
+
+// Reset a request body to its initial state.
+//
+// This is used to retry requests with a body that has already been read.
+// If the request body is not resettable (i.e. not nil and of type other than
+// strings.Reader or bytes.Reader), this will return an error.
+func (r RequestBody) Reset() error {
+	if r.Reader == nil {
+		return nil
+	}
+	if v, ok := r.Reader.(io.Seeker); ok {
+		_, err := v.Seek(0, io.SeekStart)
+		return err
+	} else {
+		return fmt.Errorf("cannot reset reader of type %T", r.Reader)
+	}
+}

--- a/common/response.go
+++ b/common/response.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+)
+
+// Represents a response.
+//
+// Responses must always be closed. For non-streaming responses, they are closed
+// during deserialization in the client (see unmarshall()). For streaming
+// responses, they are returned to the caller, who is responsible for closing
+// them. When debugging is enabled, the value of DebugBytes is printed when
+// logging the response body.
+type ResponseWrapper struct {
+	// ReadCloser is the response body that was received from the server.
+	ReadCloser io.ReadCloser
+
+	// DebugBytes is the raw response body that was received from the server, if
+	// the response was not streamed.
+	DebugBytes []byte
+
+	// Response is the original http.Response object.
+	Response *http.Response
+
+	// RequestBody is the request body that was sent to the server.
+	RequestBody RequestBody
+}
+
+func NewResponseWrapper(data any, response *http.Response, req RequestBody) (ResponseWrapper, error) {
+	switch v := data.(type) {
+	case io.ReadCloser:
+		return ResponseWrapper{
+			ReadCloser:  v,
+			DebugBytes:  []byte("<Streaming response>"),
+			Response:    response,
+			RequestBody: req,
+		}, nil
+	case []byte:
+		return ResponseWrapper{
+			ReadCloser:  io.NopCloser(bytes.NewReader(v)),
+			DebugBytes:  v,
+			Response:    response,
+			RequestBody: req,
+		}, nil
+	default:
+		return ResponseWrapper{}, errors.New("newResponseBody can only be called with io.ReadCloser or []byte")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,13 +3,13 @@ package config
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go/common"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/logger"
 )
@@ -319,8 +319,8 @@ func (c *Config) fixHostIfNeeded() error {
 	return nil
 }
 
-func (c *Config) refreshTokenErrorMapper(ctx context.Context, resp *http.Response, body io.ReadCloser) error {
-	defaultErr := httpclient.DefaultErrorMapper(ctx, resp, body)
+func (c *Config) refreshTokenErrorMapper(ctx context.Context, resp common.ResponseWrapper) error {
+	defaultErr := httpclient.DefaultErrorMapper(ctx, resp)
 	if defaultErr == nil {
 		return nil
 	}

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -252,12 +252,13 @@ func (c *ApiClient) recordRequestLog(
 		return
 	}
 	message := httplog.RoundTripStringer{
-		Response:           response,
-		Err:                err,
-		RequestBody:        requestBody,
-		ResponseBody:       responseBody,
-		DebugHeaders:       c.config.DebugHeaders,
-		DebugTruncateBytes: c.config.DebugTruncateBytes,
+		Response:                 response,
+		Err:                      err,
+		RequestBody:              requestBody,
+		ResponseBody:             responseBody,
+		DebugHeaders:             c.config.DebugHeaders,
+		DebugTruncateBytes:       c.config.DebugTruncateBytes,
+		DebugAuthorizationHeader: true,
 	}.String()
 	logger.Debugf(ctx, message)
 }

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -13,7 +13,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go/common"
 	"github.com/databricks/databricks-sdk-go/logger"
+	"github.com/databricks/databricks-sdk-go/logger/httplog"
 	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/useragent"
 	"golang.org/x/oauth2"
@@ -32,7 +34,7 @@ type ClientConfig struct {
 	DebugTruncateBytes int
 	RateLimitPerSecond int
 
-	ErrorMapper     func(ctx context.Context, resp *http.Response, body io.ReadCloser) error
+	ErrorMapper     func(ctx context.Context, resp common.ResponseWrapper) error
 	ErrorRetriable  func(ctx context.Context, err error) bool
 	TransientErrors []string
 
@@ -101,7 +103,7 @@ type ApiClient struct {
 
 type DoOption struct {
 	in   RequestVisitor
-	out  func(body *responseBody) error
+	out  func(body *common.ResponseWrapper) error
 	body any
 }
 
@@ -138,12 +140,12 @@ func (c *ApiClient) Do(ctx context.Context, method, path string, opts ...DoOptio
 	return nil
 }
 
-func (c *ApiClient) fromResponse(r *http.Response) (responseBody, error) {
+func (c *ApiClient) fromResponse(r *http.Response, req common.RequestBody) (common.ResponseWrapper, error) {
 	if r == nil {
-		return responseBody{}, fmt.Errorf("nil response")
+		return common.ResponseWrapper{}, fmt.Errorf("nil response")
 	}
 	if r.Request == nil {
-		return responseBody{}, fmt.Errorf("nil request")
+		return common.ResponseWrapper{}, fmt.Errorf("nil request")
 	}
 	// JSON media types might have more information after `application/json`, like
 	// `application/json;odata.metadata=minimal;odata...=...`.
@@ -151,20 +153,14 @@ func (c *ApiClient) fromResponse(r *http.Response) (responseBody, error) {
 	isJSON := strings.HasPrefix(r.Header.Get("Content-Type"), "application/json")
 	streamResponse := r.Request.Header.Get("Accept") != "application/json" && !isJSON
 	if streamResponse {
-		return newResponseBody(r.Body, r)
+		return common.NewResponseWrapper(r.Body, r, req)
 	}
 	defer r.Body.Close()
 	bs, err := io.ReadAll(r.Body)
 	if err != nil {
-		return responseBody{}, fmt.Errorf("response body: %w", err)
+		return common.ResponseWrapper{}, fmt.Errorf("response body: %w", err)
 	}
-	return newResponseBody(bs, r)
-}
-
-func (c *ApiClient) redactedDump(prefix string, body []byte) (res string) {
-	return bodyLogger{
-		debugTruncateBytes: c.config.DebugTruncateBytes,
-	}.redactedDump(prefix, body)
+	return common.NewResponseWrapper(bs, r, req)
 }
 
 func (c *ApiClient) isRetriable(ctx context.Context, err error) bool {
@@ -196,18 +192,18 @@ func (c *ApiClient) isRetriable(ctx context.Context, err error) bool {
 // Always returns nil for the first parameter as there is no meaningful response body to return in the error case.
 //
 // If it is certain that an error should not be retried, use failRequest() instead.
-func (c *ApiClient) handleError(ctx context.Context, err error, body requestBody) (*responseBody, *retries.Err) {
+func (c *ApiClient) handleError(ctx context.Context, err error, body common.RequestBody) (*common.ResponseWrapper, *retries.Err) {
 	if !c.isRetriable(ctx, err) {
 		return c.failRequest(ctx, "non-retriable error", err)
 	}
-	if resetErr := body.reset(); resetErr != nil {
+	if resetErr := body.Reset(); resetErr != nil {
 		return nil, retries.Halt(resetErr)
 	}
 	return nil, retries.Continue(err)
 }
 
 // Fails the request with a retries.Err to halt future retries.
-func (c *ApiClient) failRequest(ctx context.Context, msg string, err error) (*responseBody, *retries.Err) {
+func (c *ApiClient) failRequest(ctx context.Context, msg string, err error) (*common.ResponseWrapper, *retries.Err) {
 	logger.Debugf(ctx, "%s: %s", msg, err)
 	return nil, retries.Halt(err)
 }
@@ -216,10 +212,10 @@ func (c *ApiClient) attempt(
 	ctx context.Context,
 	method string,
 	requestURL string,
-	requestBody requestBody,
+	requestBody common.RequestBody,
 	visitors ...RequestVisitor,
-) func() (*responseBody, *retries.Err) {
-	return func() (*responseBody, *retries.Err) {
+) func() (*common.ResponseWrapper, *retries.Err) {
+	return func() (*common.ResponseWrapper, *retries.Err) {
 		err := c.rateLimiter.Wait(ctx)
 		if err != nil {
 			return c.failRequest(ctx, "failed in rate limiter", err)
@@ -250,12 +246,12 @@ func (c *ApiClient) attempt(
 		}
 
 		// By this point, the request body has certainly been consumed.
-		responseBody, responseBodyErr := c.fromResponse(response)
+		responseBody, responseBodyErr := c.fromResponse(response, requestBody)
 		if responseBodyErr != nil {
 			return c.failRequest(ctx, "failed while reading response", responseBodyErr)
 		}
 
-		mappedError := c.config.ErrorMapper(ctx, response, responseBody.ReadCloser)
+		mappedError := c.config.ErrorMapper(ctx, responseBody)
 		defer c.recordRequestLog(ctx, request, response, mappedError, requestBody.DebugBytes, responseBody.DebugBytes)
 
 		if mappedError == nil {
@@ -279,44 +275,13 @@ func (c *ApiClient) recordRequestLog(
 	if !logger.Get(ctx).Enabled(ctx, logger.LevelDebug) {
 		return
 	}
-	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("%s %s", request.Method,
-		escapeNewLines(request.URL.Path)))
-	if request.URL.RawQuery != "" {
-		sb.WriteString("?")
-		q, _ := url.QueryUnescape(request.URL.RawQuery)
-		sb.WriteString(q)
-	}
-	sb.WriteString("\n")
-	if c.config.DebugHeaders {
-		sb.WriteString("> * Host: ")
-		sb.WriteString(escapeNewLines(request.Host))
-		sb.WriteString("\n")
-		for k, v := range request.Header {
-			trunc := onlyNBytes(strings.Join(v, ""), c.config.DebugTruncateBytes)
-			sb.WriteString(fmt.Sprintf("> * %s: %s\n", k, escapeNewLines(trunc)))
-		}
-	}
-	if len(requestBody) > 0 {
-		sb.WriteString(c.redactedDump("> ", requestBody))
-		sb.WriteString("\n")
-	}
-	sb.WriteString("< ")
-	if response != nil {
-		sb.WriteString(fmt.Sprintf("%s %s", response.Proto, response.Status))
-		// Only display error on this line if the response body is empty.
-		// Otherwise the response body will include details about the error.
-		if len(responseBody) == 0 && err != nil {
-			sb.WriteString(fmt.Sprintf(" (Error: %s)", err))
-		}
-	} else {
-		sb.WriteString(fmt.Sprintf("Error: %s", err))
-	}
-	sb.WriteString("\n")
-	if len(responseBody) > 0 {
-		sb.WriteString(c.redactedDump("< ", responseBody))
-	}
-	logger.Debugf(ctx, sb.String()) // lgtm [go/log-injection] lgtm [go/clear-text-logging]
+	message := httplog.RoundTripStringer{
+		Response:     response,
+		Err:          err,
+		RequestBody:  requestBody,
+		ResponseBody: responseBody,
+	}.String()
+	logger.Debugf(ctx, message)
 }
 
 // RoundTrip implements http.RoundTripper to integrate with golang.org/x/oauth2
@@ -324,7 +289,7 @@ func (c *ApiClient) RoundTrip(request *http.Request) (*http.Response, error) {
 	ctx := request.Context()
 	requestURL := request.URL.String()
 	resp, err := retries.Poll(ctx, c.config.RetryTimeout,
-		c.attempt(ctx, request.Method, requestURL, requestBody{
+		c.attempt(ctx, request.Method, requestURL, common.RequestBody{
 			Reader: request.Body,
 			// DO NOT DECODE BODY, because it may contain sensitive payload,
 			// like Azure Service Principal in a multipart/form-data body.
@@ -356,7 +321,7 @@ func (c *ApiClient) perform(
 	requestURL string,
 	data interface{},
 	visitors ...RequestVisitor,
-) (*responseBody, error) {
+) (*common.ResponseWrapper, error) {
 	requestBody, err := makeRequestBody(method, &requestURL, data)
 	if err != nil {
 		return nil, fmt.Errorf("request marshal: %w", err)
@@ -379,11 +344,4 @@ func orDefault(configured, _default int) int {
 		return _default
 	}
 	return configured
-}
-
-// CWE-117 prevention
-func escapeNewLines(in string) string {
-	in = strings.Replace(in, "\n", "", -1)
-	in = strings.Replace(in, "\r", "", -1)
-	return in
 }

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -151,14 +151,14 @@ func (c *ApiClient) fromResponse(r *http.Response) (responseBody, error) {
 	isJSON := strings.HasPrefix(r.Header.Get("Content-Type"), "application/json")
 	streamResponse := r.Request.Header.Get("Accept") != "application/json" && !isJSON
 	if streamResponse {
-		return newResponseBody(r.Body, r.Header, r.StatusCode, r.Status)
+		return newResponseBody(r.Body, r)
 	}
 	defer r.Body.Close()
 	bs, err := io.ReadAll(r.Body)
 	if err != nil {
 		return responseBody{}, fmt.Errorf("response body: %w", err)
 	}
-	return newResponseBody(bs, r.Header, r.StatusCode, r.Status)
+	return newResponseBody(bs, r)
 }
 
 func (c *ApiClient) redactedDump(prefix string, body []byte) (res string) {
@@ -338,13 +338,7 @@ func (c *ApiClient) RoundTrip(request *http.Request) (*http.Response, error) {
 	}
 	// here we assume only successful responses, as HTTP 4XX and 5XX are mapped
 	// to Go's error implementations.
-	return &http.Response{
-		Request:    request,
-		Status:     resp.Status,
-		StatusCode: resp.StatusCode,
-		Header:     resp.Header,
-		Body:       resp.ReadCloser,
-	}, nil
+	return resp.Response, nil
 }
 
 // InContextForOAuth2 returns a context with a custom *http.Client to be used

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -276,10 +276,12 @@ func (c *ApiClient) recordRequestLog(
 		return
 	}
 	message := httplog.RoundTripStringer{
-		Response:     response,
-		Err:          err,
-		RequestBody:  requestBody,
-		ResponseBody: responseBody,
+		Response:           response,
+		Err:                err,
+		RequestBody:        requestBody,
+		ResponseBody:       responseBody,
+		DebugHeaders:       c.config.DebugHeaders,
+		DebugTruncateBytes: c.config.DebugTruncateBytes,
 	}.String()
 	logger.Debugf(ctx, message)
 }

--- a/httpclient/api_client_test.go
+++ b/httpclient/api_client_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go/common"
 	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -181,7 +182,7 @@ func TestHaltAttemptForLimit(t *testing.T) {
 		config:      ClientConfig{},
 		rateLimiter: &rate.Limiter{},
 	}
-	req, err := newRequestBody([]byte{})
+	req, err := common.NewRequestBody([]byte{})
 	require.NoError(t, err)
 	_, rerr := c.attempt(ctx, "GET", "foo", req)()
 	require.NotNil(t, rerr)
@@ -192,7 +193,7 @@ func TestHaltAttemptForLimit(t *testing.T) {
 func TestHaltAttemptForNewRequest(t *testing.T) {
 	ctx := context.Background()
 	c := NewApiClient(ClientConfig{})
-	req, err := newRequestBody([]byte{})
+	req, err := common.NewRequestBody([]byte{})
 	require.NoError(t, err)
 	_, rerr := c.attempt(ctx, "🥱", "/", req)()
 	require.NotNil(t, rerr)
@@ -203,7 +204,7 @@ func TestHaltAttemptForNewRequest(t *testing.T) {
 func TestHaltAttemptForVisitor(t *testing.T) {
 	ctx := context.Background()
 	c := NewApiClient(ClientConfig{})
-	req, err := newRequestBody([]byte{})
+	req, err := common.NewRequestBody([]byte{})
 	require.NoError(t, err)
 	_, rerr := c.attempt(ctx, "GET", "/", req,
 		func(r *http.Request) error {

--- a/httpclient/api_client_test.go
+++ b/httpclient/api_client_test.go
@@ -420,7 +420,7 @@ func TestInlineArrayDebugging_StreamResponse(t *testing.T) {
 
 	require.Equal(t, `[DEBUG] GET /a?a=3&b=0&c=23
 <  
-< [non-JSON document of 15 bytes]. <io.ReadCloser>`, bufLogger.String())
+< <Streaming response>`, bufLogger.String())
 }
 
 func TestStreamRequestFromFileWithReset(t *testing.T) {

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/databricks/databricks-sdk-go/common"
 )
 
 type HttpError struct {
@@ -25,20 +27,20 @@ func (r *HttpError) Error() string {
 }
 
 // DefaultErrorMapper returns *HttpError
-func DefaultErrorMapper(ctx context.Context, resp *http.Response, body io.ReadCloser) error {
-	if resp.StatusCode < 400 {
+func DefaultErrorMapper(ctx context.Context, resp common.ResponseWrapper) error {
+	if resp.Response.StatusCode < 400 {
 		return nil
 	}
-	raw, err := io.ReadAll(body)
+	raw, err := io.ReadAll(resp.ReadCloser)
 	if err != nil {
 		return &HttpError{
-			Response: resp,
+			Response: resp.Response,
 			Message:  "failed to read response",
 			err:      err,
 		}
 	}
 	return &HttpError{
-		Response: resp,
+		Response: resp.Response,
 		Message:  string(raw),
 	}
 }

--- a/httpclient/request.go
+++ b/httpclient/request.go
@@ -1,10 +1,7 @@
 package httpclient
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -15,68 +12,6 @@ import (
 	"github.com/google/go-querystring/query"
 	"golang.org/x/oauth2"
 )
-
-// Represents a request body.
-//
-// If the provided request data is an io.Reader, DebugBytes is set to
-// "<io.Reader>". Otherwise, DebugBytes is set to the marshaled JSON
-// representation of the request data, and ReadCloser is set to a new
-// io.ReadCloser that reads from DebugBytes.
-//
-// Request bodies are never closed by the client, hence only accepting
-// io.Reader.
-type RequestBody struct {
-	Reader      io.Reader
-	ContentType string
-	DebugBytes  []byte
-}
-
-func newRequestBody(data any) (RequestBody, error) {
-	switch v := data.(type) {
-	case io.Reader:
-		return RequestBody{
-			Reader:     v,
-			DebugBytes: []byte("<io.Reader>"),
-		}, nil
-	case string:
-		return RequestBody{
-			Reader:     strings.NewReader(v),
-			DebugBytes: []byte(v),
-		}, nil
-	case []byte:
-		return RequestBody{
-			Reader:     bytes.NewReader(v),
-			DebugBytes: v,
-		}, nil
-	default:
-		bs, err := json.Marshal(data)
-		if err != nil {
-			return RequestBody{}, fmt.Errorf("request marshal failure: %w", err)
-		}
-		return RequestBody{
-			Reader:      bytes.NewReader(bs),
-			ContentType: "application/json",
-			DebugBytes:  bs,
-		}, nil
-	}
-}
-
-// Reset a request body to its initial state.
-//
-// This is used to retry requests with a body that has already been read.
-// If the request body is not resettable (i.e. not nil and of type other than
-// strings.Reader or bytes.Reader), this will return an error.
-func (r RequestBody) reset() error {
-	if r.Reader == nil {
-		return nil
-	}
-	if v, ok := r.Reader.(io.Seeker); ok {
-		_, err := v.Seek(0, io.SeekStart)
-		return err
-	} else {
-		return fmt.Errorf("cannot reset reader of type %T", r.Reader)
-	}
-}
 
 // WithRequestHeader adds a request visitor, that sets a header on a request
 func WithRequestHeader(k, v string) DoOption {

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -98,7 +98,11 @@ func WithResponseUnmarshal(response any) DoOption {
 				_, err := raw.Write(bs)
 				return err
 			}
-			return json.Unmarshal(bs, &response)
+			err = json.Unmarshal(bs, &response)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal response body: %w (original: %s)", err, string(bs))
+			}
+			return nil
 		},
 	}
 }

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -18,28 +18,22 @@ import (
 type responseBody struct {
 	ReadCloser io.ReadCloser
 	DebugBytes []byte
-	Header     http.Header
-	Status     string
-	StatusCode int
+	Response   *http.Response
 }
 
-func newResponseBody(data any, header http.Header, statusCode int, status string) (responseBody, error) {
+func newResponseBody(data any, response *http.Response) (responseBody, error) {
 	switch v := data.(type) {
 	case io.ReadCloser:
 		return responseBody{
 			ReadCloser: v,
 			DebugBytes: []byte("<io.ReadCloser>"),
-			Header:     header,
-			StatusCode: statusCode,
-			Status:     status,
+			Response:   response,
 		}, nil
 	case []byte:
 		return responseBody{
 			ReadCloser: io.NopCloser(bytes.NewReader(v)),
 			DebugBytes: v,
-			Header:     header,
-			StatusCode: statusCode,
-			Status:     status,
+			Response:   response,
 		}, nil
 	default:
 		return responseBody{}, errors.New("newResponseBody can only be called with io.ReadCloser or []byte")
@@ -49,7 +43,7 @@ func newResponseBody(data any, header http.Header, statusCode int, status string
 func WithResponseHeader(key string, value *string) DoOption {
 	return DoOption{
 		out: func(body *responseBody) error {
-			*value = body.Header.Get(key)
+			*value = body.Response.Header.Get(key)
 			return nil
 		},
 	}

--- a/logger/httplog/body_logger.go
+++ b/logger/httplog/body_logger.go
@@ -117,9 +117,12 @@ func (b bodyLogger) redactedDump(prefix string, body []byte) string {
 		truncated := onlyNBytes(string(body), b.debugTruncateBytes)
 		splitByNewlines := strings.Split(truncated, "\n")
 		sb := strings.Builder{}
-		for _, line := range splitByNewlines {
+		for i, line := range splitByNewlines {
+			if i != 0 {
+				sb.WriteString("\n")
+			}
 			line = strings.Trim(line, "\r")
-			sb.WriteString(fmt.Sprintf("%s%s\n", prefix, line))
+			sb.WriteString(fmt.Sprintf("%s%s", prefix, line))
 		}
 		return sb.String()
 	}

--- a/logger/httplog/body_logger_test.go
+++ b/logger/httplog/body_logger_test.go
@@ -1,4 +1,4 @@
-package httpclient
+package httplog
 
 import (
 	"encoding/json"

--- a/logger/httplog/body_logger_test.go
+++ b/logger/httplog/body_logger_test.go
@@ -79,6 +79,5 @@ func TestBodyLoggerNonJSONNewline(t *testing.T) {
 < 	<body>
 < 		Hello world!
 < 	</body>
-< </html>
-`)
+< </html>`)
 }

--- a/logger/httplog/body_logger_test.go
+++ b/logger/httplog/body_logger_test.go
@@ -66,5 +66,19 @@ func TestBodyLoggerEmpty(t *testing.T) {
 
 func TestBodyLoggerNotJson(t *testing.T) {
 	dump := bodyLogger{debugTruncateBytes: 10}.redactedDump("", []byte("<html>"))
-	assert.Equal(t, dump, "[non-JSON document of 6 bytes]. <html>")
+	assert.Equal(t, dump, "<html>")
+}
+
+func TestBodyLoggerNonJSONNewline(t *testing.T) {
+	dump := bodyLogger{debugTruncateBytes: 100}.redactedDump("< ", []byte(`<html>
+	<body>
+		Hello world!
+	</body>
+</html>`))
+	assert.Equal(t, dump, `< <html>
+< 	<body>
+< 		Hello world!
+< 	</body>
+< </html>
+`)
 }

--- a/logger/httplog/round_trip_stringer.go
+++ b/logger/httplog/round_trip_stringer.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
 type RoundTripStringer struct {

--- a/logger/httplog/round_trip_stringer.go
+++ b/logger/httplog/round_trip_stringer.go
@@ -1,0 +1,78 @@
+package httplog
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type RoundTripStringer struct {
+	Response           *http.Response
+	Err                error
+	RequestBody        []byte
+	ResponseBody       []byte
+	DebugHeaders       bool
+	DebugTruncateBytes int
+}
+
+func (r RoundTripStringer) String() string {
+	request := r.Response.Request
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%s %s", request.Method,
+		escapeNewLines(request.URL.Path)))
+	if request.URL.RawQuery != "" {
+		sb.WriteString("?")
+		q, _ := url.QueryUnescape(request.URL.RawQuery)
+		sb.WriteString(q)
+	}
+	sb.WriteString("\n")
+	if r.DebugHeaders {
+		sb.WriteString("> * Host: ")
+		sb.WriteString(escapeNewLines(request.Host))
+		sb.WriteString("\n")
+		for k, v := range request.Header {
+			trunc := onlyNBytes(strings.Join(v, ""), r.DebugTruncateBytes)
+			sb.WriteString(fmt.Sprintf("> * %s: %s\n", k, escapeNewLines(trunc)))
+		}
+	}
+	if len(r.RequestBody) > 0 {
+		sb.WriteString(r.redactedDump("> ", r.RequestBody))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("< ")
+	if r.Response != nil {
+		sb.WriteString(fmt.Sprintf("%s %s", r.Response.Proto, r.Response.Status))
+		// Only display error on this line if the response body is empty.
+		// Otherwise the response body will include details about the error.
+		if len(r.ResponseBody) == 0 && r.Err != nil {
+			sb.WriteString(fmt.Sprintf(" (Error: %s)", r.Err))
+		}
+	} else {
+		sb.WriteString(fmt.Sprintf("Error: %s", r.Err))
+	}
+	sb.WriteString("\n")
+	if r.DebugHeaders {
+		for k, v := range r.Response.Header {
+			trunc := onlyNBytes(strings.Join(v, ""), r.DebugTruncateBytes)
+			sb.WriteString(fmt.Sprintf("< * %s: %s\n", k, escapeNewLines(trunc)))
+		}
+	}
+	if len(r.ResponseBody) > 0 {
+		sb.WriteString(r.redactedDump("< ", r.ResponseBody))
+	}
+	return sb.String()
+}
+
+func (r RoundTripStringer) redactedDump(prefix string, body []byte) (res string) {
+	return bodyLogger{
+		debugTruncateBytes: r.DebugTruncateBytes,
+	}.redactedDump(prefix, body)
+}
+
+// CWE-117 prevention
+func escapeNewLines(in string) string {
+	in = strings.Replace(in, "\n", "", -1)
+	in = strings.Replace(in, "\r", "", -1)
+	return in
+}

--- a/logger/httplog/round_trip_stringer.go
+++ b/logger/httplog/round_trip_stringer.go
@@ -10,12 +10,13 @@ import (
 )
 
 type RoundTripStringer struct {
-	Response           *http.Response
-	Err                error
-	RequestBody        []byte
-	ResponseBody       []byte
-	DebugHeaders       bool
-	DebugTruncateBytes int
+	Response                 *http.Response
+	Err                      error
+	RequestBody              []byte
+	ResponseBody             []byte
+	DebugHeaders             bool
+	DebugAuthorizationHeader bool
+	DebugTruncateBytes       int
 }
 
 func (r RoundTripStringer) writeHeaders(sb *strings.Builder, prefix string, headers http.Header) {
@@ -29,6 +30,9 @@ func (r RoundTripStringer) writeHeaders(sb *strings.Builder, prefix string, head
 			sb.WriteString("\n")
 		}
 		v := headers[k]
+		if k == "Authorization" && !r.DebugAuthorizationHeader {
+			v = []string{"REDACTED"}
+		}
 		trunc := onlyNBytes(strings.Join(v, ""), r.DebugTruncateBytes)
 		sb.WriteString(fmt.Sprintf("> * %s: %s", k, escapeNewLines(trunc)))
 	}

--- a/logger/httplog/round_trip_stringer.go
+++ b/logger/httplog/round_trip_stringer.go
@@ -34,7 +34,7 @@ func (r RoundTripStringer) writeHeaders(sb *strings.Builder, prefix string, head
 			v = []string{"REDACTED"}
 		}
 		trunc := onlyNBytes(strings.Join(v, ""), r.DebugTruncateBytes)
-		sb.WriteString(fmt.Sprintf("> * %s: %s", k, escapeNewLines(trunc)))
+		sb.WriteString(fmt.Sprintf("%s* %s: %s", prefix, k, escapeNewLines(trunc)))
 	}
 }
 

--- a/logger/httplog/round_trip_stringer_test.go
+++ b/logger/httplog/round_trip_stringer_test.go
@@ -1,0 +1,1 @@
+package httplog

--- a/logger/httplog/round_trip_stringer_test.go
+++ b/logger/httplog/round_trip_stringer_test.go
@@ -55,8 +55,8 @@ func TestRequestAndResponseHaveHeadersAndBody(t *testing.T) {
 > * Foo: bar
 > request-hello
 < HTTP/1.1 200 OK
-> * Response-Bar: baz
-> * Response-Foo: bar
+< * Response-Bar: baz
+< * Response-Foo: bar
 < response-hello`, res)
 }
 

--- a/logger/httplog/round_trip_stringer_test.go
+++ b/logger/httplog/round_trip_stringer_test.go
@@ -1,1 +1,87 @@
 package httplog
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoHeadersNoBody(t *testing.T) {
+	res := RoundTripStringer{
+		Response: &http.Response{
+			Request: &http.Request{
+				Method: "GET",
+				URL:    &url.URL{Path: "/"},
+			},
+			Status: "200 OK",
+			Proto:  "HTTP/1.1",
+		},
+	}.String()
+	assert.Equal(t, `GET /
+< HTTP/1.1 200 OK`, res)
+}
+
+func TestRequestAndResponseHaveHeadersAndBody(t *testing.T) {
+	res := RoundTripStringer{
+		Response: &http.Response{
+			Request: &http.Request{
+				Method: "GET",
+				URL:    &url.URL{Path: "/"},
+				Header: http.Header{
+					"Foo": []string{"bar"},
+					"Bar": []string{"baz"},
+				},
+			},
+			Status: "200 OK",
+			Proto:  "HTTP/1.1",
+			Header: http.Header{
+				"Response-Foo": []string{"bar"},
+				"Response-Bar": []string{"baz"},
+			},
+		},
+		RequestBody:        []byte("request-hello"),
+		ResponseBody:       []byte("response-hello"),
+		DebugHeaders:       true,
+		DebugTruncateBytes: 100,
+	}.String()
+	assert.Equal(t, `GET /
+> * Host: 
+> * Bar: baz
+> * Foo: bar
+> request-hello
+< HTTP/1.1 200 OK
+> * Response-Bar: baz
+> * Response-Foo: bar
+< response-hello`, res)
+}
+
+func TestDoNotPrintHeadersWhenNotConfigured(t *testing.T) {
+	res := RoundTripStringer{
+		Response: &http.Response{
+			Request: &http.Request{
+				Method: "GET",
+				URL:    &url.URL{Path: "/"},
+				Header: http.Header{
+					"Foo": []string{"bar"},
+					"Bar": []string{"baz"},
+				},
+			},
+			Status: "200 OK",
+			Proto:  "HTTP/1.1",
+			Header: http.Header{
+				"Response-Foo": []string{"bar"},
+				"Response-Bar": []string{"baz"},
+			},
+		},
+		RequestBody:        []byte("request-hello"),
+		ResponseBody:       []byte("response-hello"),
+		DebugHeaders:       false,
+		DebugTruncateBytes: 100,
+	}.String()
+	assert.Equal(t, `GET /
+> request-hello
+< HTTP/1.1 200 OK
+< response-hello`, res)
+}


### PR DESCRIPTION
## Changes
Issues like https://github.com/databricks/terraform-provider-databricks/issues/3031 are difficult for users to debug when Databricks APIs respond with unexpected response bodies. This is often a bug in either the API (returning a non-JSON error message, for example) or from the caller (e.g. calling update but not specifying the ID of the resource to update), though it could also be due to a bug in the SDK itself. 

This PR improves the debuggability of errors returned from the SDK due to malformed responses or other failures to process the response by including the request log in the error, along with helpful text that points the user to report the issue at the Go SDK so it can be triaged and fixed.

The returned error's `Error()` method will produce a string like this:

unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
```
GET /a
> * Host: 
> * Accept: application/json
> * Authorization: REDACTED
> * User-Agent: unknown/0.0.0 databricks-sdk-go/0.28.0 go/1.21.3 os/darwin auth/pat
< HTTP/2.0 Internal Server Error
< <html><body>hello</body></html>
```

Note that the markdown ticks are present in the request log itself for ease of copy-pasting into Github's new issue UI.

## Tests
- [x] New unit tests cover RoundTripStringer.

