### PR TITLE
Support schema descriptions when generating SDK

### DIFF
--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -106,8 +106,18 @@ func (svc *Service) HasPagination() bool {
 	return false
 }
 
+func (svc *Service) getDescription(param openapi.Parameter) string {
+	if param.Description != "" {
+		return param.Description
+	}
+	if param.Schema != nil {
+		return param.Schema.Description
+	}
+	return ""
+}
+
 func (svc *Service) paramToField(op *openapi.Operation, param openapi.Parameter) *Field {
-	named := Named{param.Name, param.Description}
+	named := Named{param.Name, svc.getDescription(param)}
 	return &Field{
 		Named:    named,
 		Required: param.Required,

--- a/openapi/generator/config.go
+++ b/openapi/generator/config.go
@@ -135,7 +135,10 @@ func (c *Generator) Apply(ctx context.Context, batch *code.Batch, suite *roll.Su
 		}
 		filenames = append(filenames, pass.Filenames...)
 	}
-	render.Formatter(ctx, c.dir, filenames, c.Formatter)
+	err := render.Formatter(ctx, c.dir, filenames, c.Formatter)
+	if err != nil {
+		return err
+	}
 	sort.Strings(filenames)
 	sb := bytes.NewBuffer([]byte{})
 	for _, v := range filenames {


### PR DESCRIPTION
## Changes
Support schema descriptions when generating SDK
Manually created specs have this form
```
{
          "in": "path",
          "name": "ip_access_list_id",
          "required": true,
         "description": "description here". <-------
        }
```
Generated specs have this form
```
{
          "in": "path",
          "name": "ip_access_list_id",
          "required": true,
          "schema": {
            "description": "description here"  <-------
            "type": "string"
          }
        }
```


## Tests
deco openapi generate-sdk cli --openapi-spec universe:~/universe

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

