### PR TITLE
Ensure that NewResponseWrapper resets the Body of the *http.Response if it is consumed for DebugBytes

### DIFF
--- a/common/response.go
+++ b/common/response.go
@@ -41,6 +41,9 @@ func makeResponseWrapper(data any, response *http.Response, req RequestBody) (Re
 			RequestBody: req,
 		}, nil
 	case []byte:
+		// We need to set the response body to a new ReadCloser, because the
+		// original response body has already been read and closed.
+		response.Body = io.NopCloser(bytes.NewReader(v))
 		return ResponseWrapper{
 			ReadCloser:  io.NopCloser(bytes.NewReader(v)),
 			DebugBytes:  v,

--- a/common/response_test.go
+++ b/common/response_test.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type oneTimeCloser struct {
+	r        io.Reader
+	isClosed bool
+}
+
+func newOneTimeCloser(r io.Reader) *oneTimeCloser {
+	return &oneTimeCloser{r: r}
+}
+
+func (c *oneTimeCloser) Read(p []byte) (n int, err error) {
+	if c.isClosed {
+		return 0, io.ErrClosedPipe
+	}
+	return c.r.Read(p)
+}
+
+func (c *oneTimeCloser) Close() error {
+	if c.isClosed {
+		return io.ErrClosedPipe
+	}
+	c.isClosed = true
+	return nil
+}
+
+func TestNewResponseWrapperBodyCanBeConsumed(t *testing.T) {
+	ctx := context.Background()
+	inner, err := http.NewRequestWithContext(ctx, "GET", "abc", nil)
+	inner.Header.Set("Content-Type", "application/json")
+	require.NoError(t, err)
+	req, err := NewRequestBody("abc123")
+	require.NoError(t, err)
+	resp := &http.Response{
+		Body:    newOneTimeCloser(strings.NewReader("Response Body")),
+		Request: inner,
+		Header:  make(http.Header),
+	}
+	resp.Header.Set("Content-Type", "application/json")
+
+	wrapper, err := NewResponseWrapper(resp, req)
+	require.NoError(t, err)
+
+	bs, err := io.ReadAll(wrapper.Response.Body)
+	require.NoError(t, err)
+	// The response body should be available both in the Body field of the
+	// *http.Response as well as the DebugBytes field of the ResponseWrapper,
+	// because this is a non-streaming response.
+	require.Equal(t, "Response Body", string(bs))
+	require.Equal(t, "Response Body", string(wrapper.DebugBytes))
+}


### PR DESCRIPTION
## Changes
Computing DebugBytes requires consuming the response body. In the client's main pathway, we don't use the response from the `*http.Request` field, but the OAuth implementation calling `RoundTrip()` does. This PR ensures that we reset the response for debug logging purposes.

## Tests
- [x] Unit test
- [x] Manually ran an integration test that failed with OAuth failure in nightlies, this passed.
