### PR TITLE
Add debug authorization header flag

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,13 +31,14 @@ func New(cfg *config.Config) (*DatabricksClient, error) {
 	return &DatabricksClient{
 		Config: cfg,
 		client: httpclient.NewApiClient(httpclient.ClientConfig{
-			RetryTimeout:       retryTimeout,
-			HTTPTimeout:        httpTimeout,
-			RateLimitPerSecond: orDefault(cfg.RateLimitPerSecond, 15),
-			DebugHeaders:       cfg.DebugHeaders,
-			DebugTruncateBytes: cfg.DebugTruncateBytes,
-			InsecureSkipVerify: cfg.InsecureSkipVerify,
-			Transport:          cfg.HTTPTransport,
+			RetryTimeout:             retryTimeout,
+			HTTPTimeout:              httpTimeout,
+			RateLimitPerSecond:       orDefault(cfg.RateLimitPerSecond, 15),
+			DebugHeaders:             cfg.DebugHeaders,
+			DebugAuthorizationHeader: cfg.DebugAuthorizationHeader,
+			DebugTruncateBytes:       cfg.DebugTruncateBytes,
+			InsecureSkipVerify:       cfg.InsecureSkipVerify,
+			Transport:                cfg.HTTPTransport,
 			Visitors: []httpclient.RequestVisitor{
 				cfg.Authenticate,
 				func(r *http.Request) error {

--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,9 @@ type Config struct {
 	// Debug HTTP headers of requests made by the provider. Default is false.
 	DebugHeaders bool `name:"debug_headers" env:"DATABRICKS_DEBUG_HEADERS" auth:"-"`
 
+	// If true, the unredacted Authorization header will be logged. Default is false.
+	DebugAuthorizationHeader bool `name:"debug_authorization_header" env:"DATABRICKS_DEBUG_AUTHORIZATION_HEADER" auth:"-"`
+
 	// Maximum number of requests per second made to Databricks REST API.
 	RateLimitPerSecond int `name:"rate_limit" env:"DATABRICKS_RATE_LIMIT" auth:"-"`
 
@@ -227,13 +230,14 @@ func (c *Config) EnsureResolved() error {
 	}
 	c.refreshCtx = ctx
 	c.refreshClient = httpclient.NewApiClient(httpclient.ClientConfig{
-		DebugHeaders:       c.DebugHeaders,
-		DebugTruncateBytes: c.DebugTruncateBytes,
-		InsecureSkipVerify: c.InsecureSkipVerify,
-		RetryTimeout:       time.Duration(c.RetryTimeoutSeconds) * time.Second,
-		HTTPTimeout:        time.Duration(c.HTTPTimeoutSeconds) * time.Second,
-		Transport:          c.HTTPTransport,
-		ErrorMapper:        c.refreshTokenErrorMapper,
+		DebugHeaders:             c.DebugHeaders,
+		DebugAuthorizationHeader: c.DebugAuthorizationHeader,
+		DebugTruncateBytes:       c.DebugTruncateBytes,
+		InsecureSkipVerify:       c.InsecureSkipVerify,
+		RetryTimeout:             time.Duration(c.RetryTimeoutSeconds) * time.Second,
+		HTTPTimeout:              time.Duration(c.HTTPTimeoutSeconds) * time.Second,
+		Transport:                c.HTTPTransport,
+		ErrorMapper:              c.refreshTokenErrorMapper,
 		TransientErrors: []string{
 			"throttled",
 			"too many requests",

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -26,12 +26,13 @@ type RequestVisitor func(*http.Request) error
 type ClientConfig struct {
 	Visitors []RequestVisitor
 
-	RetryTimeout       time.Duration
-	HTTPTimeout        time.Duration
-	InsecureSkipVerify bool
-	DebugHeaders       bool
-	DebugTruncateBytes int
-	RateLimitPerSecond int
+	RetryTimeout             time.Duration
+	HTTPTimeout              time.Duration
+	InsecureSkipVerify       bool
+	DebugHeaders             bool
+	DebugAuthorizationHeader bool
+	DebugTruncateBytes       int
+	RateLimitPerSecond       int
 
 	ErrorMapper     func(ctx context.Context, resp common.ResponseWrapper) error
 	ErrorRetriable  func(ctx context.Context, err error) bool
@@ -257,8 +258,8 @@ func (c *ApiClient) recordRequestLog(
 		RequestBody:              requestBody,
 		ResponseBody:             responseBody,
 		DebugHeaders:             c.config.DebugHeaders,
+		DebugAuthorizationHeader: c.config.DebugAuthorizationHeader,
 		DebugTruncateBytes:       c.config.DebugTruncateBytes,
-		DebugAuthorizationHeader: true,
 	}.String()
 	logger.Debugf(ctx, message)
 }


### PR DESCRIPTION
## Changes
DebugHeaders by default prints all headers, including the sensitive Authorization header. To allow users to print debug logs with headers but without including this sensitive header, we introduce a new flag, DebugAuthorizationHeader, which is disabled by default for users. This way, enabling debug headers does not automatically leak the token used to authenticate to our REST API.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

