### PR TITLE
Handle empty response for errors

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -168,6 +168,11 @@ func GetAPIError(ctx context.Context, resp common.ResponseWrapper) error {
 }
 
 func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byte) *APIError {
+	if len(responseBody) == 0 {
+		return &APIError{
+			StatusCode: resp.StatusCode,
+		}
+	}
 	// try to read in nicely formatted API error response
 	var errorBody APIErrorBody
 	err := json.Unmarshal(responseBody, &errorBody)

--- a/apierr/errors_test.go
+++ b/apierr/errors_test.go
@@ -1,0 +1,24 @@
+package apierr
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAPIErrorHandlesEmptyResponse(t *testing.T) {
+	resp := common.ResponseWrapper{
+		Response: &http.Response{
+			StatusCode: http.StatusConflict,
+		},
+		DebugBytes: []byte{},
+		ReadCloser: io.NopCloser(bytes.NewReader([]byte{})),
+	}
+	err := GetAPIError(context.Background(), resp)
+	assert.Equal(t, err.(*APIError).Message, "")
+}


### PR DESCRIPTION
## Changes
Credential deletion fails with 409 and no response body if the credential is in use with a running workspace. This leads to some race conditions because workspace deletion is asynchronous, so attempting to delete a credential while a workspace is running will ultimately fail. This PR tolerates empty error bodies. Note that `Unwrap()` for APIError will delegate this to the appropriate status code-based error, so users can still use `errors.Is` to examine errors with no body.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

