### PR TITLE
Add utility to retry on specific errors

### DIFF
--- a/internal/deployment_test.go
+++ b/internal/deployment_test.go
@@ -256,6 +256,12 @@ func TestMwsAccWorkspaces(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := retries.New[struct{}](retries.OnErrors(apierr.ErrResourceConflict)).Wait(ctx, func(ctx context.Context) error {
+			return a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
+		})
+		require.NoError(t, err)
+	})
 
 	// this also takes a while
 	_, err = a.Workspaces.UpdateAndWait(ctx, provisioning.UpdateWorkspaceRequest{

--- a/internal/deployment_test.go
+++ b/internal/deployment_test.go
@@ -228,7 +228,7 @@ func TestMwsAccWorkspaces(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		err := retries.NewWaiter(retries.OnErrors(apierr.ErrResourceConflict)).Wait(ctx, func(ctx context.Context) error {
+		err := retries.New[struct{}](retries.OnErrors(apierr.ErrResourceConflict)).Wait(ctx, func(ctx context.Context) error {
 			return a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
 		})
 		require.NoError(t, err)

--- a/internal/deployment_test.go
+++ b/internal/deployment_test.go
@@ -1,8 +1,11 @@
 package internal
 
 import (
+	"context"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,7 +228,9 @@ func TestMwsAccWorkspaces(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		err := a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
+		err := retries.NewWaiter(retries.OnErrors(apierr.ErrResourceConflict)).Wait(ctx, func(ctx context.Context) error {
+			return a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
+		})
 		require.NoError(t, err)
 	})
 
@@ -251,13 +256,6 @@ func TestMwsAccWorkspaces(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	// TODO: OpenAPI: add error retry to properly wait for things like
-	// 409 Conflict - INVALID_STATE: Unable to delete, credential is being used by an active workspace
-	defer a.Credentials.DeleteByCredentialsId(ctx, updateRole.CredentialsId)
-	// t.Cleanup(func() {
-	// 	err := a.Credentials.DeleteByCredentialsId(ctx, updateRole.CredentialsId)
-	// 	require.NoError(t, err)
-	// })
 
 	// this also takes a while
 	_, err = a.Workspaces.UpdateAndWait(ctx, provisioning.UpdateWorkspaceRequest{

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -157,10 +157,11 @@ func WithRetryFunc(halt func(error) bool) RetryOption {
 
 // Retrier is a struct that can retry an operation until it succeeds or the timeout is reached.
 // The empty struct indicates that the retrier should run for 20 minutes and retry on any non-nil error.
+// The type parameter is the return type of the Run() method. When using the Wait() method, this can be struct{}.
 //
 // Example:
 //
-//	r := retries.New(retries.WithTimeout(5 * time.Minute), retries.OnError(apierr.ErrResourceConflict))
+//	r := retries.New[struct{}](retries.WithTimeout(5 * time.Minute), retries.OnErrors(apierr.ErrResourceConflict))
 //	err := r.Wait(ctx, func(ctx context.Context) error {
 //		return a.Workspaces.Delete(ctx, provisioning.DeleteWorkspaceRequest{
 //			WorkspaceId: workspace.WorkspaceId,

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -127,10 +127,6 @@ type retrier[T any] struct {
 	config RetryConfig
 }
 
-func NewWaiter(configOpts ...func(*RetryConfig)) *retrier[struct{}] {
-	return New[struct{}](configOpts...)
-}
-
 func New[T any](configOpts ...func(*RetryConfig)) *retrier[T] {
 	config := RetryConfig{
 		timeout: 20 * time.Minute,

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -46,6 +46,10 @@ func (e *Err) Error() string {
 	return e.Err.Error()
 }
 
+func (e *Err) Unwrap() error {
+	return e.Err
+}
+
 func Halt(err error) *Err {
 	return &Err{err, true}
 }

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -2,6 +2,7 @@ package retries
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -41,6 +42,10 @@ type Err struct {
 	Halt bool
 }
 
+func (e *Err) Error() string {
+	return e.Err.Error()
+}
+
 func Halt(err error) *Err {
 	return &Err{err, true}
 }
@@ -57,8 +62,6 @@ func Continuef(format string, err error, args ...interface{}) *Err {
 	wrapped := fmt.Errorf(format, append([]interface{}{err}, args...))
 	return Continue(wrapped)
 }
-
-type WaitFn func() *Err
 
 var maxWait = 10 * time.Second
 var minJitter = 50 * time.Millisecond
@@ -88,55 +91,82 @@ func (et *ErrTimedOut) Unwrap() error {
 	return et.err
 }
 
-func Wait(pctx context.Context, timeout time.Duration, fn WaitFn) error {
-	ctx, cancel := context.WithTimeout(pctx, timeout)
-	defer cancel()
-	var attempt int
-	var lastErr error
-	for {
-		attempt++
-		res := fn()
-		if res == nil {
-			return nil
-		}
-		if res.Halt {
-			return res.Err
-		}
-		lastErr = res.Err
-		wait := Backoff(attempt)
-		timer := time.NewTimer(wait)
-		logger.Tracef(ctx, "%s. Sleeping %s",
-			strings.TrimSuffix(res.Err.Error(), "."),
-			wait.Round(time.Millisecond))
-		select {
-		// stop when either this or parent context times out
-		case <-ctx.Done():
-			timer.Stop()
-			return &ErrTimedOut{lastErr}
-		case <-timer.C:
+type RetryOption func(*RetryConfig)
+
+type RetryConfig struct {
+	timeout    time.Duration
+	shouldHalt func(error) bool
+}
+
+func WithTimeout(timeout time.Duration) RetryOption {
+	return func(rc *RetryConfig) {
+		rc.timeout = timeout
+	}
+}
+
+func OnErrors(on ...error) RetryOption {
+	return func(rc *RetryConfig) {
+		rc.shouldHalt = func(err error) bool {
+			for _, e := range on {
+				if errors.Is(err, e) {
+					return true
+				}
+			}
+			return false
 		}
 	}
 }
 
-func Poll[T any](pctx context.Context, timeout time.Duration, fn func() (*T, *Err)) (*T, error) {
-	ctx, cancel := context.WithTimeout(pctx, timeout)
+func WithHalt(halt func(error) bool) RetryOption {
+	return func(rc *RetryConfig) {
+		rc.shouldHalt = halt
+	}
+}
+
+type retrier[T any] struct {
+	config RetryConfig
+}
+
+func NewWaiter(configOpts ...func(*RetryConfig)) *retrier[struct{}] {
+	return New[struct{}](configOpts...)
+}
+
+func New[T any](configOpts ...func(*RetryConfig)) *retrier[T] {
+	config := RetryConfig{
+		timeout: 20 * time.Minute,
+	}
+	for _, opt := range configOpts {
+		opt(&config)
+	}
+	return &retrier[T]{config}
+}
+
+func (r *retrier[T]) Wait(ctx context.Context, fn func(ctx context.Context) error) error {
+	_, err := r.Run(ctx, func(ctx context.Context) (*T, error) {
+		return nil, fn(ctx)
+	})
+	return err
+}
+
+func (r *retrier[T]) Run(ctx context.Context, fn func(context.Context) (*T, error)) (*T, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.config.timeout)
 	defer cancel()
 	var attempt int
 	var lastErr error
 	for {
 		attempt++
-		entity, err := fn()
+		entity, err := fn(ctx)
 		if err == nil {
 			return entity, nil
 		}
-		if err.Halt {
-			return nil, err.Err
+		if r.config.shouldHalt != nil && r.config.shouldHalt(err) {
+			return nil, err
 		}
-		lastErr = err.Err
+		lastErr = err
 		wait := Backoff(attempt)
 		timer := time.NewTimer(wait)
 		logger.Tracef(ctx, "%s. Sleeping %s",
-			strings.TrimSuffix(err.Err.Error(), "."),
+			strings.TrimSuffix(err.Error(), "."),
 			wait.Round(time.Millisecond))
 		select {
 		// stop when either this or parent context times out
@@ -146,4 +176,32 @@ func Poll[T any](pctx context.Context, timeout time.Duration, fn func() (*T, *Er
 		case <-timer.C:
 		}
 	}
+}
+
+func isHalt(err error) bool {
+	if err == nil {
+		return true
+	}
+	e := err.(*Err)
+	return e == nil || e.Halt
+}
+
+func Wait(ctx context.Context, timeout time.Duration, fn func() *Err) error {
+	return New[struct{}](WithTimeout(timeout), WithHalt(isHalt)).Wait(ctx, func(_ context.Context) error {
+		err := fn()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func Poll[T any](ctx context.Context, timeout time.Duration, fn func() (*T, *Err)) (*T, error) {
+	return New[T](WithTimeout(timeout), WithHalt(isHalt)).Run(ctx, func(_ context.Context) (*T, error) {
+		res, err := fn()
+		if err != nil {
+			return res, err
+		}
+		return res, nil
+	})
 }

--- a/retries/retries_test.go
+++ b/retries/retries_test.go
@@ -1,0 +1,121 @@
+package retries
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetriesDefaults(t *testing.T) {
+	r := Retrier[struct{}]{}
+	assert.Equal(t, r.config.Timeout(), 20*time.Minute)
+	assert.Equal(t, r.config.ShouldRetry(nil), false)
+	assert.Equal(t, r.config.ShouldRetry(errors.New("an error")), true)
+}
+
+func forTesting[T any](opts ...RetryOption) Retrier[T] {
+	r := New[T](opts...)
+	r.config.backoff = func(_ int) time.Duration {
+		return 100 * time.Millisecond
+	}
+	return r
+}
+
+func TestRetriesRunSuccess(t *testing.T) {
+	r := forTesting[int]()
+	res, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		res := 3
+		return &res, nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, *res, 3)
+}
+
+func TestRetriesRunSuccessAfterError(t *testing.T) {
+	r := forTesting[int]()
+	hasRun := false
+	res, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		if !hasRun {
+			hasRun = true
+			return nil, errors.New("an error")
+		}
+		res := 3
+		return &res, nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, *res, 3)
+}
+
+func TestRetriesRunError(t *testing.T) {
+	r := forTesting[int](WithTimeout(200 * time.Millisecond))
+	_, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		return nil, errors.New("an error")
+	})
+	assert.Equal(t, err.Error(), "timed out: an error")
+}
+
+func TestRetriesRunOnErrorRetry(t *testing.T) {
+	e := errors.New("an error")
+	hasRun := false
+	r := forTesting[int](OnErrors(e))
+	_, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		if !hasRun {
+			hasRun = true
+			return nil, e
+		}
+		res := 3
+		return &res, nil
+	})
+	assert.NoError(t, err)
+}
+
+func TestRetriesRunOnErrorNoRetry(t *testing.T) {
+	e := errors.New("an error")
+	hasRun := false
+	r := forTesting[int](OnErrors(e))
+	_, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		if !hasRun {
+			hasRun = true
+			return nil, errors.New("a different error")
+		}
+		res := 3
+		return &res, nil
+	})
+	assert.Equal(t, err.Error(), "a different error")
+}
+
+func TestRetriesRunWithRetryFunc(t *testing.T) {
+	hasRun := false
+	r := forTesting[int](WithRetryFunc(func(err error) bool {
+		return strings.Contains(err.Error(), "hi")
+	}))
+	_, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		if !hasRun {
+			hasRun = true
+			return nil, errors.New("hi hello")
+		}
+		res := 3
+		return &res, nil
+	})
+	assert.NoError(t, err)
+}
+
+func TestRetriesRunWithRetryFuncNoRetry(t *testing.T) {
+	hasRun := false
+	r := forTesting[int](WithRetryFunc(func(err error) bool {
+		return strings.Contains(err.Error(), "hi")
+	}))
+	_, err := r.Run(context.Background(), func(_ context.Context) (*int, error) {
+		if !hasRun {
+			hasRun = true
+			return nil, errors.New("oh no")
+		}
+		res := 3
+		return &res, nil
+	})
+	assert.Equal(t, err.Error(), "oh no")
+}


### PR DESCRIPTION
## Changes
The SDK may return errors that users want to retry. For instance, a user that makes many SCIM operations in parallel and some fail with a Conflict may want to retry those failed requests. To simplify this process for users, this PR introduces a Retrier abstraction that allows users to configure the timeout for retries, a set of errors that should be retried, and/or a custom callback that can check whether a particular error should be retried. Example from this PR:

```go
	t.Cleanup(func() {
		err := retries.New[struct{}](retries.OnErrors(apierr.ErrResourceConflict)).Wait(ctx, func(ctx context.Context) error {
			return a.Credentials.DeleteByCredentialsId(ctx, role.CredentialsId)
		})
		require.NoError(t, err)
	})
```

I have used this to retry credential deletion in TestMwsAccWorkspaces.

## Tests
- [x] Lots of unit tests.

