### PR TITLE
Fix TestAccUsageDownload by increasing HTTP timeout

### DIFF
--- a/internal/billing_test.go
+++ b/internal/billing_test.go
@@ -10,11 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMwsAccUsageDownload(t *testing.T) {
+func TestAccUsageDownload(t *testing.T) {
 	ctx, a := accountTest(t)
 	if !a.Config.IsAws() {
 		t.SkipNow()
 	}
+
+	// The billing API can take multiple minutes to return the records.
+	a.Config.HTTPTimeoutSeconds = 300
+
 	resp, err := a.BillableUsage.Download(ctx, billing.DownloadRequest{
 		StartMonth: "2023-01",
 		EndMonth:   "2023-02",


### PR DESCRIPTION
## Changes
The test consistently timed out. The API for the billing download API states it can take up to multiple minutes, so I increased the HTTP timeout from 1 minute -> 5 minutes.

## Tests
The test now passes.
