### PR TITLE
Fix billing download acceptance test

### DIFF
--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -57,6 +57,8 @@ func accountTest(t *testing.T) (context.Context, *databricks.AccountClient) {
 	loadDebugEnvIfRunsFromIDE(t, "account")
 	cfg := &config.Config{
 		AccountID: GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID"),
+		// Large timeout to support API calls that take long.
+		HTTPTimeoutSeconds: 300,
 	}
 	err := cfg.EnsureResolved()
 	if err != nil {


### PR DESCRIPTION
The timeout is increased when the testing client is created because doing so in the test itself makes the transpilation test (TestLoadsFolder) fail

