### PR TITLE
Support unmarshalling top-level ignored fields

### DIFF
--- a/marshal/reflect_cache.go
+++ b/marshal/reflect_cache.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/databricks/databricks-sdk-go/openapi/code"
 )
 
 var mutexType sync.Mutex
@@ -56,7 +58,12 @@ func parseJSONTag(field reflect.StructField) jsonTag {
 	name := field.Name
 
 	if raw == "-" {
-		return jsonTag{ignore: true}
+		// For CLI deserialization purposes, use the snake case of the field name
+		// as the JSON name.
+		return jsonTag{
+			ignore: true,
+			name:   (&code.Named{Name: name}).SnakeName(),
+		}
 	}
 
 	parts := strings.Split(raw, ",")

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -20,7 +20,7 @@ type UnmarshalOptions struct {
 	//
 	// This option only applies to top-level ignored fields. Nested fields
 	// with `json:"-"` will still be ignored.
-	UnmarshalIgnoredFields bool
+	UnmarshalTopLevelIgnoredFields bool
 }
 
 func UnmarshalCustom(data []byte, v any, opts UnmarshalOptions) error {
@@ -41,7 +41,7 @@ func UnmarshalCustom(data []byte, v any, opts UnmarshalOptions) error {
 	foundFields := []string{}
 
 	for _, field := range getTypeFields(objectType) {
-		if !opts.UnmarshalIgnoredFields && field.JsonTag.ignore {
+		if !opts.UnmarshalTopLevelIgnoredFields && field.JsonTag.ignore {
 			continue
 		}
 		index := field.IndexInStruct

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -9,6 +9,21 @@ import (
 // Unmarshals a JSON element and fills in the ForceSendFields field if
 // the struct contains it. Only anotates basic types in the ForceSendFields.
 func Unmarshal(data []byte, v any) error {
+	return UnmarshalCustom(data, v, UnmarshalOptions{})
+}
+
+// UnmarshalOptions is used to configure the Unmarshal function.
+type UnmarshalOptions struct {
+	// If true, the function will unmarshal fields that are ignored by the
+	// JSON tag. Path and query parameters are annotated with `json:"-"` to
+	// prevent them from being serialized in request bodies.
+	//
+	// This option only applies to top-level ignored fields. Nested fields
+	// with `json:"-"` will still be ignored.
+	UnmarshalIgnoredFields bool
+}
+
+func UnmarshalCustom(data []byte, v any, opts UnmarshalOptions) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -26,7 +41,7 @@ func Unmarshal(data []byte, v any) error {
 	foundFields := []string{}
 
 	for _, field := range getTypeFields(objectType) {
-		if field.JsonTag.ignore {
+		if !opts.UnmarshalIgnoredFields && field.JsonTag.ignore {
 			continue
 		}
 		index := field.IndexInStruct

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -1,0 +1,32 @@
+package marshal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ignoredField struct {
+	A string `json:"a"`
+	B string `json:"-"`
+}
+
+func TestUnmarshalCustom_Default(t *testing.T) {
+	raw := []byte(`{"a": "foo", "b": "bar"}`)
+
+	var request ignoredField
+	UnmarshalCustom(raw, &request, UnmarshalOptions{})
+
+	assert.Equal(t, ignoredField{A: "foo", B: ""}, request)
+}
+
+func TestUnmarshalCustom_UnmarshalIgnoredFields(t *testing.T) {
+	raw := []byte(`{"a": "foo", "b": "bar"}`)
+
+	var request ignoredField
+	UnmarshalCustom(raw, &request, UnmarshalOptions{
+		UnmarshalIgnoredFields: true,
+	})
+
+	assert.Equal(t, ignoredField{A: "foo", B: "bar"}, request)
+}

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -25,7 +25,7 @@ func TestUnmarshalCustom_UnmarshalIgnoredFields(t *testing.T) {
 
 	var request ignoredField
 	UnmarshalCustom(raw, &request, UnmarshalOptions{
-		UnmarshalIgnoredFields: true,
+		UnmarshalTopLevelIgnoredFields: true,
 	})
 
 	assert.Equal(t, ignoredField{A: "foo", B: "bar"}, request)


### PR DESCRIPTION
## Changes
The CLI allows users to pass a `--json` flag to provide all parameters needed for executing the request. When a request includes fields annotated with `json:"-"`, those fields are not deserialized. As a result, requests like
```
databricks account workspace-assignment update --json "{\"principal_id\":123, \"permissions\": [\"USER\"],\"workspace_id \":456}"
```
fail because the request made is
```
PUT /api/2.0/accounts/<account-id>/workspaces/0/permissionassignments/principals/0
```

To address this, we extend the unmarshaller to support unmarshalling top-level fields annotated with `json:"-"`. I'm not sure if it is possible to support unmarshalling _all_ fields with this annotation, as we call `json.Marshal` recursively. On the other hand, it isn't necessary to support at this time. The default behavior follows the `encoding/json` behavior of not including ignored fields.

## Tests
- [x] Added unit tests for UnmarshalCustom.

