### PR TITLE
Experimental support for generating Lakeview widgets

### DIFF
--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -74,6 +74,7 @@ type Entity struct {
 	IsString     bool
 	IsByteStream bool
 	IsEmpty      bool
+	Const        any
 
 	// this field does not have a concrete type
 	IsAny bool

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -172,7 +172,8 @@ func (pkg *Package) schemaToEntity(s *openapi.Schema, path []string, hasName boo
 	e.IsString = s.Type == "string"
 	e.IsInt64 = s.Type == "integer" && s.Format == "int64"
 	e.IsFloat64 = s.Type == "number" && s.Format == "double"
-	e.IsInt = s.Type == "integer" || s.Type == "int"
+	e.IsInt = s.Type == "integer" || s.Type == "int" || s.Type == "number"
+	e.Const = s.Const
 	return e
 }
 

--- a/openapi/code/tmpl_util_funcs.go
+++ b/openapi/code/tmpl_util_funcs.go
@@ -49,6 +49,24 @@ var HelperFuncs = template.FuncMap{
 		}
 		return out
 	},
+	"noConst": func(in []*Field) (out []*Field) {
+		for _, v := range in {
+			if v.Entity.Const != nil {
+				continue
+			}
+			out = append(out, v)
+		}
+		return out
+	},
+	"constOnly": func(in []*Field) (out []*Field) {
+		for _, v := range in {
+			if v.Entity.Const == nil {
+				continue
+			}
+			out = append(out, v)
+		}
+		return out
+	},
 	"list": func(l ...any) []any {
 		return l
 	},

--- a/openapi/generator/x_test.go
+++ b/openapi/generator/x_test.go
@@ -1,0 +1,34 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/openapi/code"
+	"github.com/stretchr/testify/require"
+)
+
+func run() error {
+	ctx := context.Background()
+	home, _ := os.UserHomeDir()
+	spec, err := code.NewFromFile(ctx, filepath.Join(home,
+		"Downloads/RenderWidgetSpec.openapi.json"))
+	if err != nil {
+		return fmt.Errorf("spec: %w", err)
+	}
+	gen, err := NewGenerator(filepath.Join(home,
+		"git/labs/ucx/src/databricks/labs/ucx/framework/lakeview"))
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	return gen.Apply(ctx, spec, nil)
+}
+
+func TestX(t *testing.T) {
+	t.SkipNow()
+	err := run()
+	require.NoError(t, err)
+}

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -231,6 +231,7 @@ type Schema struct {
 	EnumDescriptions map[string]string  `json:"x-databricks-enum-descriptions,omitempty"`
 	Default          any                `json:"default,omitempty"`
 	Example          any                `json:"example,omitempty"`
+	Const            any                `json:"const,omitempty"`
 	Format           string             `json:"format,omitempty"`
 	Required         []string           `json:"required,omitempty"`
 	Properties       map[string]*Schema `json:"properties,omitempty"`


### PR DESCRIPTION
## Changes

- added `const` support
- added`noConst` field slice filters to facilitate `{{- range .NonRequiredFields | alphanumOnly | noConst}}` 
- added `constOnly` to facilitate `body = { {{range .Fields | constOnly}}'{{.Name}}': {{template "const" .Entity}},{{end}} }`

## Tests

- manual tests only
