### PR TITLE
Enable Databricks CLI auth for all clouds

### DIFF
--- a/config/auth_databricks_cli.go
+++ b/config/auth_databricks_cli.go
@@ -23,9 +23,6 @@ func (c DatabricksCliCredentials) Name() string {
 }
 
 func (c DatabricksCliCredentials) Configure(ctx context.Context, cfg *Config) (func(*http.Request) error, error) {
-	if !cfg.IsAws() {
-		return nil, nil
-	}
 	if cfg.Host == "" {
 		return nil, nil
 	}


### PR DESCRIPTION
## Changes
Enable Databricks CLI auth for all clouds

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied
- [x] Manual test oauth in both Azure and GCP
```
databricks auth login
databricks current-user me
```

