### PR TITLE
Update actions/setup-go to v5

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goVersion }}
 
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.18.x
 


### PR DESCRIPTION
## Changes

This silences the following warning as seen in action output:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v4.
