### PR TITLE
Update codecov/codecov-action to v3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,7 +42,7 @@ jobs:
         run: make test
 
       - name: Publish test coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

v1 has been deprecated for a long time and produces warnings in action output.