### PR TITLE
Release v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Version changelog
 
+## 0.30.1
+
+Major changes:
+
+* Enable Databricks CLI auth for all clouds ([#783](https://github.com/databricks/databricks-sdk-go/pull/783)).
+
+Other changes:
+
+* Update codecov/codecov-action to v3 ([#785](https://github.com/databricks/databricks-sdk-go/pull/785)).
+* MustUseJson must be true if request is a map ([#786](https://github.com/databricks/databricks-sdk-go/pull/786)).
+
+
 ## 0.30.0
 
 Other changes:

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -286,6 +286,7 @@ func (s ChannelInfo) MarshalJSON() ([]byte, error) {
 	return marshal.Marshal(s)
 }
 
+// Name of the channel
 type ChannelName string
 
 const ChannelNameChannelNameCurrent ChannelName = `CHANNEL_NAME_CURRENT`

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version of the SDK, updated manually before every tag
-const Version = "0.30.0"
+const Version = "0.30.1"


### PR DESCRIPTION

Major changes:

* Enable Databricks CLI auth for all clouds ([#783](https://github.com/databricks/databricks-sdk-go/pull/783)).

Other changes:

* Update codecov/codecov-action to v3 ([#785](https://github.com/databricks/databricks-sdk-go/pull/785)).
* MustUseJson must be true if request is a map ([#786](https://github.com/databricks/databricks-sdk-go/pull/786)).


