### PR TITLE
Disable acquiring lock while running git integration tests due to invalid parsing

### DIFF
--- a/internal/git_credentials_test.go
+++ b/internal/git_credentials_test.go
@@ -1,32 +1,16 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go"
-	"github.com/databricks/databricks-sdk-go/qa/lock"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func acquireGitCredentialsLock(ctx context.Context, t *testing.T, w *databricks.WorkspaceClient) {
-	me, err := w.CurrentUser.Me(ctx)
-	require.NoError(t, err)
-	lockable := lock.GitCredentials{
-		WorkspaceHost: w.Config.Host,
-		Username:      me.UserName,
-	}
-	_, err = lock.Acquire(ctx, lockable, lock.InTest(t))
-	require.NoError(t, err)
-}
-
 func TestAccGitCredentials(t *testing.T) {
 	ctx, w := workspaceTest(t)
 
-	// skip-next-line-roll
-	acquireGitCredentialsLock(ctx, t, w)
 	list, err := w.GitCredentials.ListAll(ctx)
 	require.NoError(t, err)
 	for _, v := range list {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
The integration test (added: https://github.com/databricks/databricks-sdk-go/pull/776) cannot be parsed correct:
````
2024/01/31 15:49:00 [INFO] loading OpenAPI spec with sha:e05401ed5dd4974c5333d737ec308a7d451f749f sha
2024/01/31 15:49:00 [INFO] parsing Go SDK integration tests for examples: /Users/tanmay.rustagi/eng-dev-ecosystem/ext/databricks-sdk-go/internal
     0  *roll.call {
     1  .  Named: code.Named {
     2  .  .  Name: "acquireGitCredentialsLock"
     3  .  .  Description: ""
     4  .  }
     5  .  IsAccount: false
     6  .  Args: []roll.expression (len = 1) {
     7  .  .  0: *roll.variable {
     8  .  .  .  Named: code.Named {
     9  .  .  .  .  Name: "w"
    10  .  .  .  .  Description: ""
    11  .  .  .  }
    12  .  .  }
    13  .  }
    14  }
panic: expected known assertion
````
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
`deco openapi generate-sdk go`
- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

