### PR TITLE
Skip AccountClient_GetWorkspaceClient() test in Azure/GCP

### DIFF
--- a/internal/account_client_test.go
+++ b/internal/account_client_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestMwsAccAccountClient_GetWorkspaceClient_NoTranspile(t *testing.T) {
 	ctx, a := accountTest(t)
+	if !a.Config.IsAws() {
+		skipf(t)("Only works on AWS")
+	}
 	wss, err := a.Workspaces.List(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes
Need to investigate why this doesn't work in Azure/GCP. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

