### PR TITLE
Support HEAD operations

### DIFF
--- a/.codegen/impl.go.tmpl
+++ b/.codegen/impl.go.tmpl
@@ -32,7 +32,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 {{end}}
 
 {{ define "request-param" -}}
-  {{ if or (and .Request (or (eq .Verb "GET") (eq .Verb "DELETE"))) (and .Operation .Operation.RequestBody) -}}
+  {{ if or (and .Request (or (eq .Verb "GET") (eq .Verb "DELETE") (eq .Verb "HEAD"))) (and .Operation .Operation.RequestBody) -}}
     request{{ if .RequestBodyField }}.{{.RequestBodyField.PascalName}}{{end}}
   {{- else }}nil
   {{- end }}

--- a/httpclient/request.go
+++ b/httpclient/request.go
@@ -113,7 +113,7 @@ func makeRequestBody(method string, requestURL *string, data interface{}) (commo
 	if data == nil {
 		return common.RequestBody{}, nil
 	}
-	if method == "GET" || method == "DELETE" {
+	if method == "GET" || method == "DELETE" || method == "HEAD" {
 		qs, err := makeQueryString(data)
 		if err != nil {
 			return common.RequestBody{}, err

--- a/httpclient/request_test.go
+++ b/httpclient/request_test.go
@@ -34,6 +34,14 @@ func TestMakeRequestBody(t *testing.T) {
 	require.Equal(t, "/a/b/c", requestURL)
 	x1 := `{"scope":"test"}`
 	require.Equal(t, []byte(x1), bodyBytes)
+
+	requestURL = "/a/b/c"
+	body, err = makeRequestBody("HEAD", &requestURL, x{"test"})
+	require.NoError(t, err)
+	bodyBytes, err = io.ReadAll(body.Reader)
+	require.NoError(t, err)
+	require.Equal(t, "/a/b/c?scope=test", requestURL)
+	require.Equal(t, 0, len(bodyBytes))
 }
 
 func TestMakeRequestBodyFromReader(t *testing.T) {

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -19,7 +19,7 @@ func TestBasic(t *testing.T) {
 
 	require.Len(t, batch.Packages(), 1)
 	require.Len(t, batch.Services(), 1)
-	require.Len(t, batch.Types(), 14)
+	require.Len(t, batch.Types(), 15)
 	commands, ok := batch.packages["commands"]
 	require.True(t, ok)
 
@@ -33,7 +33,7 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, commands, ce.Package)
 
 	methods := ce.Methods()
-	assert.Equal(t, 6, len(methods))
+	assert.Equal(t, 7, len(methods))
 
 	execute := methods[5]
 	assert.Equal(t, "execute", execute.Name)
@@ -51,7 +51,7 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, 0, len(wait.MessagePath()))
 
 	types := commands.Types()
-	assert.Equal(t, 14, len(types))
+	assert.Equal(t, 15, len(types))
 
 	command := types[1]
 	assert.Equal(t, "Command", command.PascalName())

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -101,7 +101,7 @@ func (m *Method) pathParams() (params []Field) {
 	if len(m.PathParts) == 0 {
 		return nil
 	}
-	if !(m.Verb == "GET" || m.Verb == "DELETE") {
+	if !(m.Verb == "GET" || m.Verb == "DELETE" || m.Verb == "HEAD") {
 		return nil
 	}
 	for _, part := range m.PathParts {

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -331,6 +331,10 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 	}
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {
+			if op.OperationId == "Files.getStatusHead" {
+				// skip this method, it needs to be removed from the spec
+				continue
+			}
 			if !op.HasTag(tag.Name) {
 				continue
 			}

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -131,6 +131,7 @@ var crudNames = map[string]bool{
 	"create":  true,
 	"read":    true,
 	"get":     true,
+	"head":    true,
 	"update":  true,
 	"replace": true,
 	"delete":  true,

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -87,6 +87,7 @@ type Path struct {
 	Node
 	Parameters []Parameter `json:"parameters,omitempty"`
 	Get        *Operation  `json:"get,omitempty"`
+	Head       *Operation  `json:"head,omitempty"`
 	Post       *Operation  `json:"post,omitempty"`
 	Put        *Operation  `json:"put,omitempty"`
 	Patch      *Operation  `json:"patch,omitempty"`
@@ -98,6 +99,9 @@ func (path *Path) Verbs() map[string]*Operation {
 	m := map[string]*Operation{}
 	if path.Get != nil {
 		m["GET"] = path.Get
+	}
+	if path.Head != nil {
+		m["HEAD"] = path.Head
 	}
 	if path.Post != nil {
 		m["POST"] = path.Post

--- a/openapi/testdata/spec.json
+++ b/openapi/testdata/spec.json
@@ -274,6 +274,39 @@
         "tags": [
           "Command Execution"
         ]
+      },
+      "head": {
+        "operationId": "CommandExecution.headContextStatus",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "contextId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Head returned succesfully"
+          }
+        },
+        "summary": "Get head information about the context status",
+        "tags": [
+          "Command Execution"
+        ]
       }
     }
   },


### PR DESCRIPTION
## Changes
Support HEAD operations

## Tests
- [X] generate the Go SDK
- [X] `make test` passing
- [X] `make fmt` applied
- [X] relevant integration tests applied

