### PR TITLE
Fix GetWorkspaceClient for GCP

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -179,15 +179,14 @@ func (c *Config) NewWithWorkspaceHost(host string) (*Config, error) {
 	}
 
 	res.Host = host
-	// We can reuse the same OAuth token refresh client and context. The
-	// reuseTokenSource internally locks.
-	res.refreshClient = c.refreshClient
-	res.refreshCtx = c.refreshCtx
-	// The config does not need to be re-resolved, as we reuse all attributes
-	// from the original config.
-	res.resolved = c.resolved
-	res.auth = c.auth
 	res.isTesting = c.isTesting
+	// We need to reresolve the config with the updated host in general. For
+	// example, the audience for OAuth tokens provided by GCP is derived from
+	// the host, so account-level tokens cannot be used at workspace-level or
+	// vice-versa.
+	//
+	// In the future, when unified login is widely available, we may be able to
+	// reuse the authentication visitor specifically for in-house OAuth.
 	return res, nil
 }
 

--- a/internal/account_client_test.go
+++ b/internal/account_client_test.go
@@ -9,16 +9,10 @@ import (
 
 func TestMwsAccAccountClient_GetWorkspaceClient_NoTranspile(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
-		skipf(t)("Only works on AWS")
-	}
-	wss, err := a.Workspaces.List(ctx)
+	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
+	ws, err := a.Workspaces.GetByWorkspaceId(ctx, int64(workspaceId))
 	require.NoError(t, err)
-
-	if len(wss) == 0 {
-		t.Skip("No workspaces found")
-	}
-	w, err := a.GetWorkspaceClient(wss[0])
+	w, err := a.GetWorkspaceClient(*ws)
 	assert.NoError(t, err)
 	me, err := w.CurrentUser.Me(ctx)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Changes
The current implementation of GetWorkspaceClient copies the entire config, critically reusing the cached authenticator so as to use the same auth mechanism when getting a workspace client. However, at least in GCP, account-level OAuth tokens can't be used to authenticate to a workspace (probably because the audience for the account-level and workspace-level tokens is different).

This PR fixes this by only copying the exported fields and not copying the authenticator or refresh client. Subsequent use of the config in WorkspaceClient will trigger config resolution. For GCP, this means creating a new token source using the correct host as the audience.

## Tests
Manually ran this integration test in all non-UC (Azure, AWS, GCP) and UC (AWS, GCP) account-level environments.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

