### PR TITLE
Fix `any` references when generating code with circular dependencies

### DIFF
--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -100,7 +100,7 @@ func (pkg *Package) ImportedPackages() (res []string) {
 
 // schemaToEntity converts a schema into an Entity
 // processedEntities keeps track of the entities that are being generated to avoid infinite recursion.
-func (pkg *Package) schemaToEntity(s *openapi.Schema, path []string, hasName bool, processedEntities []string) *Entity {
+func (pkg *Package) schemaToEntity(s *openapi.Schema, path []string, hasName bool, processedEntities map[string]*Entity) *Entity {
 	if s.IsRef() {
 		pair := strings.Split(s.Component(), ".")
 		if len(pair) == 2 && pair[0] != pkg.Name {
@@ -142,6 +142,7 @@ func (pkg *Package) schemaToEntity(s *openapi.Schema, path []string, hasName boo
 		Package: pkg,
 		enum:    map[string]EnumEntry{},
 	}
+	processedEntities[s.Component()] = e
 	// pull embedded types up, if they can be defined at package level
 	if s.IsDefinable() && !hasName {
 		// TODO: log message or panic when overrides a type
@@ -180,7 +181,7 @@ func (pkg *Package) schemaToEntity(s *openapi.Schema, path []string, hasName boo
 
 // makeObject converts OpenAPI Schema into type representation
 // processedEntities keeps track of the entities that are being generated to avoid infinite recursion.
-func (pkg *Package) makeObject(e *Entity, s *openapi.Schema, path []string, processedEntities []string) *Entity {
+func (pkg *Package) makeObject(e *Entity, s *openapi.Schema, path []string, processedEntities map[string]*Entity) *Entity {
 	e.fields = map[string]*Field{}
 	required := map[string]bool{}
 	for _, v := range s.Required {
@@ -234,10 +235,10 @@ func (pkg *Package) localComponent(n *openapi.Node) string {
 
 // definedEntity defines and returns the requested entity based on the schema.
 // processedEntities keeps track of the entities that are being generated to avoid infinite recursion.
-func (pkg *Package) definedEntity(name string, s *openapi.Schema, processedEntities []string) *Entity {
-	if slices.Contains(processedEntities, name) {
-		// Skip if it's already being generated has part of this stack to avoid infinite recursion.
-		return nil
+func (pkg *Package) definedEntity(name string, s *openapi.Schema, processedEntities map[string]*Entity) *Entity {
+	if entity, ok := processedEntities[s.Component()]; ok {
+		// Return existing entity if it's already being generated.
+		return entity
 	}
 	if s == nil || s.IsEmpty() {
 		entity := &Entity{
@@ -249,7 +250,6 @@ func (pkg *Package) definedEntity(name string, s *openapi.Schema, processedEntit
 		}
 		return pkg.define(entity)
 	}
-	processedEntities = append(processedEntities, name)
 
 	e := pkg.schemaToEntity(s, []string{name}, true, processedEntities)
 	if e == nil {
@@ -327,7 +327,7 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 		if split[0] != pkg.Name {
 			continue
 		}
-		pkg.definedEntity(split[1], *v, []string{})
+		pkg.definedEntity(split[1], *v, map[string]*Entity{})
 	}
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -123,7 +123,7 @@ func (svc *Service) paramToField(op *openapi.Operation, param openapi.Parameter)
 		Entity: svc.Package.schemaToEntity(param.Schema, []string{
 			op.Name(),
 			named.PascalName(),
-		}, false, []string{}),
+		}, false, map[string]*Entity{}),
 	}
 }
 
@@ -177,7 +177,7 @@ func (svc *Service) newMethodEntity(op *openapi.Operation) (*Entity, openapi.Mim
 		return &Entity{fields: map[string]*Field{}}, "", nil
 	}
 	requestSchema, mimeType := svc.getBaseSchemaAndMimeType(op.RequestBody)
-	res := svc.Package.schemaToEntity(requestSchema, []string{op.Name()}, true, []string{})
+	res := svc.Package.schemaToEntity(requestSchema, []string{op.Name()}, true, map[string]*Entity{})
 	if res == nil {
 		panic(fmt.Errorf("%s request body is nil", op.OperationId))
 	}
@@ -317,7 +317,7 @@ func (svc *Service) newResponse(op *openapi.Operation) (*Entity, openapi.MimeTyp
 	body := op.SuccessResponseBody(svc.Package.Components)
 	schema, mimeType := svc.getBaseSchemaAndMimeType(body)
 	name := op.Name()
-	response := svc.Package.definedEntity(name+"Response", schema, []string{})
+	response := svc.Package.definedEntity(name+"Response", schema, map[string]*Entity{})
 	var bodyField *Field
 	if mimeType.IsByteStream() {
 		bodyField = response.fields[openapi.MediaTypeNonJsonBodyFieldName]

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -12,6 +12,8 @@ type Node struct {
 	Description string `json:"description,omitempty"`
 	Preview     string `json:"x-databricks-preview,omitempty"`
 	Ref         string `json:"$ref,omitempty"`
+	// Currently it is only defined for top level schemas
+	JsonPath string `json:"-"`
 }
 
 // IsRef flags object being a reference to a component
@@ -35,7 +37,15 @@ func NewFromReader(r io.Reader) (*Specification, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse openapi spec: %w", err)
 	}
+	setJsonPaths(spec)
 	return &spec, nil
+}
+
+func setJsonPaths(spec Specification) {
+	for name, schema := range spec.Components.Schemas {
+		deref := *schema
+		deref.JsonPath = fmt.Sprintf("%s,%s", "#/components/schemas/", name)
+	}
 }
 
 type Specification struct {


### PR DESCRIPTION
## Changes
Fix `any` references when generating code with circular dependencies

## Tests
Generated Go SDK

- [X] `make test` passing
- [X] `make fmt` applied
- [X] relevant integration tests applied

