### PR TITLE
Do not generate erroneous "r" and "w" samples

### DIFF
--- a/openapi/roll/tool.go
+++ b/openapi/roll/tool.go
@@ -726,16 +726,31 @@ func (s *Suite) expectLookup(se *ast.SelectorExpr) *lookup {
 	}
 }
 
+func (s *Suite) failOnBareRetrier(e *ast.CallExpr) {
+	t, ok := e.Fun.(*ast.IndexExpr)
+	if !ok {
+		return
+	}
+	t2, ok := t.X.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	if t2.X.(*ast.Ident).Name != "retries" {
+		return
+	}
+	if t2.Sel.Name == "New" {
+		s.explainAndPanic("cannot call retrier.New() without immediately calling Run() or Wait()", e)
+	}
+}
+
 func (s *Suite) inlineRetryExpression(e *ast.CallExpr) *ast.CallExpr {
+	// TODO: support reusable Retriers in integration tests.
+	s.failOnBareRetrier(e)
 	t, ok := e.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return e
 	}
 	name := t.Sel.Name
-	// TODO: support reusable Retriers in integration tests.
-	if name == "New" && t.X.(*ast.Ident).Name == "retrier" {
-		s.explainAndPanic("cannot call retrier.New() without immediately calling Run() or Wait()", e)
-	}
 	if name != "Run" && name != "Wait" {
 		return e
 	}


### PR DESCRIPTION
## Changes
The example generator can handle some custom code in integration tests. If we need to use retrier in integration tests, there is a specific format that is expected:
```
retrier.New().Wait(ctx, func() {
  return ...
})
```
or
```
retrier.New().Run(ctx, func() {
  return ...
})
```

This PR changes the UC catalog acceptance test to use this structure, as well as adds validation that no bare retriers are created.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

