### PR TITLE
Generate fields for headers in responses

### DIFF
--- a/.codegen/impl.go.tmpl
+++ b/.codegen/impl.go.tmpl
@@ -40,11 +40,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 
 {{ define "response-var" -}}
 {{ if .Response }}
-  var {{ .Response.CamelName }} {{ if .IsResponseByteStream -}}
-    io.ReadCloser
-  {{- else -}}
-	{{ template "type" .Response }}
-  {{- end }}
+  var {{ .Response.CamelName }} {{ template "type" .Response }}
 {{- end }}
 {{- end }}
 
@@ -57,11 +53,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 
 {{ define "response" -}}
   {{ if .Response -}}
-  {{ if .IsResponseByteStream -}}
-    &{{ .Response.PascalName }}{ {{ .ResponseBodyField.PascalName }}: {{ .Response.CamelName }} }
-  {{- else -}}
-    {{ if not .Response.ArrayValue }}&{{end}}{{.Response.CamelName}}
-  {{- end }}, {{end}}err
+  {{ if not .Response.ArrayValue }}&{{end}}{{.Response.CamelName}}, {{end}}err
 {{- end }}
 
 {{ define "make-header" -}}

--- a/.codegen/model.go.tmpl
+++ b/.codegen/model.go.tmpl
@@ -62,6 +62,7 @@ func (f *{{.PascalName}}) Type() string {
 {{- define "field-tag" -}}
 	{{if .IsJson}}json:"{{.Name}}{{if not .Required}},omitempty{{end}}"{{else}}json:"-"{{end -}}
 	{{if .IsPath}} url:"-"{{end -}}
+	{{if .IsHeader}} url:"-" header:"{{.Name}}{{if not .Required}},omitempty{{end}}"{{end -}}
 	{{if .IsQuery}} url:"{{.Name}}{{if not .Required}},omitempty{{end}}"{{end -}}
 {{- end -}}
 

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -88,6 +88,9 @@ func tryInjectContent(response any, body *common.ResponseWrapper) bool {
 	value := reflect.ValueOf(response)
 	value = reflect.Indirect(value)
 
+	if value.Kind() != reflect.Struct {
+		return false
+	}
 	contentField := value.FieldByName("Content")
 	if !contentField.IsValid() {
 		return false
@@ -105,6 +108,9 @@ func injectHeaders(response any, body *common.ResponseWrapper) error {
 	value = reflect.Indirect(value)
 	objectType := value.Type()
 
+	if objectType.Kind() != reflect.Struct {
+		return nil
+	}
 	headers := body.Response.Header
 
 	for i := 0; i < objectType.NumField(); i++ {

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -136,8 +136,7 @@ func injectHeaders(response any, body *common.ResponseWrapper) error {
 			}
 			value.Field(i).Set(reflect.ValueOf(intValue))
 		default:
-			// Don't fail the request if we can't inject a header for backwards compatibility.
-			//return fmt.Errorf("unsupported header type %s for field %s", field.Type.Kind(), field.Name)
+			// Do not fail the request if the header is not supported to avoid breaking changes.
 			logger.Warnf(context.Background(), "unsupported header type %s for field %s", field.Type.Kind(), field.Name)
 		}
 

--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -91,7 +91,7 @@ func tryInjectContent(response any, body *common.ResponseWrapper) bool {
 	if value.Kind() != reflect.Struct {
 		return false
 	}
-	contentField := value.FieldByName("Content")
+	contentField := value.FieldByName("Contents")
 	if !contentField.IsValid() {
 		return false
 	}

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -59,6 +59,12 @@ func TestUcAccFilesAPI(t *testing.T) {
 		Contents: io.NopCloser(strings.NewReader("abcd")),
 	})
 	require.NoError(t, err)
+	// TODO: Enable this after SDK Generation. Method name may differ.
+	// fileHead, err := w.Files.GetStatusHead(ctx, files.GetStatusHeadRequest{
+	// 	FilePath: filePath,
+	// })
+	// require.NoError(t, err)
+	// require.Equal(t, fileHead.ContentType, "application/octet-stream")
 	t.Cleanup(func() {
 		err = w.Files.DeleteByFilePath(ctx, filePath)
 		assert.NoError(t, err)

--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -16,6 +16,7 @@ type Field struct {
 	IsJson   bool
 	IsPath   bool
 	IsQuery  bool
+	IsHeader bool
 	Schema   *openapi.Schema
 }
 
@@ -39,7 +40,7 @@ func (f *Field) IsPublicPreview() bool {
 // by making path parameters always required. Thus, we don't need to consider such fields
 // as request body fields anymore.
 func (f *Field) IsRequestBodyField() bool {
-	return f.IsJson && !f.IsPath && !f.IsQuery
+	return f.IsJson && !f.IsPath && !f.IsQuery && !f.IsHeader
 }
 
 // Call the provided callback on this field and any nested fields in its entity,
@@ -247,6 +248,16 @@ func (e *Entity) Fields() (fields []*Field) {
 func (e *Entity) HasQueryField() bool {
 	for _, v := range e.fields {
 		if v.IsQuery {
+			return true
+		}
+	}
+	return false
+}
+
+// HasHeaderField returns true if any of the fields is from header
+func (e *Entity) HasHeaderField() bool {
+	for _, v := range e.fields {
+		if v.IsHeader {
 			return true
 		}
 	}

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -19,7 +19,7 @@ func TestBasic(t *testing.T) {
 
 	require.Len(t, batch.Packages(), 1)
 	require.Len(t, batch.Services(), 1)
-	require.Len(t, batch.Types(), 15)
+	require.Len(t, batch.Types(), 16)
 	commands, ok := batch.packages["commands"]
 	require.True(t, ok)
 
@@ -51,9 +51,9 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, 0, len(wait.MessagePath()))
 
 	types := commands.Types()
-	assert.Equal(t, 15, len(types))
+	assert.Equal(t, 16, len(types))
 
-	command := types[1]
+	command := types[2]
 	assert.Equal(t, "Command", command.PascalName())
 	assert.Equal(t, "command", command.CamelName())
 	assert.Equal(t, "commands.Command", command.FullName())

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -65,6 +65,13 @@ func TestBasic(t *testing.T) {
 	assert.NotNil(t, language)
 	assert.False(t, language.IsOptionalObject())
 	assert.Equal(t, 3, len(language.Entity.Enum()))
+
+	cancel := methods[0]
+	cancelResponse := cancel.Response
+	assert.Equal(t, "cancel", cancel.Name)
+	assert.Equal(t, "cancelResponse", cancelResponse.Name)
+	assert.Equal(t, 1, len(cancelResponse.fields))
+	assert.Equal(t, "content-type", cancelResponse.fields["content-type"].Name)
 }
 
 // This test is used for debugging purposes

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -19,7 +19,7 @@ func TestBasic(t *testing.T) {
 
 	require.Len(t, batch.Packages(), 1)
 	require.Len(t, batch.Services(), 1)
-	require.Len(t, batch.Types(), 16)
+	require.Len(t, batch.Types(), 17)
 	commands, ok := batch.packages["commands"]
 	require.True(t, ok)
 
@@ -51,7 +51,7 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, 0, len(wait.MessagePath()))
 
 	types := commands.Types()
-	assert.Equal(t, 16, len(types))
+	assert.Equal(t, 17, len(types))
 
 	command := types[2]
 	assert.Equal(t, "Command", command.PascalName())
@@ -70,8 +70,9 @@ func TestBasic(t *testing.T) {
 	cancelResponse := cancel.Response
 	assert.Equal(t, "cancel", cancel.Name)
 	assert.Equal(t, "cancelResponse", cancelResponse.Name)
-	assert.Equal(t, 1, len(cancelResponse.fields))
+	assert.Equal(t, 2, len(cancelResponse.fields))
 	assert.Equal(t, "content-type", cancelResponse.fields["content-type"].Name)
+	assert.Equal(t, "last-modified", cancelResponse.fields["last-modified"].Name)
 }
 
 // This test is used for debugging purposes

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -370,6 +370,7 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 					if param == nil {
 						return nil
 					}
+					// We don't support headers in requests.
 					if param.In == "header" {
 						continue
 					}
@@ -389,7 +390,10 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 					seenParams[param.Name] = true
 				}
 			}
-			method := svc.newMethod(verb, prefix, params, op)
+			method, err := svc.newMethod(verb, prefix, params, op)
+			if err != nil {
+				return err
+			}
 			svc.methods[method.Name] = method
 		}
 	}

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -336,10 +336,6 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 	}
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {
-			if op.OperationId == "Files.getStatusHead" {
-				// skip this method, it needs to be removed from the spec
-				continue
-			}
 			if !op.HasTag(tag.Name) {
 				continue
 			}

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -336,6 +336,10 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 	}
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {
+			if op.OperationId == "Files.getStatusHead" {
+				// skip this method, it needs to be removed from the spec
+				continue
+			}
 			if !op.HasTag(tag.Name) {
 				continue
 			}

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -251,6 +251,7 @@ func (pkg *Package) definedEntity(name string, s *openapi.Schema, processedEntit
 				Description: "",
 			},
 			IsEmpty: true,
+			fields:  map[string]*Field{},
 		}
 		return pkg.define(entity)
 	}

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -13,8 +13,8 @@ var HIDDEN_HEADERS = map[string]struct{}{
 	"X-Databricks-GCP-SA-Access-Token": {},
 }
 
-// When adding a new type, implement it
-// in httpclient/response.go#injectHeaders
+// When adding a new type, implement it in all SDKs
+// GO: httpclient/response.go#injectHeaders
 var SUPPORTED_HEADER_TYPES = map[string]struct{}{
 	"string":  {},
 	"integer": {},

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -9,8 +9,8 @@ import (
 )
 
 // The following headers should not be added added to the generated structs
-var HIDDEN_HEADERS = map[string]bool{
-	"X-Databricks-GCP-SA-Access-Token": true,
+var HIDDEN_HEADERS = map[string]struct{}{
+	"X-Databricks-GCP-SA-Access-Token": {},
 }
 
 // Service represents specific Databricks API
@@ -209,7 +209,7 @@ func (svc *Service) newMethodEntity(op *openapi.Operation) (*Entity, openapi.Mim
 }
 
 func (svc *Service) skipHeader(v openapi.Parameter, includeHeaders bool) bool {
-	hiddenHeader := HIDDEN_HEADERS[v.Name]
+	_, hiddenHeader := HIDDEN_HEADERS[v.Name]
 	return v.In == "header" && (!includeHeaders || hiddenHeader)
 }
 

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -357,7 +357,7 @@ func (svc *Service) newResponse(op *openapi.Operation) (*Entity, openapi.MimeTyp
 	if response.HasHeaderField() {
 		response.IsEmpty = false
 		svc.Package.define(response)
-		svc.removeFromEmtyList(response)
+		svc.removeFromEmptyList(response)
 	}
 
 	var emptyResponse Named
@@ -368,7 +368,7 @@ func (svc *Service) newResponse(op *openapi.Operation) (*Entity, openapi.MimeTyp
 	return response, mimeType, bodyField, emptyResponse
 }
 
-func (svc *Service) removeFromEmtyList(response *Entity) {
+func (svc *Service) removeFromEmptyList(response *Entity) {
 	list := svc.Package.emptyTypes
 	for i, t := range list {
 		if t.Name == response.Name {

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -13,6 +13,13 @@ var HIDDEN_HEADERS = map[string]struct{}{
 	"X-Databricks-GCP-SA-Access-Token": {},
 }
 
+// When adding a new type, implement it
+// in httpclient/response.go#injectHeaders
+var SUPPORTED_HEADER_TYPES = map[string]struct{}{
+	"string":  {},
+	"integer": {},
+}
+
 // Service represents specific Databricks API
 type Service struct {
 	Named
@@ -325,7 +332,7 @@ func (svc *Service) newRequest(params []openapi.Parameter, op *openapi.Operation
 	return request, mimeType, bodyField
 }
 
-func (svc *Service) newResponse(op *openapi.Operation) (*Entity, openapi.MimeType, *Field, Named) {
+func (svc *Service) newResponse(op *openapi.Operation) (*Entity, openapi.MimeType, *Field, Named, error) {
 	body := op.SuccessResponseBody(svc.Package.Components)
 	schema, mimeType := svc.getBaseSchemaAndMimeType(body)
 	name := op.Name()
@@ -360,12 +367,21 @@ func (svc *Service) newResponse(op *openapi.Operation) (*Entity, openapi.MimeTyp
 		svc.removeFromEmptyList(response)
 	}
 
+	// We only support certain types of headers. Fail at build time if an unsupported type is found.
+	// We don't check this before because we need to ensure all referenced schemas have been defined.
+	if op.Responses["200"] != nil {
+		err := svc.validateHeaders(op.Responses["200"].Headers)
+		if err != nil {
+			return nil, "", nil, Named{}, err
+		}
+	}
+
 	var emptyResponse Named
 	if response != nil && response.IsEmpty {
 		emptyResponse = response.Named
 		response = nil
 	}
-	return response, mimeType, bodyField, emptyResponse
+	return response, mimeType, bodyField, emptyResponse, nil
 }
 
 func (svc *Service) removeFromEmptyList(response *Entity) {
@@ -378,14 +394,30 @@ func (svc *Service) removeFromEmptyList(response *Entity) {
 	}
 }
 
-func (svc *Service) addHeaderParams(request *Entity, op *openapi.Operation, headers map[string]*openapi.Parameter) {
+// ResponseHeaders are a map[string]*openapi.Parameter. The name is the key. This function converts
+// the map to a slice of openapi.Parameter.
+func (svc *Service) convertResponseHeaders(headers map[string]*openapi.Parameter) []openapi.Parameter {
 	headersList := make([]openapi.Parameter, 0, len(headers))
 	for name, header := range headers {
 		header.Name = name
 		header.In = "header"
 		headersList = append(headersList, *header)
 	}
-	svc.addParams(request, op, headersList, true)
+	return headersList
+}
+
+func (svc *Service) validateHeaders(headers map[string]*openapi.Parameter) error {
+	for _, header := range svc.convertResponseHeaders(headers) {
+		param := *svc.Package.Components.Schemas.Resolve(header.Schema)
+		if _, ok := SUPPORTED_HEADER_TYPES[param.Type]; !ok {
+			return fmt.Errorf("unsupported header type %q", param.Type)
+		}
+	}
+	return nil
+}
+
+func (svc *Service) addHeaderParams(request *Entity, op *openapi.Operation, headers map[string]*openapi.Parameter) {
+	svc.addParams(request, op, svc.convertResponseHeaders(headers), true)
 }
 
 func (svc *Service) paramPath(path string, request *Entity, params []openapi.Parameter) (parts []PathPart) {
@@ -434,10 +466,13 @@ func (svc *Service) getPathStyle(op *openapi.Operation) openapi.PathStyle {
 	return openapi.PathStyleRest
 }
 
-func (svc *Service) newMethod(verb, path string, params []openapi.Parameter, op *openapi.Operation) *Method {
+func (svc *Service) newMethod(verb, path string, params []openapi.Parameter, op *openapi.Operation) (*Method, error) {
 	methodName := op.Name()
 	request, reqMimeType, reqBodyField := svc.newRequest(params, op)
-	response, respMimeType, respBodyField, emptyResponse := svc.newResponse(op)
+	response, respMimeType, respBodyField, emptyResponse, err := svc.newResponse(op)
+	if err != nil {
+		return nil, err
+	}
 	requestStyle := svc.getPathStyle(op)
 	if requestStyle == openapi.PathStyleRpc {
 		methodName = filepath.Base(path)
@@ -497,7 +532,7 @@ func (svc *Service) newMethod(verb, path string, params []openapi.Parameter, op 
 		Operation:           op,
 		pagination:          op.Pagination,
 		shortcut:            op.Shortcut,
-	}
+	}, nil
 }
 
 func (svc *Service) HasWaits() bool {

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -304,8 +304,9 @@ type Parameter struct {
 
 type Body struct {
 	Node
-	Required bool                 `json:"required,omitempty"`
-	Content  map[string]MediaType `json:"content,omitempty"`
+	Required bool                  `json:"required,omitempty"`
+	Content  map[string]MediaType  `json:"content,omitempty"`
+	Headers  map[string]*Parameter `json:"headers,omitempty"`
 }
 
 type MimeType string

--- a/openapi/testdata/spec.json
+++ b/openapi/testdata/spec.json
@@ -23,6 +23,14 @@
         },
         "responses": {
           "200": {
+            "headers": {
+              "content-type": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The content type of the response."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {}

--- a/openapi/testdata/spec.json
+++ b/openapi/testdata/spec.json
@@ -29,6 +29,9 @@
                   "type": "string"
                 },
                 "description": "The content type of the response."
+              },
+              "last-modified": {
+                "schema": { "$ref": "#/components/schemas/ModificationTime" }
               }
             },
             "content": {
@@ -440,6 +443,11 @@
           "sql"
         ],
         "type": "string"
+      },
+      "ModificationTime": {
+        "description": "Last modification time of given file in milliseconds since unix epoch.",
+        "type": "integer",
+        "format": "int64"
       },
       "ResultType": {
         "enum": [


### PR DESCRIPTION
## Changes
Support header fields  in responses.

## Tests
* Generated Go SDK. A new field was added:
```
	// The name of the served model that served the request. This is useful when
	// there are multiple models behind the same endpoint with traffic split.
	ServedModelName string `json:"-" url:"-" header:"served-model-name,omitempty"`
```
* Run integration tests in PR (only AWS due to issues running workflows in EMU)
* Run files_test.go test after generation to validate changes to Content type.

- [X] `make test` passing
- [X] `make fmt` applied
- [X] relevant integration tests applied

