### PR TITLE
Add Int64 to header type injection

### DIFF
--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -135,6 +135,12 @@ func injectHeaders(response any, body *common.ResponseWrapper) error {
 				return fmt.Errorf("failed to parse header %s as int: %w", headerTag.name, err)
 			}
 			value.Field(i).Set(reflect.ValueOf(intValue))
+		case reflect.Int64:
+			intValue, err := strconv.ParseInt(headerValue, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse header %s as int: %w", headerTag.name, err)
+			}
+			value.Field(i).Set(reflect.ValueOf(intValue))
 		default:
 			// Do not fail the request if the header is not supported to avoid breaking changes.
 			logger.Warnf(context.Background(), "unsupported header type %s for field %s", field.Type.Kind(), field.Name)

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -64,6 +64,7 @@ func TestUcAccFilesAPI(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, fileHead.ContentType, "application/octet-stream")
+	require.Equal(t, fileHead.ContentLength, int64(4))
 	t.Cleanup(func() {
 		err = w.Files.DeleteByFilePath(ctx, filePath)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Changes
Add Int64 to header type injection

## Tests

- [X] `make test` passing
- [X] `make fmt` applied
- [X] relevant integration tests applied

