### PR TITLE
Add helper function to get header fields

### DIFF
--- a/httpclient/response.go
+++ b/httpclient/response.go
@@ -135,6 +135,12 @@ func injectHeaders(response any, body *common.ResponseWrapper) error {
 				return fmt.Errorf("failed to parse header %s as int: %w", headerTag.name, err)
 			}
 			value.Field(i).Set(reflect.ValueOf(intValue))
+		case reflect.Int64:
+			intValue, err := strconv.ParseInt(headerValue, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse header %s as int: %w", headerTag.name, err)
+			}
+			value.Field(i).Set(reflect.ValueOf(intValue))
 		default:
 			// Do not fail the request if the header is not supported to avoid breaking changes.
 			logger.Warnf(context.Background(), "unsupported header type %s for field %s", field.Type.Kind(), field.Name)

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -64,6 +64,7 @@ func TestUcAccFilesAPI(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, fileHead.ContentType, "application/octet-stream")
+	require.Equal(t, fileHead.ContentLength, int64(4))
 	t.Cleanup(func() {
 		err = w.Files.DeleteByFilePath(ctx, filePath)
 		assert.NoError(t, err)

--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -113,6 +113,18 @@ func (m *Method) pathParams() (params []Field) {
 	return params
 }
 
+func (m *Method) ResponseHeaders() (headers []Field) {
+	if m.Response == nil {
+		return headers
+	}
+	for _, field := range m.Response.Fields() {
+		if field.IsHeader {
+			headers = append(headers, *field)
+		}
+	}
+	return headers
+}
+
 func (m *Method) allowShortcut() bool {
 	if m.shortcut {
 		return true


### PR DESCRIPTION
## Changes
Add helper function to get header fields. Used during Python SDK generation

## Tests

- [X] `make test` passing
- [X] `make fmt` applied
- N/A relevant integration tests applied

