### PR TITLE
Do not transpile getWorkspaceClient

### DIFF
--- a/internal/workspace_client_test.go
+++ b/internal/workspace_client_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUcAccWorkspaceClient_CurrentWorkspaceId(t *testing.T) {
+func TestUcAccWorkspaceClient_CurrentWorkspaceId_NoTranspile(t *testing.T) {
 	ctx, w := ucwsTest(t)
 	expectedWorkspaceId := MustParseInt64(GetEnvOrSkipTest(t, "THIS_WORKSPACE_ID"))
 	workspaceId, err := w.CurrentWorkspaceID(ctx)


### PR DESCRIPTION
## Changes
This test should not be transpiled into a Python example.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

