### PR TITLE
Adaptive request timeouts

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -233,6 +233,7 @@ func (c *ApiClient) attempt(
 		// After this point, the request body has (probably) been consumed. handleError() must be called to reset it if
 		// possible.
 		if uerr, ok := err.(*url.Error); ok {
+			// If the timeout context has been canceled but the parent context hasn't, then the request has timed out.
 			if pctx.Err() == nil && uerr.Err == context.Canceled {
 				uerr.Err = fmt.Errorf("request timed out after %s of inactivity", c.config.HTTPTimeout)
 			}

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -200,10 +200,11 @@ func (c *ApiClient) attempt(
 			return c.failRequest(ctx, "failed in rate limiter", err)
 		}
 
-		// This custom context enables us to extend the request timeout
-		// while the request or response body is being read.
-		// It exists because the net/http package supports only a fixed timeout.
 		pctx := ctx
+
+		// This timeout context enables us to extend the request timeout
+		// while the request or response body is being read.
+		// It exists because the net/http package uses a fixed timeout regardless of payload size.
 		ctx, ticker := newTimeoutContext(pctx, c.config.HTTPTimeout)
 		request, err := http.NewRequestWithContext(ctx, method, requestURL, requestBody.Reader)
 		if err != nil {

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -223,7 +223,7 @@ func (c *ApiClient) attempt(
 		// If there is a request body, wrap it to extend the request timeout while it is being read.
 		// Note: we do not wrap the request body earlier, because [http.NewRequestWithContext] performs
 		// type probing on the body variable to determine the content length.
-		if request.Body != nil {
+		if request.Body != nil && request.Body != http.NoBody {
 			request.Body = newRequestBodyTicker(ticker, request.Body)
 		}
 

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -232,6 +232,11 @@ func (c *ApiClient) attempt(
 		// If there is a response body, wrap it to extend the request timeout while it is being read.
 		if response != nil && response.Body != nil {
 			response.Body = tickingReadCloser(ticker, response.Body)
+		} else {
+			// If there is no response body, the request has completed and there
+			// is no need to extend the timeout. Cancel the context to clean up
+			// the underlying goroutine.
+			ticker.Cancel()
 		}
 
 		// By this point, the request body has certainly been consumed.

--- a/httpclient/timeout_context.go
+++ b/httpclient/timeout_context.go
@@ -9,7 +9,7 @@ import (
 
 type timeoutContext struct {
 	ctx    context.Context
-	cancel context.CancelCauseFunc
+	cancel context.CancelFunc
 
 	// Timeout is constant.
 	// Deadline is updated when Tick function is called.
@@ -26,7 +26,7 @@ type TimeoutTicker interface {
 }
 
 func newTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, TimeoutTicker) {
-	ctx, cancel := context.WithCancelCause(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	t := &timeoutContext{
 		ctx:      ctx,
 		cancel:   cancel,
@@ -48,7 +48,7 @@ func (t *timeoutContext) Tick() {
 
 // Cancel cancels the context.
 func (t *timeoutContext) Cancel() {
-	t.cancel(context.Canceled)
+	t.cancel()
 }
 
 // Deadline returns the current deadline.
@@ -62,7 +62,7 @@ func (t *timeoutContext) run() {
 	for {
 		ttl := time.Until(t.Deadline())
 		if ttl <= 0 {
-			t.cancel(context.DeadlineExceeded)
+			t.cancel()
 			return
 		}
 		select {

--- a/httpclient/timeout_context.go
+++ b/httpclient/timeout_context.go
@@ -1,0 +1,120 @@
+package httpclient
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+)
+
+type timeoutContext struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+
+	// Timeout is constant.
+	// Deadline is updated when Mark function is called.
+	timeout  time.Duration
+	deadline time.Time
+
+	// Protect against concurrent deadline reads/writes.
+	lock sync.Mutex
+}
+
+type TimeoutTicker interface {
+	Tick()
+	Cancel()
+}
+
+func newTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, TimeoutTicker) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	t := &timeoutContext{
+		ctx:      ctx,
+		cancel:   cancel,
+		timeout:  timeout,
+		deadline: time.Now().Add(timeout),
+	}
+
+	// Start goroutine to cancel the context when the deadline is reached.
+	go t.run()
+	return ctx, t
+}
+
+// Tick updates the deadline to the current time plus the timeout.
+func (t *timeoutContext) Tick() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.deadline = time.Now().Add(t.timeout)
+}
+
+// Cancel cancels the context.
+func (t *timeoutContext) Cancel() {
+	t.cancel(context.Canceled)
+}
+
+// Deadline returns the current deadline.
+func (t *timeoutContext) Deadline() time.Time {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.deadline
+}
+
+func (t *timeoutContext) run() {
+	for {
+		ttl := time.Until(t.Deadline())
+		if ttl <= 0 {
+			t.cancel(context.DeadlineExceeded)
+			return
+		}
+		select {
+		case <-time.After(ttl):
+			// Check if the deadline has been updated
+			continue
+		case <-t.ctx.Done():
+			return
+		}
+	}
+}
+
+type timeoutTickReader struct {
+	t TimeoutTicker
+	r io.Reader
+}
+
+func (t timeoutTickReader) Read(p []byte) (n int, err error) {
+	defer t.t.Tick()
+	return t.r.Read(p)
+}
+
+// tickingReader returns a reader that ticks the timeout ticker on each read.
+// This is used when reading the request body and writing it to the server.
+func tickingReader(t TimeoutTicker, r io.Reader) io.Reader {
+	if r == nil {
+		return nil
+	}
+	return timeoutTickReader{t, r}
+}
+
+type timeoutTickReadCloser struct {
+	t TimeoutTicker
+	r io.ReadCloser
+}
+
+// tickingReadCloser returns a read closer that ticks the timeout ticker on each read.
+// It also cancels the ticker when the read closer is closed.
+// This is used specifically for reading the response body.
+func tickingReadCloser(t TimeoutTicker, r io.ReadCloser) io.ReadCloser {
+	if r == nil {
+		return nil
+	}
+	return timeoutTickReadCloser{t, r}
+}
+
+func (t timeoutTickReadCloser) Read(p []byte) (n int, err error) {
+	defer t.t.Tick()
+	return t.r.Read(p)
+}
+
+func (t timeoutTickReadCloser) Close() error {
+	t.t.Cancel()
+	return t.r.Close()
+}

--- a/httpclient/timeout_context.go
+++ b/httpclient/timeout_context.go
@@ -77,24 +77,32 @@ func (t *timeoutContext) run() {
 
 // tickingReadCloser wraps an io.ReadCloser and calls the tick function on each read.
 type tickingReadCloser struct {
-	io.ReadCloser
-	t TimeoutTicker
+	rc io.ReadCloser
+	t  TimeoutTicker
 }
 
 func (t tickingReadCloser) Read(p []byte) (n int, err error) {
 	defer t.t.Tick()
-	return t.ReadCloser.Read(p)
+	return t.rc.Read(p)
+}
+
+func (t tickingReadCloser) Close() error {
+	return t.rc.Close()
 }
 
 // cancellingReadCloser wraps an io.ReadCloser and calls the cancel function on close.
 type cancellingReadCloser struct {
-	io.ReadCloser
-	t TimeoutTicker
+	rc io.ReadCloser
+	t  TimeoutTicker
+}
+
+func (t cancellingReadCloser) Read(p []byte) (n int, err error) {
+	return t.rc.Read(p)
 }
 
 func (t cancellingReadCloser) Close() error {
 	defer t.t.Cancel()
-	return t.ReadCloser.Close()
+	return t.rc.Close()
 }
 
 func newRequestBodyTicker(t TimeoutTicker, r io.ReadCloser) io.ReadCloser {

--- a/httpclient/timeout_context.go
+++ b/httpclient/timeout_context.go
@@ -65,11 +65,14 @@ func (t *timeoutContext) run() {
 			t.cancel()
 			return
 		}
+
+		timer := time.NewTimer(ttl)
 		select {
-		case <-time.After(ttl):
+		case <-timer.C:
 			// Check if the deadline has been updated
 			continue
 		case <-t.ctx.Done():
+			timer.Stop()
 			return
 		}
 	}

--- a/httpclient/timeout_context.go
+++ b/httpclient/timeout_context.go
@@ -12,7 +12,7 @@ type timeoutContext struct {
 	cancel context.CancelCauseFunc
 
 	// Timeout is constant.
-	// Deadline is updated when Mark function is called.
+	// Deadline is updated when Tick function is called.
 	timeout  time.Duration
 	deadline time.Time
 

--- a/httpclient/timeout_context_test.go
+++ b/httpclient/timeout_context_test.go
@@ -15,7 +15,6 @@ func TestTimeoutContextTimeout(t *testing.T) {
 
 	// The context should have timed out.
 	assert.Equal(t, context.Canceled, ctx.Err())
-	assert.Equal(t, context.DeadlineExceeded, context.Cause(ctx))
 }
 
 func TestTimeoutContextTick(t *testing.T) {
@@ -30,7 +29,6 @@ func TestTimeoutContextTick(t *testing.T) {
 
 	// The context should not have timed out.
 	assert.Nil(t, ctx.Err())
-	assert.Nil(t, context.Cause(ctx))
 }
 
 func TestTimeoutContextCancel(t *testing.T) {
@@ -42,5 +40,4 @@ func TestTimeoutContextCancel(t *testing.T) {
 
 	// The context should have timed out.
 	assert.Equal(t, context.Canceled, ctx.Err())
-	assert.Equal(t, context.Canceled, context.Cause(ctx))
 }


### PR DESCRIPTION
## Changes

The net/http package supports only a fixed timeout.

This is problematic when streaming a large request or response body.

The approach proposed in this PR is to disable the net/http timeouts and use our own context for cancellation instead. This context is canceled only if there is no activity for the duration of 1 timeout period. As the request or response body is read, the deadline is reinitialized to equal 1 timeout period from the current timestamp. This means real timeouts will still time out in the same amount of time, but streaming requests will not time out as long as there is activity.

If a request times out, it used to return the following error:
> Get "/a?": context deadline exceeded (Client.Timeout exceeded while awaiting headers)

Now it returns the following error:
> Get "/a?": request timed out after 10ms of inactivity

**Note:** the unit tests are time-based. Not great but I don't have a great alternative (that doesn't involve mocking time itself).

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

