### PR TITLE
[WIP] DATABRICKS_CA_BUNDLE

### DIFF
--- a/config/api_client.go
+++ b/config/api_client.go
@@ -33,6 +33,7 @@ func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
 		DebugHeaders:       c.DebugHeaders,
 		DebugTruncateBytes: c.DebugTruncateBytes,
 		InsecureSkipVerify: c.InsecureSkipVerify,
+		CABundle:           c.CABundle,
 		Transport:          c.HTTPTransport,
 		Visitors: []httpclient.RequestVisitor{
 			c.Authenticate,
@@ -76,7 +77,7 @@ func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
 			}
 			return false
 		},
-	}), nil
+	})
 }
 
 func orDefault(configured, _default int) int {

--- a/examples/http-proxy/README.md
+++ b/examples/http-proxy/README.md
@@ -6,6 +6,8 @@ The proxy server generates a self-signed certificate and listens on port 8443 wi
 
 ## Run the Example: Auto-registration of the Proxy Server Certificate
 
+This example demonstrates how to automatically register the proxy server's certificate with the system's certificate store. This allows the client to trust the proxy server's certificate without needing to manually configure the client to trust the certificate. This is the preferred way to configure your system, as it doesn't require application-specific configuration to trust the proxy server's certificate.
+
 Note: this example requires root access to register the proxy server's certificate with the system's certificate store. On Windows, this requires running the proxy server as an administrator.
 
 1. Run the proxy server:
@@ -14,7 +16,7 @@ Note: this example requires root access to register the proxy server's certifica
    go run ./proxy --register-certificate
    ```
 
-   This will attempt to register the proxy server's certificate with the system's certificate store.
+   This will attempt to register the proxy server's certificate with the system's certificate store. If you're using Windows, you will need to run Powershell as an administrator to register the certificate.
 
 2. In another terminal, run the client:
 
@@ -28,9 +30,13 @@ Note: this example requires root access to register the proxy server's certifica
    $env:HTTPS_PROXY="https://localhost:8443" go run ./client
    ```
 
+   Note that on Windows, this does not require administrator privileges.
+
 3. When done, terminate the proxy server by typing `CMD+C` or `Ctrl+C` in the terminal where it is running.
 
 ## Run the Example: Configure the Proxy Server Certificate at Runtime
+
+This example demonstrates how to configure the client to trust the proxy server's certificate at runtime. This is useful when you don't have root access to register the proxy server's certificate with the system's certificate store, or when you want to avoid modifying the system's certificate store.
 
 1. Run the proxy server:
 

--- a/examples/http-proxy/README.md
+++ b/examples/http-proxy/README.md
@@ -1,0 +1,53 @@
+# HTTP Proxy Example
+
+This example demonstrates how to use the Databricks SDK for Go with an HTTPS proxy. The `proxy` directory contains a simple HTTP proxy server that forwards requests to the Databricks REST API. The `client` directory contains a simple client that uses the Databricks SDK for Go to make requests to the proxy server.
+
+The proxy server generates a self-signed certificate and listens on port 8443 with this certificate. The generated certificate can be found at `proxy/proxy.crt`, and it is cleaned up when the proxy is terminated. The client must trust this certificate to make requests to Databricks through the proxy server.
+
+## Run the Example: Auto-registration of the Proxy Server Certificate
+
+Note: this example requires root access to register the proxy server's certificate with the system's certificate store. On Windows, this requires running the proxy server as an administrator.
+
+1. Run the proxy server:
+
+   ```bash
+   go run ./proxy --register-certificate
+   ```
+
+   This will attempt to register the proxy server's certificate with the system's certificate store.
+
+2. In another terminal, run the client:
+
+   ```bash
+   HTTPS_PROXY=https://localhost:8443 go run ./client
+   ```
+
+   or on Windows:
+
+   ```powershell
+   $env:HTTPS_PROXY="https://localhost:8443" go run ./client
+   ```
+
+3. When done, terminate the proxy server by typing `CMD+C` or `Ctrl+C` in the terminal where it is running.
+
+## Run the Example: Configure the Proxy Server Certificate at Runtime
+
+1. Run the proxy server:
+
+   ```bash
+   go run ./proxy
+   ```
+
+2. In another terminal, run the client, this time specifying the path to the CA file:
+
+   ```bash
+   DATABRICKS_CA_BUNDLE=proxy/proxy.crt HTTPS_PROXY=https://localhost:8443 go run ./client
+   ```
+
+   or on Windows:
+
+   ```powershell
+   $env:DATABRICKS_CA_BUNDLE="proxy/proxy.crt" $env:HTTPS_PROXY="https://localhost:8443" go run ./client
+   ```
+
+3. When done, terminate the proxy server by typing `CMD+C` or `Ctrl+C` in the terminal where it is running.

--- a/examples/http-proxy/client/main.go
+++ b/examples/http-proxy/client/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -14,42 +12,14 @@ import (
 
 func main() {
 	if os.Getenv("HTTPS_PROXY") != "https://localhost:8443" {
-		log.Printf(`To run this example, first start the proxy server in the examples/http-proxy/proxy directory:
-
-$ go run ../proxy
-
-On Windows, you must do this from a command prompt with administrator privileges.
-
-Then, run this example setting the HTTP_PROXY or HTTPS_PROXY environment variable to the proxy server:
-
-$ HTTPS_PROXY=https://localhost:8443 go run .
-
-on macOS or Linux, or
-
-$ $env:HTTPS_PROXY="https://localhost:8443"; go run .
-
-on Windows to see the list of clusters in your Databricks workspace using this proxy.
-`)
+		log.Printf(`To run this example, see the instructions in examples/http-proxy/README.md.`)
 		os.Exit(1)
 	}
 	log.Printf("Constructing client...")
 	logger.DefaultLogger = &logger.SimpleLogger{
 		Level: logger.LevelDebug,
 	}
-	var tlsNextProto map[string]func(authority string, c *tls.Conn) http.RoundTripper
-	if os.Getenv("HTTPS_PROXY") != "" {
-		// Go's HTTP client only supports HTTP/1.1 proxies when using TLS. See
-		// https://github.com/golang/go/issues/26479 for more information. Configuring
-		// this property to be a non-nil empty map will disable HTTP/2 on the HTTP
-		// transport.
-		tlsNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
-	}
-	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{
-		HTTPTransport: &http.Transport{
-			Proxy:        http.ProxyFromEnvironment,
-			TLSNextProto: tlsNextProto,
-		},
-	}))
+	w := databricks.Must(databricks.NewWorkspaceClient())
 	log.Printf("Listing clusters...")
 	all, err := w.Clusters.ListAll(context.Background(), compute.ListClustersRequest{})
 	if err != nil {

--- a/examples/http-proxy/proxy/.gitignore
+++ b/examples/http-proxy/proxy/.gitignore
@@ -1,0 +1,2 @@
+proxy.crt
+proxy.key

--- a/httpclient/errors_test.go
+++ b/httpclient/errors_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSimpleRequestAPIError(t *testing.T) {
-	c := NewApiClient(ClientConfig{
+	c, err := NewApiClient(ClientConfig{
 		Transport: hc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 400,
@@ -24,7 +24,8 @@ func TestSimpleRequestAPIError(t *testing.T) {
 			}, nil
 		}),
 	})
-	err := c.Do(context.Background(), "PATCH", "/a", WithRequestData(map[string]any{}))
+	require.NoError(t, err)
+	err = c.Do(context.Background(), "PATCH", "/a", WithRequestData(map[string]any{}))
 	var httpErr *HttpError
 	if assert.ErrorAs(t, err, &httpErr) {
 		require.Equal(t, 400, httpErr.StatusCode)
@@ -32,7 +33,7 @@ func TestSimpleRequestAPIError(t *testing.T) {
 }
 
 func TestSimpleRequestErrReaderBody(t *testing.T) {
-	c := NewApiClient(ClientConfig{
+	c, err := NewApiClient(ClientConfig{
 		Transport: hc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
@@ -41,7 +42,8 @@ func TestSimpleRequestErrReaderBody(t *testing.T) {
 			}, nil
 		}),
 	})
+	require.NoError(t, err)
 	headers := map[string]string{"Accept": "application/json"}
-	err := c.Do(context.Background(), "PATCH", "/a", WithRequestHeaders(headers), WithRequestData(map[string]any{}))
+	err = c.Do(context.Background(), "PATCH", "/a", WithRequestHeaders(headers), WithRequestData(map[string]any{}))
 	require.EqualError(t, err, "response body: test error")
 }

--- a/httpclient/fixtures/map_transport_test.go
+++ b/httpclient/fixtures/map_transport_test.go
@@ -18,11 +18,12 @@ func init() {
 }
 
 func TestSimpleGetErrorStub(t *testing.T) {
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.MappingTransport{},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "/foo",
+	err = client.Do(ctx, "GET", "/foo",
 		httpclient.WithRequestData(map[string]any{
 			"foo": "bar",
 		}))
@@ -35,7 +36,7 @@ func TestSimpleGetErrorStub(t *testing.T) {
 }
 
 func TestSimplePostErrorStubFilled(t *testing.T) {
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.MappingTransport{
 			"POST /foo": {
 				Status:          203,
@@ -44,9 +45,10 @@ func TestSimplePostErrorStubFilled(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	var out map[string]string
 	ctx := context.Background()
-	err := client.Do(ctx, "POST", "/foo",
+	err = client.Do(ctx, "POST", "/foo",
 		httpclient.WithResponseUnmarshal(&out),
 		httpclient.WithRequestData(map[string]any{
 			"foo": "bar",
@@ -56,18 +58,19 @@ func TestSimplePostErrorStubFilled(t *testing.T) {
 }
 
 func TestPassFile(t *testing.T) {
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.MappingTransport{
 			"GET /some": {
 				PassFile: "testdata/some.json",
 			},
 		},
 	})
+	require.NoError(t, err)
 	var out struct {
 		Some string `json:"some"`
 	}
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "/some",
+	err = client.Do(ctx, "GET", "/some",
 		httpclient.WithResponseUnmarshal(&out))
 	require.NoError(t, err)
 	assert.Equal(t, "data", out.Some)

--- a/httpclient/fixtures/slice_transport_test.go
+++ b/httpclient/fixtures/slice_transport_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetErrorStub(t *testing.T) {
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "/foo", httpclient.WithRequestData(map[string]any{
+	err = client.Do(ctx, "GET", "/foo", httpclient.WithRequestData(map[string]any{
 		"foo": "bar",
 	}))
 	// spacing in this test is very important
@@ -31,7 +33,7 @@ func TestGetErrorStubFilled(t *testing.T) {
 	var out struct {
 		Foo string `json:"foo"`
 	}
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{
 			{
 				Method:   "GET",
@@ -42,8 +44,9 @@ func TestGetErrorStubFilled(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "/foo",
+	err = client.Do(ctx, "GET", "/foo",
 		httpclient.WithResponseUnmarshal(&out),
 		httpclient.WithRequestData(map[string]any{
 			"foo": "bar",
@@ -56,7 +59,7 @@ func TestReplyWithString(t *testing.T) {
 	var out struct {
 		Foo string `json:"foo"`
 	}
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{
 			{
 				Method:   "GET",
@@ -65,8 +68,9 @@ func TestReplyWithString(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "/foo",
+	err = client.Do(ctx, "GET", "/foo",
 		httpclient.WithResponseUnmarshal(&out),
 		httpclient.WithRequestData(map[string]any{
 			"foo": "bar",
@@ -76,11 +80,12 @@ func TestReplyWithString(t *testing.T) {
 }
 
 func TestGetErrorStubWithHost(t *testing.T) {
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "http://localhost:1234/foo", httpclient.WithRequestData(map[string]any{
+	err = client.Do(ctx, "GET", "http://localhost:1234/foo", httpclient.WithRequestData(map[string]any{
 		"foo": "bar",
 	}))
 	// spacing in this test is very important
@@ -94,11 +99,12 @@ func TestGetErrorStubWithHost(t *testing.T) {
 }
 
 func TestPostErrorStub(t *testing.T) {
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "POST", "/foo", httpclient.WithRequestData(map[string]any{
+	err = client.Do(ctx, "POST", "/foo", httpclient.WithRequestData(map[string]any{
 		"foo": "bar",
 	}))
 	// spacing in this test is very important
@@ -119,7 +125,7 @@ func TestPostErrorStubFilled(t *testing.T) {
 	type op struct {
 		Foo string `json:"foo"`
 	}
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{
 			{
 				Method:   "POST",
@@ -130,8 +136,9 @@ func TestPostErrorStubFilled(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "POST", "/foo", httpclient.WithRequestData(map[string]any{
+	err = client.Do(ctx, "POST", "/foo", httpclient.WithRequestData(map[string]any{
 		"foo": "bar",
 	}))
 	assert.NoError(t, err)
@@ -141,7 +148,7 @@ func TestPostUnexpectedRequest(t *testing.T) {
 	type op struct {
 		Foo string `json:"foo"`
 	}
-	client := httpclient.NewApiClient(httpclient.ClientConfig{
+	client, err := httpclient.NewApiClient(httpclient.ClientConfig{
 		Transport: fixtures.SliceTransport{
 			{
 				Method:   "POST",
@@ -152,8 +159,9 @@ func TestPostUnexpectedRequest(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	ctx := context.Background()
-	err := client.Do(ctx, "POST", "/foo", httpclient.WithRequestData(map[string]any{
+	err = client.Do(ctx, "POST", "/foo", httpclient.WithRequestData(map[string]any{
 		"foo": "bar",
 	}))
 	assert.EqualError(t, err, `Post "/foo": expected: want {

--- a/httpclient/request_test.go
+++ b/httpclient/request_test.go
@@ -92,7 +92,7 @@ func TestMakeRequestBodyQueryUnsupported(t *testing.T) {
 }
 
 func TestWithTokenSource(t *testing.T) {
-	client := NewApiClient(ClientConfig{
+	client, err := NewApiClient(ClientConfig{
 		Transport: hc(func(r *http.Request) (*http.Response, error) {
 			foo := r.Header.Get("Foo")
 			require.Equal(t, "bar", foo)
@@ -105,10 +105,11 @@ func TestWithTokenSource(t *testing.T) {
 			}, nil
 		}),
 	})
+	require.NoError(t, err)
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "abc",
+	err = client.Do(ctx, "GET", "abc",
 		WithResponseUnmarshal(&buf),
 		WithRequestHeader("Foo", "bar"),
 		WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{

--- a/httpclient/response_test.go
+++ b/httpclient/response_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSimpleRequestRawResponse(t *testing.T) {
-	c := NewApiClient(ClientConfig{
+	c, err := NewApiClient(ClientConfig{
 		Transport: hc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
@@ -20,14 +20,15 @@ func TestSimpleRequestRawResponse(t *testing.T) {
 			}, nil
 		}),
 	})
+	require.NoError(t, err)
 	var raw []byte
-	err := c.Do(context.Background(), "GET", "/a", WithResponseUnmarshal(&raw))
+	err = c.Do(context.Background(), "GET", "/a", WithResponseUnmarshal(&raw))
 	require.NoError(t, err)
 	require.Equal(t, "Hello, world!", string(raw))
 }
 
 func TestWithResponseHeader(t *testing.T) {
-	client := NewApiClient(ClientConfig{
+	client, err := NewApiClient(ClientConfig{
 		Transport: hc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				Request:    r,
@@ -39,10 +40,11 @@ func TestWithResponseHeader(t *testing.T) {
 			}, nil
 		}),
 	})
+	require.NoError(t, err)
 
 	var out string
 	ctx := context.Background()
-	err := client.Do(ctx, "GET", "abc",
+	err = client.Do(ctx, "GET", "abc",
 		WithResponseHeader("Foo", &out))
 	require.NoError(t, err)
 	require.Equal(t, "some", out)


### PR DESCRIPTION
## Changes
This PR adds support for a `DATABRICKS_CA_BUNDLE` flag in the Go SDK. This would need to be ported to the Python and Java SDKs as well.

When this configuration parameter is specified, the SDK will consider the specified certificate bundle along with the system-level CA certificates when validating the server certificate while establishing TLS. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

