### PR TITLE
Support DATABRICKS_SDK_UPSTREAM and DATABRICKS_SDK_UPSTREAM_VERSION

### DIFF
--- a/useragent/user_agent.go
+++ b/useragent/user_agent.go
@@ -3,6 +3,7 @@ package useragent
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 
@@ -45,6 +46,18 @@ func WithUserAgentExtra(key, value string) {
 	extra = extra.With(key, value)
 }
 
+func getUpstreamUserAgentInfo() []info {
+	product := os.Getenv("DATABRICKS_SDK_UPSTREAM")
+	version := os.Getenv("DATABRICKS_SDK_UPSTREAM_VERSION")
+	if product == "" || version == "" {
+		return nil
+	}
+	return []info{
+		{"upstream", product},
+		{"upstream-version", version},
+	}
+}
+
 // InContext populates context with user agent dimension,
 // usually to differentiate subsets of functionality and
 // agreed with Databricks.
@@ -63,6 +76,7 @@ func FromContext(ctx context.Context) string {
 		{"os", runtime.GOOS},
 	}
 	base = append(base, extra...)
+	base = append(base, getUpstreamUserAgentInfo()...)
 	uac, _ := ctx.Value(ctxAgent).(data)
 	return append(base, uac...).String()
 }

--- a/useragent/user_agent_test.go
+++ b/useragent/user_agent_test.go
@@ -3,6 +3,7 @@ package useragent
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -59,4 +60,15 @@ func TestFromContext_Custom(t *testing.T) {
 
 func TestDefaultsAreValid(t *testing.T) {
 	WithProduct(productName, productVersion)
+}
+
+func TestUpstreamUserAgent(t *testing.T) {
+	// Set the environment variables to test the upstream user agent
+	// and check that it is included in the user agent string.
+	os.Setenv("DATABRICKS_SDK_UPSTREAM", "my-upstream-sdk")
+	os.Setenv("DATABRICKS_SDK_UPSTREAM_VERSION", "1.2.3")
+	userAgent := FromContext(context.Background())
+	assert.Contains(t, userAgent, "upstream/my-upstream-sdk upstream-version/1.2.3")
+	os.Unsetenv("DATABRICKS_SDK_UPSTREAM")
+	os.Unsetenv("DATABRICKS_SDK_UPSTREAM_VERSION")
 }

--- a/useragent/user_agent_test.go
+++ b/useragent/user_agent_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/version"
@@ -57,44 +56,21 @@ func TestFromContext_Custom(t *testing.T) {
 	expectedFormat2 := "unit-tests/0.0.1 databricks-sdk-go/%s go/%s os/%s pulumi/3.8.4 terraform/1.3.6 a/f foo/bar"
 	expected2 := fmt.Sprintf(expectedFormat2, version.Version, goVersion(), runtime.GOOS)
 	assert.Equal(t, expected2, userAgent2)
+
+	// upstream and upstream-version only appear when both are set
+	assert.NotContains(t, userAgent, "upstream/")
+	os.Setenv("DATABRICKS_SDK_UPSTREAM", "my-upstream-sdk")
+	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM")
+	userAgent3 := FromContext(ctx)
+	assert.NotContains(t, userAgent3, "upstream/")
+	assert.NotContains(t, userAgent3, "upstream-version/")
+
+	os.Setenv("DATABRICKS_SDK_UPSTREAM_VERSION", "1.2.3")
+	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM_VERSION")
+	userAgent4 := FromContext(context.Background())
+	assert.Contains(t, userAgent4, "upstream/my-upstream-sdk upstream-version/1.2.3")
 }
 
 func TestDefaultsAreValid(t *testing.T) {
 	WithProduct(productName, productVersion)
-}
-
-var upstreamEnvironmentLock sync.Mutex
-
-func TestUpstreamUserAgent_NotPresent(t *testing.T) {
-	upstreamEnvironmentLock.Lock()
-	defer upstreamEnvironmentLock.Unlock()
-
-	userAgent := FromContext(context.Background())
-	assert.NotContains(t, userAgent, "upstream/")
-	assert.NotContains(t, userAgent, "upstream-version/")
-}
-
-func TestUpstreamUserAgent_OnlyOnePresent(t *testing.T) {
-	upstreamEnvironmentLock.Lock()
-	defer upstreamEnvironmentLock.Unlock()
-
-	os.Setenv("DATABRICKS_SDK_UPSTREAM", "my-upstream-sdk")
-	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM")
-
-	userAgent := FromContext(context.Background())
-	assert.NotContains(t, userAgent, "upstream/")
-	assert.NotContains(t, userAgent, "upstream-version/")
-}
-
-func TestUpstreamUserAgent_Present(t *testing.T) {
-	upstreamEnvironmentLock.Lock()
-	defer upstreamEnvironmentLock.Unlock()
-
-	os.Setenv("DATABRICKS_SDK_UPSTREAM", "my-upstream-sdk")
-	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM")
-	os.Setenv("DATABRICKS_SDK_UPSTREAM_VERSION", "1.2.3")
-	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM_VERSION")
-
-	userAgent := FromContext(context.Background())
-	assert.Contains(t, userAgent, "upstream/my-upstream-sdk upstream-version/1.2.3")
 }

--- a/useragent/user_agent_test.go
+++ b/useragent/user_agent_test.go
@@ -63,12 +63,11 @@ func TestDefaultsAreValid(t *testing.T) {
 }
 
 func TestUpstreamUserAgent(t *testing.T) {
-	// Set the environment variables to test the upstream user agent
-	// and check that it is included in the user agent string.
 	os.Setenv("DATABRICKS_SDK_UPSTREAM", "my-upstream-sdk")
+	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM")
 	os.Setenv("DATABRICKS_SDK_UPSTREAM_VERSION", "1.2.3")
+	defer os.Unsetenv("DATABRICKS_SDK_UPSTREAM_VERSION")
+
 	userAgent := FromContext(context.Background())
 	assert.Contains(t, userAgent, "upstream/my-upstream-sdk upstream-version/1.2.3")
-	os.Unsetenv("DATABRICKS_SDK_UPSTREAM")
-	os.Unsetenv("DATABRICKS_SDK_UPSTREAM_VERSION")
 }


### PR DESCRIPTION
## Changes
This PR ports https://github.com/databricks/databricks-sdk-py/pull/163 to the Go SDK. This enables partners who use the SDK through a tool (like Terraform) to add custom information to the user agent without having to make code changes to the tool.

Closes #850.

## Tests
Added unit test to verify that the user agent is only updated when both DATABRICKS_SDK_UPSTREAM and DATABRICKS_SDK_UPSTREAM_VERSION are set.

Manually ran `examples/slog` to verify that the user agent is correctly updated.
