### PR TITLE
Fix TestUcAccShares

### DIFF
--- a/internal/sharing_test.go
+++ b/internal/sharing_test.go
@@ -165,7 +165,7 @@ func TestUcAccShares(t *testing.T) {
 		WarehouseId: GetEnvOrSkipTest(t, "TEST_DEFAULT_WAREHOUSE_ID"),
 		Catalog:     createdCatalog.Name,
 		Schema:      createdSchema.Name,
-		Statement:   fmt.Sprintf("CREATE TABLE %s AS SELECT 2+2 as four", tableName),
+		Statement:   fmt.Sprintf("CREATE TABLE %s TBLPROPERTIES (delta.enableDeletionVectors=false) AS SELECT 2+2 as four", tableName),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
## Changes
A change was made recently to enable deletion vectors by default in new tables. However, this is incompatible with sharing, as shares don't currently support tables with deletion vectors, resulting in this failure:
```
Table property
delta.enableDeletionVectors
is found in table version: 0.
Here are a couple options to proceed:
1. Contact support to enable sharing of tables with Deletion Vectors or Column Mappings. Then share the table with history in UI or with SQL command: ALTER SHARE <share> ADD TABLE <table> WITH HISTORY. Note: Your recipients can only query these shared tables if they are using Databricks with DBR version 14.1 or higher, or using delta-sharing-spark with version 3.1 or higher.
2. Disable Deletion Vectors for the table with (`ALTER TABLE <table_name> SET TBLPROPERTIES (delta.enableDeletionVectors=false)`) and rewrite it without Deletion Vectors (`REORG TABLE <table_name> APPLY(PURGE)`).
```

This PR disables deletion vectors on the table created in this test so it can be added to a share.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [x] relevant integration tests applied

