### PR TITLE
Support diffs for multiple fields in one changelog line

### DIFF
--- a/.codegen/changelog.md.tmpl
+++ b/.codegen/changelog.md.tmpl
@@ -7,7 +7,7 @@
 {{end}}{{- if .ApiChanges}}
 API Changes:
 {{range .ApiChanges}}
- * {{.Action}} {{template "what" .}}{{if .Extra}} {{.Extra}}{{with .Other}} {{template "what" .}}{{end}}{{end}}.
+ * {{.Action}} {{template "what" .}}{{if .Extra}} {{.Extra}}{{with .Other}} {{template "whats" .}}{{end}}{{end}}.
 {{- end}}
 
 OpenAPI SHA: {{.Sha}}, Date: {{.Changed}}
@@ -19,6 +19,20 @@ Dependency updates:
 {{end}}
 
 ## {{.PrevVersion}}
+
+{{- define "whats" -}}
+{{- $length := len . -}}
+{{- if gt $length 1 -}}
+    {{- range $i, $v := . -}}
+        {{- if lt $i (sub $length 1) -}}
+            {{- if gt $i 0 -}}, {{- end -}}{{ template "what" $v }}
+        {{- else -}}
+            {{- " and " -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- template "what" (index . (sub $length 1)) -}}
+{{- end -}}
 
 {{- define "what" -}}
     {{if eq .X "package" -}}


### PR DESCRIPTION
## Changes
Support the same diff across multiple fields in a single autogenerated line of the changelog.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

