### PR TITLE
Fix integration test naming for UC Files

### DIFF
--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -29,7 +29,7 @@ func (buf hashable) Hash() uint32 {
 	return h.Sum32()
 }
 
-func TestUcAccUploadAndDownloadFilesAPI(t *testing.T) {
+func TestUcAccFilesUploadAndDownload(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/files-")
@@ -57,7 +57,7 @@ func TestUcAccUploadAndDownloadFilesAPI(t *testing.T) {
 	assert.Equal(t, "abcd", string(contents))
 }
 
-func TestUcAccDeleteFile(t *testing.T) {
+func TestUcAccFilesDelete(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/file-")
@@ -67,7 +67,7 @@ func TestUcAccDeleteFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestUcAccGetMetadata(t *testing.T) {
+func TestUcAccFilesGetMetadata(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/file-")
@@ -81,14 +81,14 @@ func TestUcAccGetMetadata(t *testing.T) {
 	assert.NotEmpty(t, metadata.LastModified)
 }
 
-func TestUcAccCreateDirectory(t *testing.T) {
+func TestUcAccFilesCreateDirectory(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")
 	require.NoError(t, createDirectory(t, ctx, w, directoryPath))
 }
 
-func TestUcAccListDirectoryContents(t *testing.T) {
+func TestUcAccFilesListDirectoryContents(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")
@@ -102,7 +102,7 @@ func TestUcAccListDirectoryContents(t *testing.T) {
 	assert.Len(t, response, 3)
 }
 
-func TestUcAccDeleteDirectory(t *testing.T) {
+func TestUcAccFilesDeleteDirectory(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")
@@ -112,7 +112,7 @@ func TestUcAccDeleteDirectory(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestUcAccGetDirectoryMetadata(t *testing.T) {
+func TestUcAccFilesGetDirectoryMetadata(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -29,7 +29,7 @@ func (buf hashable) Hash() uint32 {
 	return h.Sum32()
 }
 
-func TestUcAccCUploadAndDownloadFilesAPI(t *testing.T) {
+func TestUcAccUploadAndDownloadFilesAPI(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/files-")

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -29,7 +29,7 @@ func (buf hashable) Hash() uint32 {
 	return h.Sum32()
 }
 
-func TestAccUCUploadAndDownloadFilesAPI(t *testing.T) {
+func TestUcAccCUploadAndDownloadFilesAPI(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/files-")
@@ -57,7 +57,7 @@ func TestAccUCUploadAndDownloadFilesAPI(t *testing.T) {
 	assert.Equal(t, "abcd", string(contents))
 }
 
-func TestAccUCDeleteFile(t *testing.T) {
+func TestUcAccDeleteFile(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/file-")
@@ -67,7 +67,7 @@ func TestAccUCDeleteFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAccUCGetMetadata(t *testing.T) {
+func TestUcAccGetMetadata(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	filePath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/file-")
@@ -81,14 +81,14 @@ func TestAccUCGetMetadata(t *testing.T) {
 	assert.NotEmpty(t, metadata.LastModified)
 }
 
-func TestAccUCCreateDirectory(t *testing.T) {
+func TestUcAccCreateDirectory(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")
 	require.NoError(t, createDirectory(t, ctx, w, directoryPath))
 }
 
-func TestAccUCListDirectoryContents(t *testing.T) {
+func TestUcAccListDirectoryContents(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")
@@ -102,7 +102,7 @@ func TestAccUCListDirectoryContents(t *testing.T) {
 	assert.Len(t, response, 3)
 }
 
-func TestAccUCDeleteDirectory(t *testing.T) {
+func TestUcAccDeleteDirectory(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")
@@ -112,7 +112,7 @@ func TestAccUCDeleteDirectory(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestAccUCGetDirectoryMetadata(t *testing.T) {
+func TestUcAccGetDirectoryMetadata(t *testing.T) {
 	ctx, w, volume := setupUCVolume(t)
 
 	directoryPath := RandomName("/Volumes/" + volume.CatalogName + "/" + volume.SchemaName + "/" + volume.Name + "/directory-")


### PR DESCRIPTION
## Changes
These tests are currently being skipped in integration tests. They run in the non-UC runner because the test name starts with TestAcc, but they are skipped there because metastore ID is not defined:

```
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCUploadAndDownloadFilesAPI: === RUN   TestAccUCUploadAndDownloadFilesAPI
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCUploadAndDownloadFilesAPI (0.00s)
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCDeleteFile: === RUN   TestAccUCDeleteFile
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCDeleteFile (0.00s)
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCGetMetadata: === RUN   TestAccUCGetMetadata
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCGetMetadata (0.00s)
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCCreateDirectory: === RUN   TestAccUCCreateDirectory
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCCreateDirectory (0.00s)
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCListDirectoryContents: === RUN   TestAccUCListDirectoryContents
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCListDirectoryContents (0.00s)
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCDeleteDirectory: === RUN   TestAccUCDeleteDirectory
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCDeleteDirectory (0.00s)
2024/03/26 02:08:32 [INFO] 🦥 TestAccUCGetDirectoryMetadata: === RUN   TestAccUCGetDirectoryMetadata
    init_test.go:103: Environment variable TEST_METASTORE_ID is missing
--- SKIP: TestAccUCGetDirectoryMetadata (0.00s)
```

This PR renames these tests so they are run in UC testing environments.

## Tests
- [x] Triggered the integration tests on this PR.