### PR TITLE
fix to set `filter` to empty when `next_page_token` is returned from previous call

### DIFF
--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -310,6 +310,9 @@ func (a *{{.Service.Name}}API) {{.PascalName}}(ctx context.Context{{if .Request}
 		{{- else -}}
 		request.{{.Pagination.Offset.PascalName}} = resp.{{.Pagination.Offset.PascalName}} + {{template "type" .Pagination.Offset.Entity}}(len(resp.{{.Pagination.Results.PascalName}}))
 		{{- end}}{{ end }}
+		{{if or (eq .Request.PascalName "ListPipelinesRequest") (eq .Request.PascalName "ListPipelineEventsRequest")}}
+		request.Filter = ""
+		{{end}}
 		return &request
 	}
 	{{- end}}

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -442,6 +442,7 @@ func (a *PipelinesAPI) ListPipelineEvents(ctx context.Context, request ListPipel
 			return nil
 		}
 		request.PageToken = resp.NextPageToken
+		request.Filter = ""
 		return &request
 	}
 	iterator := listing.NewIterator(
@@ -491,6 +492,7 @@ func (a *PipelinesAPI) ListPipelines(ctx context.Context, request ListPipelinesR
 			return nil
 		}
 		request.PageToken = resp.NextPageToken
+		request.Filter = ""
 		return &request
 	}
 	iterator := listing.NewIterator(


### PR DESCRIPTION
## Changes
clear `request.Filter` when preivous call returns next_page_token to avoid error when with filter request
```bash
databricks.sdk.errors.platform.InvalidParameterValue: When providing a page token and a filter, the filter must match the filter represented by the page token.
```
similar fix in https://github.com/databricks/databricks-sdk-py/pull/605, https://github.com/databricks/databricks-sdk-java/pull/255
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

