### PR TITLE
Fix logging of request bodies containing percent characters.

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -310,7 +310,7 @@ func (c *ApiClient) recordRequestLog(
 		DebugTruncateBytes:       c.config.DebugTruncateBytes,
 		DebugAuthorizationHeader: true,
 	}.String()
-	logger.Debugf(ctx, message)
+	logger.Debugf(ctx, "%s", message)
 }
 
 // RoundTrip implements http.RoundTripper to integrate with golang.org/x/oauth2


### PR DESCRIPTION
## Changes
Because the debug string for requests/responses can contain percent characters, simply logging the request/response causes Go to interpret this as a format string. Instead, we should use format string `"%s"` to ensure that the percents are printed as expected to the debug log.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

