### PR TITLE
Do not leak secondary authorization tokens in debug logs

### DIFF
--- a/logger/httplog/round_trip_stringer.go
+++ b/logger/httplog/round_trip_stringer.go
@@ -19,6 +19,12 @@ type RoundTripStringer struct {
 	DebugTruncateBytes       int
 }
 
+var authorizationHeaders = map[string]bool{
+	"Authorization":                          true,
+	"X-Databricks-Azure-SP-Management-Token": true,
+	"X-Databricks-GCP-SA-Access-Token":       true,
+}
+
 func (r RoundTripStringer) writeHeaders(sb *strings.Builder, prefix string, headers http.Header) {
 	headerKeys := make([]string, 0, len(headers))
 	for k := range headers {
@@ -30,7 +36,7 @@ func (r RoundTripStringer) writeHeaders(sb *strings.Builder, prefix string, head
 			sb.WriteString("\n")
 		}
 		v := headers[k]
-		if k == "Authorization" && !r.DebugAuthorizationHeader {
+		if _, ok := authorizationHeaders[k]; ok && !r.DebugAuthorizationHeader {
 			v = []string{"REDACTED"}
 		}
 		trunc := onlyNBytes(strings.Join(v, ""), r.DebugTruncateBytes)

--- a/logger/httplog/round_trip_stringer_test.go
+++ b/logger/httplog/round_trip_stringer_test.go
@@ -96,8 +96,10 @@ func TestHideAuthorizationHeaderWhenConfigured(t *testing.T) {
 				Method: "GET",
 				URL:    &url.URL{Path: "/"},
 				Header: http.Header{
-					"Foo":           []string{"bar"},
-					"Authorization": []string{"baz"},
+					"Foo":                                    []string{"bar"},
+					"Authorization":                          []string{"baz"},
+					"X-Databricks-Azure-SP-Management-Token": []string{"open sesame"},
+					"X-Databricks-GCP-SA-Access-Token":       []string{"alohamora"},
 				},
 			},
 			Status: "200 OK",
@@ -113,6 +115,8 @@ func TestHideAuthorizationHeaderWhenConfigured(t *testing.T) {
 > * Host: 
 > * Authorization: REDACTED
 > * Foo: bar
+> * X-Databricks-Azure-SP-Management-Token: REDACTED
+> * X-Databricks-GCP-SA-Access-Token: REDACTED
 > request-hello
 < HTTP/1.1 200 OK
 < response-hello`, res)


### PR DESCRIPTION
## Changes
Besides the `Authorization` token, there are other tokens included by the SDK in requests in Azure & GCP with headers `X-Databricks-Azure-SP-Management-Token` and `X-Databricks-GCP-SA-Access-Token`. These need to be redacted as well unless DebugAuthorizationHeaders is set.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

