### PR TITLE
Add retries for "worker env WorkerEnvId(workerenv-XXXXX) not found"

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -25,8 +25,7 @@
   "toolchain": {
     "required": ["go"],
     "post_generate": [
-      "go run github.com/vektra/mockery/v2@b9df18e0f7b94f0bc11af3f379c8a9aea1e1e8da",
-      "go test -short ./..."
+      "go run github.com/vektra/mockery/v2@b9df18e0f7b94f0bc11af3f379c8a9aea1e1e8da"
     ]
   }
 }

--- a/.codegen/error_overrides.go.tmpl
+++ b/.codegen/error_overrides.go.tmpl
@@ -19,3 +19,9 @@ var allOverrides = []errorOverride{
     },
 {{- end }}
 }
+
+var allTransientErrors = []*regexp.Regexp{
+    {{ range .TransientErrorRegexes -}}
+    regexp.MustCompile(`{{.}}`),
+    {{ end }}
+}

--- a/apierr/error_overrides.go
+++ b/apierr/error_overrides.go
@@ -25,3 +25,12 @@ var allOverrides = []errorOverride{
 		customError:       ErrResourceDoesNotExist,
 	},
 }
+
+var allTransientErrors = []*regexp.Regexp{
+	regexp.MustCompile(`com\.databricks\.backend\.manager\.util\.UnknownWorkerEnvironmentException`),
+	regexp.MustCompile(`does not have any associated worker environments`),
+	regexp.MustCompile(`There is no worker environment with id`),
+	regexp.MustCompile(`Unknown worker environment`),
+	regexp.MustCompile(`ClusterNotReadyException`),
+	regexp.MustCompile(`worker env .* not found`),
+}

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -16,16 +16,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/logger/httplog"
 )
 
-var (
-	transientErrorStringMatches = []string{
-		"com.databricks.backend.manager.util.UnknownWorkerEnvironmentException",
-		"does not have any associated worker environments",
-		"There is no worker environment with id",
-		"Unknown worker environment",
-		"ClusterNotReadyException",
-	}
-)
-
 const (
 	errorInfoType string = "type.googleapis.com/google.rpc.ErrorInfo"
 )
@@ -112,9 +102,9 @@ func (apiError *APIError) IsRetriable(ctx context.Context) bool {
 		return true
 	}
 	// Handle transient errors for retries
-	for _, substring := range transientErrorStringMatches {
-		if strings.Contains(apiError.Message, substring) {
-			logger.Debugf(ctx, "Attempting retry because of %#v", substring)
+	for _, regex := range allTransientErrors {
+		if regex.Match([]byte(apiError.Message)) {
+			logger.Debugf(ctx, "Attempting retry because of %s", regex.String())
 			return true
 		}
 	}

--- a/apierr/errors_test.go
+++ b/apierr/errors_test.go
@@ -48,3 +48,11 @@ func TestGetAPIErrorAppliesOverrides(t *testing.T) {
 	err := GetAPIError(ctx, resp)
 	assert.ErrorIs(t, err, ErrResourceDoesNotExist)
 }
+
+func TestApiErrorTransientRegexMatches(t *testing.T) {
+	err := APIError{
+		Message: "worker env WorkerEnvId(workerenv-XXXXX) not found",
+	}
+	ctx := context.Background()
+	assert.True(t, err.IsRetriable(ctx))
+}

--- a/openapi/code/errors.go
+++ b/openapi/code/errors.go
@@ -99,3 +99,10 @@ func (b *Batch) ErrorOverrides() []ErrorOverride {
 	}
 	return res
 }
+
+func (b *Batch) TransientErrorRegexes() (res []string) {
+	for _, r := range openapi.TransientErrorRegexes {
+		res = append(res, r.String())
+	}
+	return res
+}

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -67,3 +67,12 @@ var ErrorOverrides = []ErrorOverride{
 		OverrideErrorCode: RESOURCE_DOES_NOT_EXIST,
 	},
 }
+
+var TransientErrorRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`com\.databricks\.backend\.manager\.util\.UnknownWorkerEnvironmentException`),
+	regexp.MustCompile(`does not have any associated worker environments`),
+	regexp.MustCompile(`There is no worker environment with id`),
+	regexp.MustCompile(`Unknown worker environment`),
+	regexp.MustCompile(`ClusterNotReadyException`),
+	regexp.MustCompile(`worker env .* not found`),
+}

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -329,7 +329,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 	// Container for the group identifier. Workspace local versus account.


### PR DESCRIPTION
## Changes
Due to the eventually consistent nature of worker environment creation as a part of workspace setup, certain API requests can fail when made right after workspace creation. We have some exception handling for these in the SDKs, but a new case has appeared: "worker env WorkerEnvId(workerenv-XXXXX) not found" (see https://github.com/databricks/terraform-provider-databricks/issues/3452).

This PR addresses this issue. Furthermore, it moves the transient error messages into autogeneration so that there is a single source of truth that applies to all SDKs.

One other small change: I removed running unit tests from the autogeneration flow. It removes a small amount of convenience (users need to run `make test` after regenerating the SDK), but it speeds up the devloop when iterating on code generation, and it allows the release flow to continue to make a PR before failing. This PR can be modified as needed to fix any test failures or compilation failures, as per usual.

## Tests
Added a unit test to cover this.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

