### PR TITLE
Ignore flaky integration tests

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -6,6 +6,3 @@ ignored_tests:
     - package: github.com/databricks/databricks-sdk-go/internal
       test_name: TestAccGroups
       comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
-    - package: github.com/databricks/databricks-sdk-go/internal
-      test_name: TestMwsAccAccountClient_GetWorkspaceClient_NoTranspile
-      comment: test comment

--- a/test-config.yaml
+++ b/test-config.yaml
@@ -1,0 +1,11 @@
+ignored_tests:
+  go:
+    - package: github.com/databricks/databricks-sdk-go/internal
+      test_name: TestAccWorkspaceUsers
+      comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/databricks-sdk-go/internal
+      test_name: TestAccGroups
+      comment: Failures due to read-after-write inconsistency. Tracked in https://databricks.atlassian.net/browse/ES-1100061
+    - package: github.com/databricks/databricks-sdk-go/internal
+      test_name: TestMwsAccAccountClient_GetWorkspaceClient_NoTranspile
+      comment: test comment


### PR DESCRIPTION
## Changes
There are a couple of flaky integration tests. This PR adds those to a configuration here so that our integration test runner doesn't fail when these specific tests fail.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

