### PR TITLE
Add ToLibraryList() for ClusterStatusResponse

### DIFF
--- a/service/compute/library_utilities.go
+++ b/service/compute/library_utilities.go
@@ -60,6 +60,16 @@ func (cls ClusterLibraryStatuses) ToLibraryList() InstallLibraries {
 	return cll
 }
 
+// ToLibraryList convert to envity for convenient comparison
+func (cls ClusterStatusResponse) ToLibraryList() InstallLibraries {
+	cll := InstallLibraries{ClusterId: cls.ClusterId}
+	for _, lib := range cls.LibraryStatuses {
+		cll.Libraries = append(cll.Libraries, *lib.Library)
+	}
+	cll.Sort()
+	return cll
+}
+
 func (w *Wait) IsNotInScope(lib *Library) bool {
 	// if we don't know concrete libraries
 	if len(w.Libraries) == 0 {


### PR DESCRIPTION
## Changes
There are a few issues with the response types for libraries APIs today. Recently, a breaking change was made in the return type of the ClusterStatuses() API, changing from ClusterLibraryStatus to ClusterStatusResponse. To unblock the release, I've implemented ToLibraryList() on this new type.

As a follow-up, I will unify the ClusterLibraryStatuses and ClusterStatusResponse structs into a single type and clean up any duplication that is introduced by this PR.

## Tests
Using `replace` in the Terraform provider's `go.mod`, I made sure that the TF provider's code still compiles after renaming `ClusterLibraryStatus` to `ClusterStatusResponse`.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

