### PR TITLE
Log cancelled and failed requests

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -224,6 +224,7 @@ func parseUnknownError(resp *http.Response, requestBody, responseBody []byte, er
 
 func MakeUnexpectedError(resp *http.Response, err error, requestBody, responseBody []byte) error {
 	rts := httplog.RoundTripStringer{
+		Request:                  resp.Request,
 		Response:                 resp,
 		Err:                      err,
 		RequestBody:              requestBody,

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -223,8 +223,12 @@ func parseUnknownError(resp *http.Response, requestBody, responseBody []byte, er
 }
 
 func MakeUnexpectedError(resp *http.Response, err error, requestBody, responseBody []byte) error {
+	var req *http.Request
+	if resp != nil {
+		req = resp.Request
+	}
 	rts := httplog.RoundTripStringer{
-		Request:                  resp.Request,
+		Request:                  req,
 		Response:                 resp,
 		Err:                      err,
 		RequestBody:              requestBody,

--- a/retries/retries.go
+++ b/retries/retries.go
@@ -210,6 +210,7 @@ func (r Retrier[T]) Run(ctx context.Context, fn func(context.Context) (*T, error
 			return entity, nil
 		}
 		if !r.config.ShouldRetry(err) {
+			logger.Debugf(ctx, "non-retriable error: %s", err)
 			return nil, err
 		}
 		lastErr = err


### PR DESCRIPTION
## Changes
Currently, we do not log requests that failed to complete or that failed when the SDK started processing the response. This means that requests that timeout due to a client-side timeout or canceled context are not logged, meaning that there is no visibility in the log of these kinds of requests.

This PR changes the request processing and error handling to ensure that all requests are logged, even those that are cancelled or fail due to other errors. The general approach is to process as much of the response as possible until encountering an error, log what we've retrieved, and then do any post-processing.

Some changes are needed in the roundtrip stringer to handle the case of a nil response.

## Tests
Unit tests verify that canceled requests or nil responses are logged.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

