### PR TITLE
Ignore DataPlane Services during generation

### DIFF
--- a/.codegen/accounts.go.tmpl
+++ b/.codegen/accounts.go.tmpl
@@ -12,7 +12,7 @@ import (
 type AccountClient struct {
 	Config *config.Config
 
-	{{range .Services}}{{if and .IsAccounts (not .HasParent)}}
+	{{range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}
 	{{.Comment "    // " 80}}
 	{{(.TrimPrefix "account").PascalName}} {{.Package.Name}}.{{.Name}}Interface
     {{end}}{{end}}
@@ -44,7 +44,7 @@ func NewAccountClient(c ...*Config) (*AccountClient, error) {
 	}
 	return &AccountClient{
 		Config: cfg,
-		{{range .Services}}{{if and .IsAccounts (not .HasParent)}}
+		{{range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}
 		{{(.TrimPrefix "account").PascalName}}: {{.Package.Name}}.New{{.Name}}(apiClient),{{end}}{{end}}
 	}, nil
 }

--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -1,6 +1,6 @@
 // Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
 
-// {{if .Description}}{{.Description}}{{else}}These APIs allow you to manage {{range .Services}}{{.TitleName}}, {{end}}etc.{{end}}
+// {{if .Description}}{{.Description}}{{else}}These APIs allow you to manage {{range .Services}}{{if (not .IsDataPlane)}}{{.TitleName}}, {{end}}{{end}}etc.{{end}}
 package {{.Name}}
 
 import (
@@ -22,6 +22,7 @@ import (
 		"Workspace"
 }}
 {{range .Services}}
+{{if not .IsDataPlane}}
 
 type {{.PascalName}}Interface interface {
 	{{if (in $extendedInterface .PascalName) }}
@@ -411,7 +412,7 @@ func (a *{{.Service.Name}}API) {{.Shortcut.PascalName}}AndWait(ctx context.Conte
 }
 {{end}}
 {{end -}}
-
+{{end}}
 {{- end}}
 {{- define "field-path" -}}
 	{{- range .}}.{{.PascalName}}{{end}}

--- a/.codegen/impl.go.tmpl
+++ b/.codegen/impl.go.tmpl
@@ -13,7 +13,7 @@ import (
 	{{range .ImportedPackages}}
 	"github.com/databricks/databricks-sdk-go/service/{{.}}"{{end}}
 )
-{{range .Services}}
+{{range .Services}} {{if not .IsDataPlane}}
 // unexported type that holds implementations of just {{.Name}} API methods
 type {{.CamelName}}Impl struct {
 	client *client.DatabricksClient
@@ -28,6 +28,7 @@ func (a *{{.Service.CamelName}}Impl) {{.PascalName}}(ctx context.Context{{if .Re
 	return {{ template "response" . }}
 }
 {{end -}}
+{{end}}
 {{end}}
 
 {{- define "path" -}}

--- a/.codegen/interface.go.tmpl
+++ b/.codegen/interface.go.tmpl
@@ -8,7 +8,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/retries"
 )
 
-{{range .Services}}
+{{range .Services}} {{if not .IsDataPlane}}
 {{.Comment "// " 80}}
 type {{.PascalName}}Service interface {
 	{{range .Methods}}
@@ -21,4 +21,5 @@ type {{.PascalName}}Service interface {
 	{{end}}
 }
 
+{{end}}
 {{end}}

--- a/.codegen/mock_account_client.go.tmpl
+++ b/.codegen/mock_account_client.go.tmpl
@@ -22,12 +22,12 @@ func NewMockAccountClient(t interface {
 	cli := &MockAccountClient {
 		AccountClient: &databricks.AccountClient{
 			Config: nil,
-			{{range .Services}}{{if and .IsAccounts (not .HasParent)}}
+			{{range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}
 			{{(.TrimPrefix "account").PascalName}}: {{ template "mock-interface-constructor" . }}(t),
 			{{- end}}{{end}}
 		},
 	}
-	{{range .ServicesSortedByParent}} {{if .IsAccounts}}
+	{{range .ServicesSortedByParent}} {{if and .IsAccounts (not .IsDataPlane)}}
 	{{if  .HasSubservices}}
 	mock{{.PascalName}}API := cli.GetMock{{.PascalName}}API()
 	{{end}}
@@ -40,7 +40,7 @@ func NewMockAccountClient(t interface {
 	return cli
 }
 
-{{range .Services}}{{if and (.IsAccounts) (.HasParent)}}
+{{range .Services}}{{if and (.IsAccounts) (.HasParent) (not .IsDataPlane)}}
 func(m *MockAccountClient) GetMock{{.PascalName}}API() *{{ template "mock-interface-name" . }} {
 	api, ok := m.GetMock{{.ParentService.PascalName}}API().{{.PascalName}}().(*{{ template "mock-interface-name" . }})
 	if !ok {
@@ -50,7 +50,7 @@ func(m *MockAccountClient) GetMock{{.PascalName}}API() *{{ template "mock-interf
 }
 {{end}}{{end}}
 
-{{range .Services}}{{if and .IsAccounts (not .HasParent)}}
+{{range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}
 func(m *MockAccountClient) GetMock{{.Name}}API() *{{ template "mock-interface-name" . }} {
 	api, ok := m.AccountClient.{{(.TrimPrefix "account").PascalName}}.(*{{ template "mock-interface-name" . }})
 	if !ok {

--- a/.codegen/mock_workspace_client.go.tmpl
+++ b/.codegen/mock_workspace_client.go.tmpl
@@ -22,12 +22,12 @@ func NewMockWorkspaceClient(t interface {
 	cli := &MockWorkspaceClient{
 		WorkspaceClient: &databricks.WorkspaceClient{
 			Config: nil,
-			{{range .Services}}{{if and (not .IsAccounts) (not .HasParent)}}
+			{{range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}
 			{{.Name}}: {{ template "mock-interface-constructor" . }}(t),
 			{{- end}}{{end}}
 		},
 	}
-	{{range .ServicesSortedByParent}} {{if not .IsAccounts}}
+	{{range .ServicesSortedByParent}} {{if and (not .IsAccounts) (not .IsDataPlane)}}
 	{{if  .HasSubservices}}
 	mock{{.CamelName}}API := cli.GetMock{{.PascalName}}API()
 	{{end}}
@@ -40,7 +40,7 @@ func NewMockWorkspaceClient(t interface {
 	return cli
 }
 
-{{range .Services}}{{if and (not .IsAccounts) (.HasParent)}}
+{{range .Services}}{{if and (not .IsAccounts) (.HasParent) (not .IsDataPlane)}}
 func(m *MockWorkspaceClient) GetMock{{.PascalName}}API() *{{ template "mock-interface-name" . }} {
 	api, ok := m.GetMock{{.ParentService.Name}}API().{{.PascalName}}().(*{{ template "mock-interface-name" . }})
 	if !ok {
@@ -51,7 +51,7 @@ func(m *MockWorkspaceClient) GetMock{{.PascalName}}API() *{{ template "mock-inte
 
 {{end}}{{end}}
 
-{{range .Services}}{{if and (not .IsAccounts) (not .HasParent)}}
+{{range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}
 func(m *MockWorkspaceClient) GetMock{{.Name}}API() *{{ template "mock-interface-name" . }} {
 	api, ok := m.WorkspaceClient.{{.Name}}.(*{{ template "mock-interface-name" . }})
 	if !ok {

--- a/.codegen/service-pkg.go.tmpl
+++ b/.codegen/service-pkg.go.tmpl
@@ -1,6 +1,6 @@
 // Databricks SDK for Go APIs
 // 
-//{{range .Services}}{{if .Description}} - [{{.Package.Name}}.{{.PascalName}}API]: {{.Summary}}
+//{{range .Services}}{{if and .Description (not .IsDataPlane)}} - [{{.Package.Name}}.{{.PascalName}}API]: {{.Summary}}
 //
 //{{end}}{{end}}
 package service
@@ -15,6 +15,6 @@ import (
 // https://pkg.go.dev/github.com/databricks/databricks-sdk-go/service
 // See: https://pkg.go.dev/golang.org/x/tools/internal/imports#ImportPathToAssumedName
 var (
-{{range .Services}}_ *{{.Package.Name}}.{{.PascalName}}API = nil
+{{range .Services}}{{if (not .IsDataPlane)}} _ *{{.Package.Name}}.{{.PascalName}}API = nil{{end}}
 {{end}}
 )

--- a/.codegen/workspaces.go.tmpl
+++ b/.codegen/workspaces.go.tmpl
@@ -14,7 +14,7 @@ type WorkspaceClient struct {
 	Config *config.Config
 	apiClient *httpclient.ApiClient
 
-	{{range .Services}}{{if and (not .IsAccounts) (not .HasParent)}}
+	{{range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}
 	{{.Comment "    // " 80}}
 	{{.Name}} {{.Package.Name}}.{{.Name}}Interface
 	{{end}}{{end}}
@@ -64,7 +64,7 @@ func NewWorkspaceClient(c ...*Config) (*WorkspaceClient, error) {
 	return &WorkspaceClient{
 		Config: cfg,
 		apiClient: apiClient,
-		{{range .Services}}{{if and (not .IsAccounts) (not .HasParent)}}
+		{{range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}
 		{{.Name}}: {{.Package.Name}}.New{{.Name}}(databricksClient),
 		{{- end}}{{end}}
 	}, nil

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -372,6 +372,16 @@ func (pkg *Package) Load(ctx context.Context, spec *openapi.Specification, tag o
 		svc.ParentService = parentSvc
 	}
 
+	// Link ControlPlane and DataPlane services
+	if tag.ControlPlaneService != "" {
+		controlPlaneTag, err := spec.GetTagByServiceName(tag.ControlPlaneService)
+		if err != nil {
+			return err
+		}
+		controlPlaneService := pkg.getService(controlPlaneTag)
+		svc.ControlPlaneService = controlPlaneService
+	}
+
 	for prefix, path := range spec.Paths {
 		for verb, op := range path.Verbs() {
 			if op.OperationId == "Files.getStatusHead" {

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -30,6 +30,7 @@ type Service struct {
 	subservices         map[string]*Service
 	ByPathParamsMethods []*Shortcut
 	ParentService       *Service
+	ControlPlaneService *Service
 	tag                 *openapi.Tag
 }
 
@@ -41,6 +42,12 @@ func (svc *Service) FullName() string {
 // Returns whether the service has a parent service
 func (svc *Service) HasParent() bool {
 	return svc.tag.ParentService != ""
+}
+
+// Returns whether the service is a DataPlane service
+// This is determined by the service having a matching control plane service
+func (svc *Service) IsDataPlane() bool {
+	return svc.tag.ControlPlaneService != ""
 }
 
 // Returns the list of subservices

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -95,12 +95,13 @@ func (r *PathStyle) UnmarshalJSON(data []byte) error {
 
 type Tag struct {
 	Node
-	Package       string    `json:"x-databricks-package"`
-	PathStyle     PathStyle `json:"x-databricks-path-style"`
-	Service       string    `json:"x-databricks-service"`
-	ParentService string    `json:"x-databricks-parent-service"`
-	IsAccounts    bool      `json:"x-databricks-is-accounts"`
-	Name          string    `json:"name"`
+	Package             string    `json:"x-databricks-package"`
+	PathStyle           PathStyle `json:"x-databricks-path-style"`
+	Service             string    `json:"x-databricks-service"`
+	ParentService       string    `json:"x-databricks-parent-service"`
+	ControlPlaneService string    `json:"x-databricks-controlplane"`
+	IsAccounts          bool      `json:"x-databricks-is-accounts"`
+	Name                string    `json:"name"`
 }
 
 type Path struct {


### PR DESCRIPTION
## Changes
Ignore DataPlane Services during generation until proper support is implemented


## Tests
Generated SDK using local universe (which contains DataPlane services)

- [X] `make test` passing
- [X] `make fmt` applied
- [ ] relevant integration tests applied

