### PR TITLE
[discuss] Don't generate shortcuts for list functions

### DIFF
--- a/openapi/code/method.go
+++ b/openapi/code/method.go
@@ -128,6 +128,11 @@ func (m *Method) allowShortcut() bool {
 	if m.shortcut {
 		return true
 	}
+	// We do not generate proper pagination (e.g. iterators) for shortcuts,
+	// so don't emit shortcuts if we have pagination.
+	if m.pagination != nil {
+		return false
+	}
 	if m.PathStyle == openapi.PathStyleRpc {
 		return true
 	}


### PR DESCRIPTION
## Changes

The `ListByZZZ` functions don't use the same pagination as the main functions.

By definition, the shortcut functions are generated only if there are required request parameters. Therefore, they should either return the same paginator, or not exist at all.

## Tests

n/a