### PR TITLE
Fallback to account-level auth if possible when using CLI auth

### DIFF
--- a/.codegen/accounts.go.tmpl
+++ b/.codegen/accounts.go.tmpl
@@ -35,7 +35,7 @@ func NewAccountClient(c ...*Config) (*AccountClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.AccountID == "" || !cfg.IsAccountClient() {
+	if !cfg.IsAccountClient() {
 		return nil, ErrNotAccountClient
 	}
 	apiClient, err := client.New(cfg)

--- a/account_client.go
+++ b/account_client.go
@@ -282,7 +282,7 @@ func NewAccountClient(c ...*Config) (*AccountClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.AccountID == "" || !cfg.IsAccountClient() {
+	if !cfg.IsAccountClient() {
 		return nil, ErrNotAccountClient
 	}
 	apiClient, err := client.New(cfg)

--- a/common/environment/environments.go
+++ b/common/environment/environments.go
@@ -45,6 +45,10 @@ func (de DatabricksEnvironment) AzureActiveDirectoryEndpoint() string {
 	return de.AzureEnvironment.ActiveDirectoryEndpoint
 }
 
+func (de DatabricksEnvironment) AccountsHost() string {
+	return "https://accounts" + de.DnsZone
+}
+
 // we default to AWS Prod environment since this case will be a hit for PVC
 func DefaultEnvironment() DatabricksEnvironment {
 	return DatabricksEnvironment{

--- a/config/auth_m2m.go
+++ b/config/auth_m2m.go
@@ -44,7 +44,7 @@ func (c M2mCredentials) Configure(ctx context.Context, cfg *Config) (credentials
 
 func oidcEndpoints(ctx context.Context, cfg *Config) (*oauthAuthorizationServer, error) {
 	prefix := cfg.Host
-	if cfg.IsAccountClient() && cfg.AccountID != "" {
+	if cfg.IsAccountClient() {
 		// TODO: technically, we could use the same config profile for both workspace
 		// and account, but we have to add logic for determining accounts host from
 		// workspace host.

--- a/config/config.go
+++ b/config/config.go
@@ -248,18 +248,17 @@ func (c *Config) IsAws() bool {
 
 // IsAccountClient returns true if client is configured for Accounts API
 func (c *Config) IsAccountClient() bool {
-	if c.AccountID != "" && c.isTesting {
+	if c.AccountID == "" {
+		return false
+	}
+	if c.isTesting {
 		return true
 	}
-
-	accountsPrefixes := []string{
-		"https://accounts.",
-		"https://accounts-dod.",
+	if c.Host == c.Environment().AccountsHost() {
+		return true
 	}
-	for _, prefix := range accountsPrefixes {
-		if strings.HasPrefix(c.Host, prefix) {
-			return true
-		}
+	if strings.HasPrefix(c.Host, "https://accounts-dod.") {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Changes
Within Databricks, it is possible to authenticate to a workspace using an account-level OAuth token. However, in the CLI today, OAuth tokens are stored on per-oauth-endpoint basis: one token is stored per account and one per workspace. There is currently no way to identify the account for a given workspace via the REST API.

This change allows the SDK to attempt to load an OAuth token at both the account and workspace level if the account ID is configured in `DatabricksConfig` when trying to login to a workspace. The initial request remains the same (try to get the OAuth token for the workspace). If this fails, however, and the account ID is configured, the SDK then makes a second request to get the OAuth token for the account. If this exists, this token can be used to interact with the workspace.

This is useful for tools like Terraform. When users authenticate via U2M auth and then apply a Terraform template containing `databricks_mws_workspaces` resources, the apply step fails because the CLI doesn't have an OAuth token stored for the newly minted workspace. However, after this change, it will fallback to the account-level token and succeed.

## Tests
- [x] Unit tests to verify that the SDK falls back to the account-scoped token
- [x] Manual test: removed the workspace-level token for a workspace from ~/.databricks/token-cache.json, then tried to authenticate to that workspace while also specifying its account ID in the config. It succeeded.


