### PR TITLE
Add `serverless_compute_id` field to the config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ type Config struct {
 
 	ClusterID           string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
 	WarehouseID         string `name:"warehouse_id" env:"DATABRICKS_WAREHOUSE_ID"`
-    ServerlessComputeId string `name:"serverless_compute_id" env:"DATABRICKS_SERVERLESS_COMPUTE_ID"`
+	ServerlessComputeId string `name:"serverless_compute_id" env:"DATABRICKS_SERVERLESS_COMPUTE_ID"`
 
 	// URL of the metadata service that provides authentication credentials.
 	MetadataServiceURL string `name:"metadata_service_url" env:"DATABRICKS_METADATA_SERVICE_URL" auth:"metadata-service,sensitive"`

--- a/config/config.go
+++ b/config/config.go
@@ -45,8 +45,9 @@ type Config struct {
 	// Databricks host (either of workspace endpoint or Accounts API endpoint)
 	Host string `name:"host" env:"DATABRICKS_HOST"`
 
-	ClusterID   string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
-	WarehouseID string `name:"warehouse_id" env:"DATABRICKS_WAREHOUSE_ID"`
+	ClusterID           string `name:"cluster_id" env:"DATABRICKS_CLUSTER_ID"`
+	WarehouseID         string `name:"warehouse_id" env:"DATABRICKS_WAREHOUSE_ID"`
+    ServerlessComputeId string `name:"serverless_compute_id" env:"DATABRICKS_SERVERLESS_COMPUTE_ID"`
 
 	// URL of the metadata service that provides authentication credentials.
 	MetadataServiceURL string `name:"metadata_service_url" env:"DATABRICKS_METADATA_SERVICE_URL" auth:"metadata-service,sensitive"`


### PR DESCRIPTION
## Changes
Adding `serverless_compute_id` field to the config following [the same change](https://github.com/databricks/databricks-sdk-py/pull/685) in databricks-sdk-py

## Tests

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

