### PR TITLE
Noop minor refactoring of a `apierr/error_override_test.go`

### DIFF
--- a/apierr/error_override_test.go
+++ b/apierr/error_override_test.go
@@ -9,93 +9,91 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type applyOverridesTestCase struct {
-	name          string
-	initialError  *APIError
-	path          string
-	method        string
-	expectedError error
-}
-
-func (a applyOverridesTestCase) testCase(t *testing.T) {
-	resp := &http.Response{
-		Request: &http.Request{
-			URL: &url.URL{
-				Path: a.path,
-			},
-			Method: a.method,
-		},
-		StatusCode: a.initialError.StatusCode,
-	}
-	applyOverrides(context.Background(), a.initialError, resp)
-	assert.ErrorIs(t, a.initialError, a.expectedError)
-}
-
-var testCases = []applyOverridesTestCase{
-	{
-		initialError: &APIError{
-			ErrorCode:  "INVALID_PARAMETER_VALUE",
-			StatusCode: 400,
-			Message:    "Cluster abc does not exist",
-		},
-		path:          "/api/2.0/clusters/get",
-		method:        "GET",
-		expectedError: ErrResourceDoesNotExist,
-	},
-	{
-		initialError: &APIError{
-			ErrorCode:  "INVALID_PARAMETER_VALUE",
-			StatusCode: 400,
-			Message:    "Job abc does not exist",
-		},
-		path:          "/api/2.0/jobs/get",
-		method:        "GET",
-		expectedError: ErrResourceDoesNotExist,
-	},
-	{
-		initialError: &APIError{
-			ErrorCode:  "INVALID_PARAMETER_VALUE",
-			StatusCode: 400,
-			Message:    "Job abc does not exist",
-		},
-		path:          "/api/2.1/jobs/get",
-		method:        "GET",
-		expectedError: ErrResourceDoesNotExist,
-	},
-	{
-		initialError: &APIError{
-			ErrorCode:  "INVALID_PARAMETER_VALUE",
-			StatusCode: 400,
-			Message:    "Notebook abc does not exist",
-		},
-		path:          "/api/2.0/notebooks/get",
-		method:        "GET",
-		expectedError: ErrBadRequest,
-	},
-	{
-		initialError: &APIError{
-			ErrorCode:  "INVALID_PARAMETER_VALUE",
-			StatusCode: 400,
-			Message:    "Invalid job attribute",
-		},
-		path:          "/api/2.0/jobs/get",
-		method:        "GET",
-		expectedError: ErrBadRequest,
-	},
-	{
-		initialError: &APIError{
-			ErrorCode:  "INVALID_PARAMETER_VALUE",
-			StatusCode: 404,
-			Message:    "Job abc does not exist",
-		},
-		path:          "/api/2.0/jobs/get",
-		method:        "GET",
-		expectedError: ErrBadRequest,
-	},
-}
-
 func TestApplyOverrides(t *testing.T) {
+	testCases := []struct {
+		name          string
+		initialError  *APIError
+		path          string
+		method        string
+		expectedError error
+	}{
+		{
+			initialError: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				StatusCode: 400,
+				Message:    "Cluster abc does not exist",
+			},
+			path:          "/api/2.0/clusters/get",
+			method:        "GET",
+			expectedError: ErrResourceDoesNotExist,
+		},
+		{
+			initialError: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				StatusCode: 400,
+				Message:    "Job abc does not exist",
+			},
+			path:          "/api/2.0/jobs/get",
+			method:        "GET",
+			expectedError: ErrResourceDoesNotExist,
+		},
+		{
+			initialError: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				StatusCode: 400,
+				Message:    "Job abc does not exist",
+			},
+			path:          "/api/2.1/jobs/get",
+			method:        "GET",
+			expectedError: ErrResourceDoesNotExist,
+		},
+		{
+			initialError: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				StatusCode: 400,
+				Message:    "Notebook abc does not exist",
+			},
+			path:          "/api/2.0/notebooks/get",
+			method:        "GET",
+			expectedError: ErrBadRequest,
+		},
+		{
+			initialError: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				StatusCode: 400,
+				Message:    "Invalid job attribute",
+			},
+			path:          "/api/2.0/jobs/get",
+			method:        "GET",
+			expectedError: ErrBadRequest,
+		},
+		{
+			initialError: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				StatusCode: 404,
+				Message:    "Job abc does not exist",
+			},
+			path:          "/api/2.0/jobs/get",
+			method:        "GET",
+			expectedError: ErrBadRequest,
+		},
+	}
+
 	for _, tc := range testCases {
-		t.Run(tc.name, tc.testCase)
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				Request: &http.Request{
+					URL: &url.URL{
+						Path: tc.path,
+					},
+					Method: tc.method,
+				},
+				StatusCode: tc.initialError.StatusCode,
+			}
+
+			applyOverrides(context.Background(), tc.initialError, resp)
+
+			assert.ErrorIs(t, tc.initialError, tc.expectedError)
+		})
 	}
 }

--- a/apierr/error_override_test.go
+++ b/apierr/error_override_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestApplyOverrides(t *testing.T) {
 	testCases := []struct {
-		name          string
 		initialError  *APIError
 		path          string
 		method        string
@@ -80,20 +79,18 @@ func TestApplyOverrides(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			resp := &http.Response{
-				Request: &http.Request{
-					URL: &url.URL{
-						Path: tc.path,
-					},
-					Method: tc.method,
+		resp := &http.Response{
+			Request: &http.Request{
+				URL: &url.URL{
+					Path: tc.path,
 				},
-				StatusCode: tc.initialError.StatusCode,
-			}
+				Method: tc.method,
+			},
+			StatusCode: tc.initialError.StatusCode,
+		}
 
-			applyOverrides(context.Background(), tc.initialError, resp)
+		applyOverrides(context.Background(), tc.initialError, resp)
 
-			assert.ErrorIs(t, tc.initialError, tc.expectedError)
-		})
+		assert.ErrorIs(t, tc.initialError, tc.expectedError)
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -47,9 +47,15 @@ func (c *DatabricksClient) ConfiguredAccountID() string {
 }
 
 // Do sends an HTTP request against path.
-func (c *DatabricksClient) Do(ctx context.Context, method, path string,
-	headers map[string]string, request, response any,
-	visitors ...func(*http.Request) error) error {
+func (c *DatabricksClient) Do(
+	ctx context.Context,
+	method string,
+	path string,
+	headers map[string]string,
+	request any,
+	response any,
+	visitors ...func(*http.Request) error,
+) error {
 	opts := []httpclient.DoOption{}
 	for _, v := range visitors {
 		opts = append(opts, httpclient.WithRequestVisitor(v))

--- a/client/client.go
+++ b/client/client.go
@@ -47,15 +47,9 @@ func (c *DatabricksClient) ConfiguredAccountID() string {
 }
 
 // Do sends an HTTP request against path.
-func (c *DatabricksClient) Do(
-	ctx context.Context,
-	method string,
-	path string,
-	headers map[string]string,
-	request any,
-	response any,
-	visitors ...func(*http.Request) error,
-) error {
+func (c *DatabricksClient) Do(ctx context.Context, method, path string,
+	headers map[string]string, request, response any,
+	visitors ...func(*http.Request) error) error {
 	opts := []httpclient.DoOption{}
 	for _, v := range visitors {
 		opts = append(opts, httpclient.WithRequestVisitor(v))


### PR DESCRIPTION
## Changes

This PR does a minor noop refactoring of `apierr/error_override_test.go` to better match the style of idiomatic table-tests. In particular, it:

- Inlines the `applyOverridesTestCase` struct which is replaced with an anonymous struct. There's nothing wrong with that struct per se but seeing it made me think at first that it was doing more than simply defining the table cases. 
- Remove the unused `name` field (was always "") and remove the subtests rather than giving them an arbitrary name (e.g. the index of the test).

Alternatively, we could give meaningful names to the subtests and keep them. Though, what these names should be was not obvious to me. 

## Tests

The test coverage is the same as before this change. 

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

