### PR TITLE
Parse API Error messages with `int` error codes

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -20,19 +20,6 @@ const (
 	errorInfoType string = "type.googleapis.com/google.rpc.ErrorInfo"
 )
 
-// APIErrorBody maps "proper" databricks rest api errors to a struct
-type APIErrorBody struct {
-	ErrorCode string        `json:"error_code,omitempty"`
-	Message   string        `json:"message,omitempty"`
-	Details   []ErrorDetail `json:"details,omitempty"`
-	// The following two are for scim api only
-	// for RFC 7644 Section 3.7.3 https://tools.ietf.org/html/rfc7644#section-3.7.3
-	ScimDetail string `json:"detail,omitempty"`
-	ScimStatus string `json:"status,omitempty"`
-	ScimType   string `json:"scimType,omitempty"`
-	API12Error string `json:"error,omitempty"`
-}
-
 type ErrorDetail struct {
 	Type     string            `json:"@type,omitempty"`
 	Reason   string            `json:"reason,omitempty"`
@@ -170,61 +157,78 @@ func GetAPIError(ctx context.Context, resp common.ResponseWrapper) error {
 
 func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byte) *APIError {
 	if len(responseBody) == 0 {
-		return &APIError{
-			StatusCode: resp.StatusCode,
-		}
+		return &APIError{StatusCode: resp.StatusCode}
 	}
-	// try to read in nicely formatted API error response
-	var errorBody APIErrorBody
-	err := json.Unmarshal(responseBody, &errorBody)
-	if err != nil {
-		errorBody = parseUnknownError(resp, requestBody, responseBody, err)
+
+	// Anonymous struct used to unmarshal JSON Databricks API error responses.
+	var errorBody struct {
+		ErrorCode any           `json:"error_code,omitempty"` // int or string
+		Message   string        `json:"message,omitempty"`
+		Details   []ErrorDetail `json:"details,omitempty"`
+
+		API12Error string `json:"error,omitempty"`
+
+		// The following fields are for scim api only. See RFC7644 section 3.7.3
+		// https://tools.ietf.org/html/rfc7644#section-3.7.3
+		ScimDetail string `json:"detail,omitempty"`
+		ScimStatus string `json:"status,omitempty"`
+		ScimType   string `json:"scimType,omitempty"`
 	}
+	if err := json.Unmarshal(responseBody, &errorBody); err != nil {
+		return unknownAPIError(resp, requestBody, responseBody, err)
+	}
+
+	// Convert API 1.2 error (which used a different format) to the new format.
 	if errorBody.API12Error != "" {
-		// API 1.2 has different response format, let's adapt
 		errorBody.Message = errorBody.API12Error
 	}
-	// Handle SCIM error message details
+
+	// Handle SCIM error message details.
 	if errorBody.Message == "" && errorBody.ScimDetail != "" {
 		if errorBody.ScimDetail == "null" {
 			errorBody.Message = "SCIM API Internal Error"
 		} else {
 			errorBody.Message = errorBody.ScimDetail
 		}
-		// add more context from SCIM responses
+		// Add more context from SCIM responses.
 		errorBody.Message = fmt.Sprintf("%s %s", errorBody.ScimType, errorBody.Message)
 		errorBody.Message = strings.Trim(errorBody.Message, " ")
 		errorBody.ErrorCode = fmt.Sprintf("SCIM_%s", errorBody.ScimStatus)
 	}
+
 	return &APIError{
 		Message:    errorBody.Message,
-		ErrorCode:  errorBody.ErrorCode,
+		ErrorCode:  fmt.Sprintf("%v", errorBody.ErrorCode),
 		StatusCode: resp.StatusCode,
 		Details:    errorBody.Details,
 	}
 }
 
-func parseUnknownError(resp *http.Response, requestBody, responseBody []byte, err error) (errorBody APIErrorBody) {
-	// this is most likely HTML... since un-marshalling JSON failed
+func unknownAPIError(resp *http.Response, requestBody, responseBody []byte, err error) *APIError {
+	apiErr := &APIError{
+		StatusCode: resp.StatusCode,
+	}
+
+	// This is most likely HTML... since un-marshalling JSON failed
 	// Status parts first in case html message is not as expected
 	statusParts := strings.SplitN(resp.Status, " ", 2)
 	if len(statusParts) < 2 {
-		errorBody.ErrorCode = "UNKNOWN"
+		apiErr.ErrorCode = "UNKNOWN"
 	} else {
-		errorBody.ErrorCode = strings.ReplaceAll(
-			strings.ToUpper(strings.Trim(statusParts[1], " .")),
-			" ", "_")
+		apiErr.ErrorCode = strings.ReplaceAll(strings.ToUpper(strings.Trim(statusParts[1], " .")), " ", "_")
 	}
+
 	stringBody := string(responseBody)
 	messageRE := regexp.MustCompile(`<pre>(.*)</pre>`)
 	messageMatches := messageRE.FindStringSubmatch(stringBody)
 	// No messages with <pre> </pre> format found so return a APIError
 	if len(messageMatches) < 2 {
-		errorBody.Message = MakeUnexpectedError(resp, err, requestBody, responseBody).Error()
-		return
+		apiErr.Message = MakeUnexpectedError(resp, err, requestBody, responseBody).Error()
+	} else {
+		apiErr.Message = strings.Trim(messageMatches[1], " .")
 	}
-	errorBody.Message = strings.Trim(messageMatches[1], " .")
-	return
+
+	return apiErr
 }
 
 func MakeUnexpectedError(resp *http.Response, err error, requestBody, responseBody []byte) error {

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -162,11 +162,10 @@ func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byt
 
 	// Anonymous struct used to unmarshal JSON Databricks API error responses.
 	var errorBody struct {
-		ErrorCode any           `json:"error_code,omitempty"` // int or string
-		Message   string        `json:"message,omitempty"`
-		Details   []ErrorDetail `json:"details,omitempty"`
-
-		API12Error string `json:"error,omitempty"`
+		ErrorCode  any           `json:"error_code,omitempty"` // int or string
+		Message    string        `json:"message,omitempty"`
+		Details    []ErrorDetail `json:"details,omitempty"`
+		API12Error string        `json:"error,omitempty"`
 
 		// The following fields are for scim api only. See RFC7644 section 3.7.3
 		// https://tools.ietf.org/html/rfc7644#section-3.7.3
@@ -209,7 +208,7 @@ func unknownAPIError(resp *http.Response, requestBody, responseBody []byte, err 
 		StatusCode: resp.StatusCode,
 	}
 
-	// This is most likely HTML... since un-marshalling JSON failed
+	// this is most likely HTML... since un-marshalling JSON failed
 	// Status parts first in case html message is not as expected
 	statusParts := strings.SplitN(resp.Status, " ", 2)
 	if len(statusParts) < 2 {

--- a/apierr/errors_test.go
+++ b/apierr/errors_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAPIError_HandlesEmptyResponse(t *testing.T) {
+func TestGetAPIError_handlesEmptyResponse(t *testing.T) {
 	resp := common.ResponseWrapper{
 		Response: &http.Response{
 			Request: &http.Request{
@@ -32,7 +32,7 @@ func TestGetAPIError_HandlesEmptyResponse(t *testing.T) {
 	assert.Equal(t, err.(*APIError).Message, "")
 }
 
-func TestGetAPIError_AppliesOverrides(t *testing.T) {
+func TestGetAPIError_appliesOverrides(t *testing.T) {
 	resp := common.ResponseWrapper{
 		Response: &http.Response{
 			StatusCode: http.StatusBadRequest,
@@ -52,7 +52,7 @@ func TestGetAPIError_AppliesOverrides(t *testing.T) {
 	assert.ErrorIs(t, err, ErrResourceDoesNotExist)
 }
 
-func TestGetAPIError_ParseIntErrorCode(t *testing.T) {
+func TestGetAPIError_parseIntErrorCode(t *testing.T) {
 	resp := common.ResponseWrapper{
 		Response: &http.Response{
 			StatusCode: http.StatusBadRequest,
@@ -73,7 +73,7 @@ func TestGetAPIError_ParseIntErrorCode(t *testing.T) {
 	assert.Equal(t, err.(*APIError).ErrorCode, "500")
 }
 
-func TestGetAPIError_MapsPrivateLinkRedirect(t *testing.T) {
+func TestGetAPIError_mapsPrivateLinkRedirect(t *testing.T) {
 	resp := common.ResponseWrapper{
 		Response: &http.Response{
 			Request: &http.Request{
@@ -92,7 +92,7 @@ func TestGetAPIError_MapsPrivateLinkRedirect(t *testing.T) {
 	assert.Equal(t, err.(*APIError).ErrorCode, "PRIVATE_LINK_VALIDATION_ERROR")
 }
 
-func TestAPIError_TransientRegexMatches(t *testing.T) {
+func TestAPIError_transientRegexMatches(t *testing.T) {
 	err := APIError{
 		Message: "worker env WorkerEnvId(workerenv-XXXXX) not found",
 	}


### PR DESCRIPTION
## Changes

Parsing error messages from the `/api/2.0/preview/scim/v2/Me` API causes parsing errors because the API returns the HTTP status (i.e. an `int`) as error code instead of a `string`. For example:

```json
{
   "error_code": 403,
   "message": "Invalid access token."
}
```

This PR solves the problem by parsing the `error_code` field as a `string` no matter its type. 

Note that the implementation is overkill because it also converts _any_ literal to a string (e.g. `true` becomes `"true"`). We could guarantee that the behavior is limited to converting `int` to `string` by adding a custom [Unmarshaler](https://pkg.go.dev/encoding/json#Unmarshaler) but this didn't seem worth the additional code. 

This PR also:

- Refactors the code by removing the `APIErroBody` struct. The rationale is that the struct exists solely for parsing and is actually not used outside of the `parseErrorFromResponse` function. Turning it into an anonymous struct within `parseErrorFromResponse` makes the intent crystal clear.
- Slightly restructures the test cases to better match go's naming conventions and separate the "three tests parts" (init, test, assert). 

## Tests

Added a unit test to verify that (i) an int error code are parsed as string, and (ii) that this string is properly ignored. 

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

