### PR TITLE
Added more error messages for retriable errors (timeouts, etc.)

### DIFF
--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -75,4 +75,6 @@ var TransientErrorRegexes = []*regexp.Regexp{
 	regexp.MustCompile(`Unknown worker environment`),
 	regexp.MustCompile(`ClusterNotReadyException`),
 	regexp.MustCompile(`worker env .* not found`),
+	regexp.MustCompile(`Timed out after `),
+	regexp.MustCompile(`deadline exceeded`),
 }


### PR DESCRIPTION
These are necessary to handle a problem with timeouts in permissions fetching

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

