### PR TITLE
Add a credentials provider for Github Azure OIDC

### DIFF
--- a/config/auth_azure_github_oidc.go
+++ b/config/auth_azure_github_oidc.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/credentials"
+	"github.com/databricks/databricks-sdk-go/httpclient"
+	"github.com/databricks/databricks-sdk-go/logger"
+	"golang.org/x/oauth2"
+)
+
+// AzureGithubOIDCCredentials provides credentials for GitHub Actions that use
+// an Azure Active Directory Federated Identity to authenticate with Azure.
+type AzureGithubOIDCCredentials struct{}
+
+// Name implements [CredentialsStrategy.Name].
+func (c AzureGithubOIDCCredentials) Name() string {
+	return "github-oidc-azure"
+}
+
+// Configure implements [CredentialsStrategy.Configure].
+func (c AzureGithubOIDCCredentials) Configure(ctx context.Context, cfg *Config) (credentials.CredentialsProvider, error) {
+	// Sanity check that the config is configured for Azure Databricks.
+	if !cfg.IsAzure() || cfg.AzureClientID == "" || cfg.Host == "" || cfg.AzureTenantID == "" {
+		return nil, nil
+	}
+
+	idToken, err := requestIDToken(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if idToken == "" {
+		return nil, nil
+	}
+
+	ts := &azureOIDCTokenSource{
+		aadEndpoint:   fmt.Sprintf("%s%s/oauth2/token", cfg.Environment().AzureActiveDirectoryEndpoint(), cfg.AzureTenantID),
+		clientID:      cfg.AzureClientID,
+		applicationID: cfg.Environment().AzureApplicationID,
+		idToken:       idToken,
+		httpClient:    cfg.refreshClient,
+	}
+
+	return credentials.NewOAuthCredentialsProvider(refreshableVisitor(ts), ts.Token), nil
+}
+
+// requestIDToken requests an ID token from the Github Action.
+func requestIDToken(ctx context.Context, cfg *Config) (string, error) {
+	if cfg.ActionsIDTokenRequestURL == "" {
+		logger.Debugf(ctx, "Missing cfg.ActionsIDTokenRequestURL, likely not calling from a Github action")
+		return "", nil
+	}
+	if cfg.ActionsIDTokenRequestToken == "" {
+		logger.Debugf(ctx, "Missing cfg.ActionsIDTokenRequestToken, likely not calling from a Github action")
+		return "", nil
+	}
+
+	resp := struct { // anonymous struct to parse the response
+		Value string `json:"value"`
+	}{}
+	err := cfg.refreshClient.Do(ctx, "GET", fmt.Sprintf("%s&audience=api://AzureADTokenExchange", cfg.ActionsIDTokenRequestURL),
+		httpclient.WithRequestHeader("Authorization", fmt.Sprintf("Bearer %s", cfg.ActionsIDTokenRequestToken)),
+		httpclient.WithResponseUnmarshal(&resp),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to request ID token from %s: %w", cfg.ActionsIDTokenRequestURL, err)
+	}
+
+	return resp.Value, nil
+}
+
+// azureOIDCTokenSource implements [oauth2.TokenSource] to obtain Azure auth
+// tokens from an ID token.
+type azureOIDCTokenSource struct {
+	aadEndpoint   string
+	clientID      string
+	applicationID string
+	idToken       string
+
+	httpClient *httpclient.ApiClient
+}
+
+const azureOICDTimeout = 10 * time.Second
+
+func (ts *azureOIDCTokenSource) Token() (*oauth2.Token, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), azureOICDTimeout)
+	defer cancel()
+
+	resp := struct { // anonymous struct to parse the response
+		TokenType    string      `json:"token_type"`
+		AccessToken  string      `json:"access_token"`
+		RefreshToken string      `json:"refresh_token"`
+		ExpiresOn    json.Number `json:"expires_on"`
+	}{}
+	err := ts.httpClient.Do(ctx, "POST", ts.aadEndpoint,
+		httpclient.WithUrlEncodedData(map[string]string{
+			"grant_type": "client_credentials",
+			"resource":   ts.applicationID,
+			"client_id":  ts.clientID,
+			// Use the ID token instead of a client_secret.
+			"client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+			"client_assertion":      ts.idToken,
+		}),
+		httpclient.WithResponseUnmarshal(&resp),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	epochInSec, err := resp.ExpiresOn.Int64()
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: cannot parse token expiry: %w", err)
+	}
+	return &oauth2.Token{
+		TokenType:    resp.TokenType,
+		AccessToken:  resp.AccessToken,
+		RefreshToken: resp.RefreshToken,
+		Expiry:       time.Unix(epochInSec, 0),
+	}, nil
+}

--- a/config/auth_azure_github_oidc_test.go
+++ b/config/auth_azure_github_oidc_test.go
@@ -1,0 +1,287 @@
+package config
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/common/environment"
+	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
+	"github.com/google/go-cmp/cmp"
+)
+
+func errPrefix(prefix string) *string {
+	return &prefix
+}
+
+func hasPrefix(err error, prefix string) bool {
+	if err == nil {
+		return false
+	}
+	return strings.HasPrefix(err.Error(), prefix)
+}
+
+func TestAzureGithubOIDCCredentials(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		cfg           *Config
+		wantHeaders   map[string]string
+		wantErrPrefix *string
+	}{
+		{
+			desc: "not an azure config",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud: "foo-bar-cloud",
+				},
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure auth: not configured"),
+		},
+		{
+			desc: "missing azure client ID",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				Host:                       "http://host.com/test",
+				AzureTenantID:              "test-tenant-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure auth: not configured"),
+		},
+		{
+			desc: "missing host",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:              "test-client-id",
+				AzureTenantID:              "test-tenant-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure auth: not configured"),
+		},
+		{
+			desc: "missing tenant ID",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				Host:                       "http://host.com/test",
+				AzureClientID:              "test-client-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure auth: not configured"),
+		},
+		{
+			desc: "missing env ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:            "test-client-id",
+				AzureTenantID:            "test-tenant-id",
+				Host:                     "http://host.com/test",
+				ActionsIDTokenRequestURL: "http://endpoint.com/test?version=1",
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure auth: not configured"),
+		},
+		{
+			desc: "missing env ACTIONS_ID_TOKEN_REQUEST_URL",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:              "test-client-id",
+				AzureTenantID:              "test-tenant-id",
+				Host:                       "http://host.com/test",
+				ActionsIDTokenRequestToken: "token-1337",
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure auth: not configured"),
+		},
+		{
+			desc: "azure aad token exchange server error",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:              "test-client-id",
+				AzureTenantID:              "test-tenant-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+				Host:                       "http://host.com/test",
+				HTTPTransport: fixtures.MappingTransport{
+					"GET /test?version=1&audience=api://AzureADTokenExchange": {
+						Status: http.StatusInternalServerError,
+						ExpectedHeaders: map[string]string{
+							"Authorization": "Bearer token-1337",
+							"Accept":        "application/json",
+						},
+					},
+				},
+			},
+			wantErrPrefix: errPrefix("github-oidc-azure"),
+		},
+		{
+			desc: "azure auth server error",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:              "test-client-id",
+				AzureTenantID:              "test-tenant-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+				Host:                       "http://host.com/test",
+				HTTPTransport: fixtures.MappingTransport{
+					"GET /test?version=1&audience=api://AzureADTokenExchange": {
+						Status: http.StatusOK,
+						ExpectedHeaders: map[string]string{
+							"Authorization": "Bearer token-1337",
+							"Accept":        "application/json",
+						},
+						Response: `{"value": "id-token-42"}`,
+					},
+					"POST /test-tenant-id/oauth2/token": {
+						Status: http.StatusInternalServerError,
+						ExpectedHeaders: map[string]string{
+							"Accept":       "application/json",
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+					},
+				},
+			},
+			wantErrPrefix: errPrefix("inner token: http 500"),
+		},
+		{
+			desc: "invalid auth token",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:              "test-client-id",
+				AzureTenantID:              "test-tenant-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+				Host:                       "http://host.com/test",
+				HTTPTransport: fixtures.MappingTransport{
+					"GET /test?version=1&audience=api://AzureADTokenExchange": {
+						Status: http.StatusOK,
+						ExpectedHeaders: map[string]string{
+							"Authorization": "Bearer token-1337",
+							"Accept":        "application/json",
+						},
+						Response: `{"value": "id-token-42"}`,
+					},
+					"POST /test-tenant-id/oauth2/token": {
+						Status: http.StatusOK,
+						ExpectedHeaders: map[string]string{
+							"Accept":       "application/json",
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						Response: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			wantErrPrefix: errPrefix("inner token: invalid token"),
+		},
+		{
+			desc: "success",
+			cfg: &Config{
+				DatabricksEnvironment: &environment.DatabricksEnvironment{
+					Cloud:              environment.CloudAzure,
+					AzureApplicationID: "test-azure-app-id",
+					AzureEnvironment:   &environment.AzurePublicCloud,
+				},
+				AzureClientID:              "test-client-id",
+				AzureTenantID:              "test-tenant-id",
+				ActionsIDTokenRequestURL:   "http://endpoint.com/test?version=1",
+				ActionsIDTokenRequestToken: "token-1337",
+				Host:                       "http://host.com/test",
+				HTTPTransport: fixtures.MappingTransport{
+					"GET /test?version=1&audience=api://AzureADTokenExchange": {
+						Status: http.StatusOK,
+						ExpectedHeaders: map[string]string{
+							"Authorization": "Bearer token-1337",
+							"Accept":        "application/json",
+						},
+						Response: `{"value": "id-token-42"}`,
+					},
+					"POST /test-tenant-id/oauth2/token": {
+						Status: http.StatusOK,
+						ExpectedHeaders: map[string]string{
+							"Accept":       "application/json",
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						Response: map[string]string{
+							"token_type":    "access-token",
+							"access_token":  "test-auth-token",
+							"refresh_token": "refresh",
+							"expires_on":    "0",
+						},
+					},
+				},
+			},
+			wantHeaders: map[string]string{
+				"Authorization": "access-token test-auth-token",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tc.cfg.Credentials = &AzureGithubOIDCCredentials{} // only test this credential strategy
+			tc.cfg.DebugHeaders = true
+			if tc.wantHeaders == nil {
+				tc.wantHeaders = map[string]string{}
+			}
+
+			req, _ := http.NewRequest("GET", "http://localhost", nil)
+			gotErr := tc.cfg.Authenticate(req)
+			gotHeaders := map[string]string{}
+			for h := range req.Header {
+				gotHeaders[h] = req.Header.Get(h)
+			}
+
+			if tc.wantErrPrefix == nil && gotErr != nil {
+				t.Errorf("Authenticate(): got error %q, want none", gotErr)
+			}
+			if tc.wantErrPrefix != nil && !hasPrefix(gotErr, *tc.wantErrPrefix) {
+				t.Errorf("Authenticate(): got error %q, want error with prefix %q", gotErr, *tc.wantErrPrefix)
+			}
+			if diff := cmp.Diff(tc.wantHeaders, gotHeaders); diff != "" {
+				t.Errorf("Authenticate(): mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAzureGithubOIDCCredentials_Name(t *testing.T) {
+	c := AzureGithubOIDCCredentials{}
+	want := "github-oidc-azure"
+
+	if got := c.Name(); got != want {
+		t.Errorf("Name(): got %s, want %s", got, want)
+	}
+}

--- a/config/auth_default.go
+++ b/config/auth_default.go
@@ -9,24 +9,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/logger"
 )
 
-var (
-	authProviders = []CredentialsStrategy{
-		PatCredentials{},
-		BasicCredentials{},
-		M2mCredentials{},
-		DatabricksCliCredentials{},
-		MetadataServiceCredentials{},
+var authProviders = []CredentialsStrategy{
+	PatCredentials{},
+	BasicCredentials{},
+	M2mCredentials{},
+	DatabricksCliCredentials{},
+	MetadataServiceCredentials{},
 
-		// Attempt to configure auth from most specific to most generic (the Azure CLI).
-		AzureMsiCredentials{},
-		AzureClientSecretCredentials{},
-		AzureCliCredentials{},
+	// Attempt to configure auth from most specific to most generic (the Azure CLI).
+	AzureGithubOIDCCredentials{},
+	AzureMsiCredentials{},
+	AzureClientSecretCredentials{},
+	AzureCliCredentials{},
 
-		// Attempt to configure auth from most specific to most generic (Google Application Default Credentials).
-		GoogleCredentials{},
-		GoogleDefaultCredentials{},
-	}
-)
+	// Attempt to configure auth from most specific to most generic (Google Application Default Credentials).
+	GoogleCredentials{},
+	GoogleDefaultCredentials{},
+}
 
 type DefaultCredentials struct {
 	name string

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,11 @@ type Config struct {
 	AzureClientID     string `name:"azure_client_id" env:"ARM_CLIENT_ID" auth:"azure" auth_types:"azure-client-secret,azure-msi"`
 	AzureTenantID     string `name:"azure_tenant_id" env:"ARM_TENANT_ID" auth:"azure" auth_types:"azure-cli,azure-client-secret"`
 
+	// Parameters to request Azure OIDC token on behalf of Github Actions.
+	// Ref: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers
+	ActionsIDTokenRequestURL   string `name:"actions_id_token_request_url" env:"ACTIONS_ID_TOKEN_REQUEST_URL"`
+	ActionsIDTokenRequestToken string `name:"actions_id_token_request_token" env:"ACTIONS_ID_TOKEN_REQUEST_TOKEN"`
+
 	// AzureEnvironment (PUBLIC, USGOVERNMENT, CHINA) has specific set of API endpoints. Starting from v0.26.0,
 	// the environment is determined based on the workspace hostname, if it's specified.
 	AzureEnvironment string `name:"azure_environment" env:"ARM_ENVIRONMENT"`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/databricks/databricks-sdk-go
 go 1.18
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=


### PR DESCRIPTION
_Note: this PR is a copy of PR #950 which could not be merged because of some unverified commits. Please check PR #950 for the original review and comments._

## Changes

This PR adds a `CredentialsProvider` to authenticate with Azure from Github workflows. 

The code is inspired by a similar feature already implemented in the Python SDK. It works as follows:

1. Obtain an ID token from Azure leveraging the env variables `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` as [explained here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers).
2. Exchange that ID token for an auth token.

## Tests

Added a test suite which covers all the added code paths. I've also confirmed in my own Github Action that the code is properly able to authenticate. 

Note: I'm not super happy with how errors are compared (i.e. using a prefix) which is a little brittle. A better approach would be to leverage `errors.As` or `errors.Is`. However, it is difficult to do that at the moment without adding ad hoc new error types. A longer term solution would probably involve standardizing the package around a set of clearly defined error types shared by all implementations of `CredentialsProvider` in `config`. That is out of the scope of this PR though.

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

