### PR TITLE
[Internal] Trigger the `validate` workflow in the merge queue

### DIFF
--- a/.github/workflows/message.yml
+++ b/.github/workflows/message.yml
@@ -3,6 +3,8 @@ name: Validate Commit Message
 on:
   pull_request:
     types: [opened, synchronize, edited]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
       

--- a/.github/workflows/message.yml
+++ b/.github/workflows/message.yml
@@ -7,9 +7,9 @@ on:
     types: [checks_requested]
 
 jobs:
-      
   validate:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' 
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Changes

PRs in the merge queue are currently unable to be merged (and thus dequeued) because the `validate` workflow is not triggered. This PR fixes the problem by adding the missing triggering event.

<img width="790" alt="image" src="https://github.com/user-attachments/assets/925601dc-4208-4b6f-a244-54ec2350b3e4">


See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

