### PR TITLE
[Internal] Configure Dependabot for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "[Internal] "
+    open-pull-requests-limit: 0 # disable version updates


### PR DESCRIPTION
## Changes

This PR update the `dependabot.yml` file to only perform security update. 

Non-security update PRs can be disabled by setting `open-pull-requests-limit` to zero ([ref](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file)). This is a little counter-intuitive. The reason this works seems to be that Dependabot uses another internal limit for security updates. 

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

