### PR TITLE
[Internal] Use HTTP status text as message if the error response body is empty

### DIFF
--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -38,7 +38,7 @@ type APIError struct {
 	unwrap error
 }
 
-// Error returns error message string instead of
+// Error returns the error message string.
 func (apiError *APIError) Error() string {
 	return apiError.Message
 }
@@ -157,7 +157,10 @@ func GetAPIError(ctx context.Context, resp common.ResponseWrapper) error {
 
 func parseErrorFromResponse(resp *http.Response, requestBody, responseBody []byte) *APIError {
 	if len(responseBody) == 0 {
-		return &APIError{StatusCode: resp.StatusCode}
+		return &APIError{
+			Message:    http.StatusText(resp.StatusCode),
+			StatusCode: resp.StatusCode,
+		}
 	}
 
 	// Anonymous struct used to unmarshal JSON Databricks API error responses.

--- a/apierr/errors_test.go
+++ b/apierr/errors_test.go
@@ -29,7 +29,7 @@ func TestGetAPIError_handlesEmptyResponse(t *testing.T) {
 
 	err := GetAPIError(context.Background(), resp)
 
-	assert.Equal(t, err.(*APIError).Message, "")
+	assert.Equal(t, err.(*APIError).Message, "Conflict")
 }
 
 func TestGetAPIError_appliesOverrides(t *testing.T) {


### PR DESCRIPTION
## Changes

Errors with an empty response body now show up as empty strings when serialized to a string.

## Tests

Modified existing unit test.