### PR TITLE
[Internal] Pin jobs APIs to 2.1 in SDKs

### DIFF
--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -138,3 +138,14 @@ func TestDataPlane(t *testing.T) {
 	require.Equal(t, "get", dataPlane.ConfigMethod)
 	require.Equal(t, "dataplaneInfo", dataPlane.Fields[0])
 }
+
+func TestJobs2Dot2Compatability(t *testing.T) {
+	ctx := context.Background()
+	batch, err := NewFromFile(ctx, "../testdata/spec_jobs_2.2.json")
+	require.NoError(t, err)
+	jobs := batch.packages["jobs"]
+	require.NotNil(t, jobs)
+	require.NotNil(t, jobs.services["Jobs"])
+	require.Equal(t, "/api/2.1/jobs/get", jobs.services["Jobs"].methods["get"].Path)
+	require.Equal(t, "/api/2.2/jobs/runs/submit", jobs.services["Jobs"].methods["submitRun"].Path)
+}

--- a/openapi/testdata/spec_jobs_2.2.json
+++ b/openapi/testdata/spec_jobs_2.2.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "tags": [
+    {
+      "name": "Jobs",
+      "x-databricks-package": "jobs",
+      "x-databricks-service": "Jobs"
+    }
+  ],
+  "paths": {
+    "/api/2.2/jobs/get": {
+      "post": {
+        "operationId": "Jobs.get",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Status was returned successfully."
+          }
+        },
+        "summary": "Get a job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/2.2/jobs/runs/submit": {
+      "post": {
+        "operationId": "Jobs.submitRun",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Status was returned successfully."
+          }
+        },
+        "summary": "Submit a run",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetJobRequest": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SubmitRunRequest": {
+        "properties": {
+          "jobId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Changes
Pin certain endpoints in jobs API to use API 2.1 after the public documentation for Jobs migrates to the 2.2 API version.

## Tests
Unit tests verify that only specific Jobs API paths are updated.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

