### PR TITLE
[Internal] Log a warning when declaring inline entities 

### DIFF
--- a/openapi/model.go
+++ b/openapi/model.go
@@ -272,12 +272,6 @@ func (s *Schema) IsObject() bool {
 	return len(s.Properties) != 0
 }
 
-// IsDefinable states that type could be translated into a valid top-level type
-// in Go, Python, Java, Scala, and JavaScript
-func (s *Schema) IsDefinable() bool {
-	return s.IsObject() || s.IsEnum()
-}
-
 func (s *Schema) IsMap() bool {
 	return s.MapValue != nil
 }


### PR DESCRIPTION
## Changes

Inlined anonymous entities (object and enum) is discouraged. Rather, the proper way to define these entities is to declare them explicitly in the component part of the OpenAPI specification. 

This PR adds a warning to inform users that their schema contains the discouraged pattern.

This PR also includes a couple of noop refactoring to improve readability:
- Move the part responsible for handling references in its own function.
- Use a switch to emphasize that an entity can only be one of a fixed set of types. 

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

