### PR TITLE
[Internal] Enable mixins via struct embedding

### DIFF
--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -111,7 +111,7 @@ controlPlane *{{.ControlPlaneService.PascalName}}API,
 {{end -}}
 ) *{{.PascalName}}API {
 	return &{{.PascalName}}API{
-		impl: &{{.CamelName}}Impl{
+		{{.PascalName}}Service: &{{.CamelName}}Impl{
 			client: client,
 			{{- if .IsDataPlane}}
 			dataPlaneService: oauth2.NewDataPlaneService(),
@@ -128,7 +128,7 @@ controlPlane *{{.ControlPlaneService.PascalName}}API,
 type {{.PascalName}}API struct {
 	// impl contains low-level REST API interface, that could be overridden 
 	// through WithImpl({{.PascalName}}Service)
-	impl {{.PascalName}}Service
+	{{.PascalName}}Service
 
 	{{range .Subservices}}
 	{{.Comment "    // " 80}}
@@ -146,14 +146,18 @@ func (a *{{.ParentService.PascalName}}API) {{.PascalName}}() {{.PascalName}}Inte
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use Mock{{.PascalName}}Interface instead.
 func (a *{{.PascalName}}API) WithImpl(impl {{.PascalName}}Service) {{.PascalName}}Interface {
-	a.impl = impl
-	return a
+	return &{{.PascalName}}API{
+		{{.PascalName}}Service: impl,
+		{{range .Subservices -}}
+		{{.CamelName}}: a.{{.CamelName}},
+		{{end}}
+	}
 }
 
 // Impl returns low-level {{.PascalName}} API implementation
 // Deprecated: use Mock{{.PascalName}}Interface instead.
 func (a *{{.PascalName}}API) Impl() {{.PascalName}}Service {
-	return a.impl
+	return a.{{.PascalName}}Service
 }
 
 
@@ -227,10 +231,16 @@ func (w *{{.PascalName}}[R]) GetWithTimeout(timeout time.Duration) (*{{.Poll.Res
 
 {{range .Methods}}
 {{- $hasWaiter := and .Wait (and (not .IsCrudRead) (not (eq .SnakeName "get_run"))) -}}
-{{if not .Pagination}}{{.Comment "// " 80}}
-func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Request}}, {{if $hasWaiter}}{{.Request.CamelName}}{{else}}request{{end}} {{.Request.PascalName}}{{end}}) {{if $hasWaiter}}{{ template "wait-response-type" . }}{{else}}{{ template "response-type" .}}{{end}} {
-	{{if $hasWaiter -}}
-	{{if not .Response.IsEmpty }}{{.Response.CamelName}}, {{end}}err := a.impl.{{.PascalName}}(ctx{{if .Request}}, {{.Request.CamelName}}{{end}})
+{{if not .Pagination}}
+
+{{/* 
+Function with no waiter are ignored as the API struct automatically inherits
+methods from the nested service interface.
+*/}}
+{{if $hasWaiter -}}
+{{.Comment "// " 80}}
+func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Request}}, {{.Request.CamelName}} {{.Request.PascalName}}{{end}}) {{ template "wait-response-type" . }} {
+	{{if not .Response.IsEmpty }}{{.Response.CamelName}}, {{end}}err := a.{{.Service.PascalName}}Service.{{.PascalName}}(ctx{{if .Request}}, {{.Request.CamelName}}{{end}})
 	if err != nil {
 		return nil, err
 	}
@@ -244,11 +254,9 @@ func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Re
 		timeout: {{.Wait.Timeout}}*time.Minute,
 		callback: nil,
 	}, nil
-	{{- else -}}
-	return a.impl.{{.PascalName}}(ctx{{if .Request}}, request{{end}})
-	{{- end}}
 }
-{{end}}
+{{- end}}
+{{end}} {{/* end of {{if not .Pagination}} */}}
 
 {{if $hasWaiter}}
 // Calls [{{.Service.PascalName}}API.{{.PascalName}}] and waits to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
@@ -294,7 +302,7 @@ func (a *{{.Service.PascalName}}API) {{.PascalName}}(ctx context.Context{{if .Re
 	{{- end}}
 	getNextPage := func(ctx context.Context, req {{ template "paginated-request-type" . }}) (*{{ .Response.PascalName }}, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.{{.PascalName}}(ctx{{if .Request}}, req{{end}})
+		return a.{{.Service.PascalName}}Service.{{.PascalName}}(ctx{{if .Request}}, req{{end}})
 	}
 	getItems := func(resp *{{ .Response.PascalName }}) []{{ template "type" .Pagination.Entity }} {
 		return {{if .Pagination.Results}}resp.{{.Pagination.Results.PascalName}}{{else}}resp{{end}}
@@ -407,7 +415,7 @@ func (a *{{.Service.PascalName}}API) GetBy{{range .NamedIdMap.NamePath}}{{.Pasca
 {{end}}{{if .Shortcut}}
 {{.Comment "// " 80}}
 func (a *{{.Service.PascalName}}API) {{.Shortcut.PascalName}}(ctx context.Context{{range .Shortcut.Params}}, {{.CamelName}} {{template "type" .Entity}}{{end}}) {{ template "response-type" . }} {
-	return a.impl.{{.PascalName}}(ctx, {{.Request.PascalName}}{
+	return a.{{.Service.PascalName}}Service.{{.PascalName}}(ctx, {{.Request.PascalName}}{
 		{{- range .Shortcut.Params}}
 		{{.PascalName}}: {{.CamelName}},{{end}}
 	})

--- a/.codegen/api.go.tmpl
+++ b/.codegen/api.go.tmpl
@@ -146,12 +146,8 @@ func (a *{{.ParentService.PascalName}}API) {{.PascalName}}() {{.PascalName}}Inte
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use Mock{{.PascalName}}Interface instead.
 func (a *{{.PascalName}}API) WithImpl(impl {{.PascalName}}Service) {{.PascalName}}Interface {
-	return &{{.PascalName}}API{
-		{{.PascalName}}Service: impl,
-		{{range .Subservices -}}
-		{{.CamelName}}: a.{{.CamelName}},
-		{{end}}
-	}
+	a.{{.PascalName}}Service = impl
+	return a
 }
 
 // Impl returns low-level {{.PascalName}} API implementation

--- a/service/billing/api.go
+++ b/service/billing/api.go
@@ -57,9 +57,8 @@ type BillableUsageAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockBillableUsageInterface instead.
 func (a *BillableUsageAPI) WithImpl(impl BillableUsageService) BillableUsageInterface {
-	return &BillableUsageAPI{
-		BillableUsageService: impl,
-	}
+	a.BillableUsageService = impl
+	return a
 }
 
 // Impl returns low-level BillableUsage API implementation
@@ -151,9 +150,8 @@ type BudgetsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockBudgetsInterface instead.
 func (a *BudgetsAPI) WithImpl(impl BudgetsService) BudgetsInterface {
-	return &BudgetsAPI{
-		BudgetsService: impl,
-	}
+	a.BudgetsService = impl
+	return a
 }
 
 // Impl returns low-level Budgets API implementation
@@ -395,9 +393,8 @@ type LogDeliveryAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockLogDeliveryInterface instead.
 func (a *LogDeliveryAPI) WithImpl(impl LogDeliveryService) LogDeliveryInterface {
-	return &LogDeliveryAPI{
-		LogDeliveryService: impl,
-	}
+	a.LogDeliveryService = impl
+	return a
 }
 
 // Impl returns low-level LogDelivery API implementation
@@ -548,9 +545,8 @@ type UsageDashboardsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockUsageDashboardsInterface instead.
 func (a *UsageDashboardsAPI) WithImpl(impl UsageDashboardsService) UsageDashboardsInterface {
-	return &UsageDashboardsAPI{
-		UsageDashboardsService: impl,
-	}
+	a.UsageDashboardsService = impl
+	return a
 }
 
 // Impl returns low-level UsageDashboards API implementation

--- a/service/catalog/api.go
+++ b/service/catalog/api.go
@@ -86,7 +86,7 @@ type AccountMetastoreAssignmentsInterface interface {
 
 func NewAccountMetastoreAssignments(client *client.DatabricksClient) *AccountMetastoreAssignmentsAPI {
 	return &AccountMetastoreAssignmentsAPI{
-		impl: &accountMetastoreAssignmentsImpl{
+		AccountMetastoreAssignmentsService: &accountMetastoreAssignmentsImpl{
 			client: client,
 		},
 	}
@@ -96,36 +96,22 @@ func NewAccountMetastoreAssignments(client *client.DatabricksClient) *AccountMet
 type AccountMetastoreAssignmentsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountMetastoreAssignmentsService)
-	impl AccountMetastoreAssignmentsService
+	AccountMetastoreAssignmentsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountMetastoreAssignmentsInterface instead.
 func (a *AccountMetastoreAssignmentsAPI) WithImpl(impl AccountMetastoreAssignmentsService) AccountMetastoreAssignmentsInterface {
-	a.impl = impl
-	return a
+	return &AccountMetastoreAssignmentsAPI{
+		AccountMetastoreAssignmentsService: impl,
+	}
 }
 
 // Impl returns low-level AccountMetastoreAssignments API implementation
 // Deprecated: use MockAccountMetastoreAssignmentsInterface instead.
 func (a *AccountMetastoreAssignmentsAPI) Impl() AccountMetastoreAssignmentsService {
-	return a.impl
-}
-
-// Assigns a workspace to a metastore.
-//
-// Creates an assignment to a metastore for a workspace
-func (a *AccountMetastoreAssignmentsAPI) Create(ctx context.Context, request AccountsCreateMetastoreAssignment) error {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a metastore assignment.
-//
-// Deletes a metastore assignment to a workspace, leaving the workspace with no
-// metastore.
-func (a *AccountMetastoreAssignmentsAPI) Delete(ctx context.Context, request DeleteAccountMetastoreAssignmentRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountMetastoreAssignmentsService
 }
 
 // Delete a metastore assignment.
@@ -133,7 +119,7 @@ func (a *AccountMetastoreAssignmentsAPI) Delete(ctx context.Context, request Del
 // Deletes a metastore assignment to a workspace, leaving the workspace with no
 // metastore.
 func (a *AccountMetastoreAssignmentsAPI) DeleteByWorkspaceIdAndMetastoreId(ctx context.Context, workspaceId int64, metastoreId string) error {
-	return a.impl.Delete(ctx, DeleteAccountMetastoreAssignmentRequest{
+	return a.AccountMetastoreAssignmentsService.Delete(ctx, DeleteAccountMetastoreAssignmentRequest{
 		WorkspaceId: workspaceId,
 		MetastoreId: metastoreId,
 	})
@@ -145,18 +131,8 @@ func (a *AccountMetastoreAssignmentsAPI) DeleteByWorkspaceIdAndMetastoreId(ctx c
 // the workspace is assigned a metastore, the mappig will be returned. If no
 // metastore is assigned to the workspace, the assignment will not be found and
 // a 404 returned.
-func (a *AccountMetastoreAssignmentsAPI) Get(ctx context.Context, request GetAccountMetastoreAssignmentRequest) (*AccountsMetastoreAssignment, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Gets the metastore assignment for a workspace.
-//
-// Gets the metastore assignment, if any, for the workspace specified by ID. If
-// the workspace is assigned a metastore, the mappig will be returned. If no
-// metastore is assigned to the workspace, the assignment will not be found and
-// a 404 returned.
 func (a *AccountMetastoreAssignmentsAPI) GetByWorkspaceId(ctx context.Context, workspaceId int64) (*AccountsMetastoreAssignment, error) {
-	return a.impl.Get(ctx, GetAccountMetastoreAssignmentRequest{
+	return a.AccountMetastoreAssignmentsService.Get(ctx, GetAccountMetastoreAssignmentRequest{
 		WorkspaceId: workspaceId,
 	})
 }
@@ -171,7 +147,7 @@ func (a *AccountMetastoreAssignmentsAPI) List(ctx context.Context, request ListA
 
 	getNextPage := func(ctx context.Context, req ListAccountMetastoreAssignmentsRequest) (*ListAccountMetastoreAssignmentsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.AccountMetastoreAssignmentsService.List(ctx, req)
 	}
 	getItems := func(resp *ListAccountMetastoreAssignmentsResponse) []int64 {
 		return resp.WorkspaceIds
@@ -201,17 +177,9 @@ func (a *AccountMetastoreAssignmentsAPI) ListAll(ctx context.Context, request Li
 // Gets a list of all Databricks workspace IDs that have been assigned to given
 // metastore.
 func (a *AccountMetastoreAssignmentsAPI) ListByMetastoreId(ctx context.Context, metastoreId string) (*ListAccountMetastoreAssignmentsResponse, error) {
-	return a.impl.List(ctx, ListAccountMetastoreAssignmentsRequest{
+	return a.AccountMetastoreAssignmentsService.List(ctx, ListAccountMetastoreAssignmentsRequest{
 		MetastoreId: metastoreId,
 	})
-}
-
-// Updates a metastore assignment to a workspaces.
-//
-// Updates an assignment to a metastore for a workspace. Currently, only the
-// default catalog may be updated.
-func (a *AccountMetastoreAssignmentsAPI) Update(ctx context.Context, request AccountsUpdateMetastoreAssignment) error {
-	return a.impl.Update(ctx, request)
 }
 
 type AccountMetastoresInterface interface {
@@ -271,7 +239,7 @@ type AccountMetastoresInterface interface {
 
 func NewAccountMetastores(client *client.DatabricksClient) *AccountMetastoresAPI {
 	return &AccountMetastoresAPI{
-		impl: &accountMetastoresImpl{
+		AccountMetastoresService: &accountMetastoresImpl{
 			client: client,
 		},
 	}
@@ -282,42 +250,29 @@ func NewAccountMetastores(client *client.DatabricksClient) *AccountMetastoresAPI
 type AccountMetastoresAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountMetastoresService)
-	impl AccountMetastoresService
+	AccountMetastoresService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountMetastoresInterface instead.
 func (a *AccountMetastoresAPI) WithImpl(impl AccountMetastoresService) AccountMetastoresInterface {
-	a.impl = impl
-	return a
+	return &AccountMetastoresAPI{
+		AccountMetastoresService: impl,
+	}
 }
 
 // Impl returns low-level AccountMetastores API implementation
 // Deprecated: use MockAccountMetastoresInterface instead.
 func (a *AccountMetastoresAPI) Impl() AccountMetastoresService {
-	return a.impl
-}
-
-// Create metastore.
-//
-// Creates a Unity Catalog metastore.
-func (a *AccountMetastoresAPI) Create(ctx context.Context, request AccountsCreateMetastore) (*AccountsMetastoreInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a metastore.
-//
-// Deletes a Unity Catalog metastore for an account, both specified by ID.
-func (a *AccountMetastoresAPI) Delete(ctx context.Context, request DeleteAccountMetastoreRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountMetastoresService
 }
 
 // Delete a metastore.
 //
 // Deletes a Unity Catalog metastore for an account, both specified by ID.
 func (a *AccountMetastoresAPI) DeleteByMetastoreId(ctx context.Context, metastoreId string) error {
-	return a.impl.Delete(ctx, DeleteAccountMetastoreRequest{
+	return a.AccountMetastoresService.Delete(ctx, DeleteAccountMetastoreRequest{
 		MetastoreId: metastoreId,
 	})
 }
@@ -325,15 +280,8 @@ func (a *AccountMetastoresAPI) DeleteByMetastoreId(ctx context.Context, metastor
 // Get a metastore.
 //
 // Gets a Unity Catalog metastore from an account, both specified by ID.
-func (a *AccountMetastoresAPI) Get(ctx context.Context, request GetAccountMetastoreRequest) (*AccountsMetastoreInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a metastore.
-//
-// Gets a Unity Catalog metastore from an account, both specified by ID.
 func (a *AccountMetastoresAPI) GetByMetastoreId(ctx context.Context, metastoreId string) (*AccountsMetastoreInfo, error) {
-	return a.impl.Get(ctx, GetAccountMetastoreRequest{
+	return a.AccountMetastoresService.Get(ctx, GetAccountMetastoreRequest{
 		MetastoreId: metastoreId,
 	})
 }
@@ -348,7 +296,7 @@ func (a *AccountMetastoresAPI) List(ctx context.Context) listing.Iterator[Metast
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListMetastoresResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.AccountMetastoresService.List(ctx)
 	}
 	getItems := func(resp *ListMetastoresResponse) []MetastoreInfo {
 		return resp.Metastores
@@ -370,13 +318,6 @@ func (a *AccountMetastoresAPI) List(ctx context.Context) listing.Iterator[Metast
 func (a *AccountMetastoresAPI) ListAll(ctx context.Context) ([]MetastoreInfo, error) {
 	iterator := a.List(ctx)
 	return listing.ToSlice[MetastoreInfo](ctx, iterator)
-}
-
-// Update a metastore.
-//
-// Updates an existing Unity Catalog metastore.
-func (a *AccountMetastoresAPI) Update(ctx context.Context, request AccountsUpdateMetastore) (*AccountsMetastoreInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type AccountStorageCredentialsInterface interface {
@@ -459,7 +400,7 @@ type AccountStorageCredentialsInterface interface {
 
 func NewAccountStorageCredentials(client *client.DatabricksClient) *AccountStorageCredentialsAPI {
 	return &AccountStorageCredentialsAPI{
-		impl: &accountStorageCredentialsImpl{
+		AccountStorageCredentialsService: &accountStorageCredentialsImpl{
 			client: client,
 		},
 	}
@@ -469,43 +410,22 @@ func NewAccountStorageCredentials(client *client.DatabricksClient) *AccountStora
 type AccountStorageCredentialsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountStorageCredentialsService)
-	impl AccountStorageCredentialsService
+	AccountStorageCredentialsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountStorageCredentialsInterface instead.
 func (a *AccountStorageCredentialsAPI) WithImpl(impl AccountStorageCredentialsService) AccountStorageCredentialsInterface {
-	a.impl = impl
-	return a
+	return &AccountStorageCredentialsAPI{
+		AccountStorageCredentialsService: impl,
+	}
 }
 
 // Impl returns low-level AccountStorageCredentials API implementation
 // Deprecated: use MockAccountStorageCredentialsInterface instead.
 func (a *AccountStorageCredentialsAPI) Impl() AccountStorageCredentialsService {
-	return a.impl
-}
-
-// Create a storage credential.
-//
-// Creates a new storage credential. The request object is specific to the
-// cloud:
-//
-// * **AwsIamRole** for AWS credentials * **AzureServicePrincipal** for Azure
-// credentials * **GcpServiceAcountKey** for GCP credentials.
-//
-// The caller must be a metastore admin and have the
-// **CREATE_STORAGE_CREDENTIAL** privilege on the metastore.
-func (a *AccountStorageCredentialsAPI) Create(ctx context.Context, request AccountsCreateStorageCredential) (*AccountsStorageCredentialInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a storage credential.
-//
-// Deletes a storage credential from the metastore. The caller must be an owner
-// of the storage credential.
-func (a *AccountStorageCredentialsAPI) Delete(ctx context.Context, request DeleteAccountStorageCredentialRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountStorageCredentialsService
 }
 
 // Delete a storage credential.
@@ -513,7 +433,7 @@ func (a *AccountStorageCredentialsAPI) Delete(ctx context.Context, request Delet
 // Deletes a storage credential from the metastore. The caller must be an owner
 // of the storage credential.
 func (a *AccountStorageCredentialsAPI) DeleteByMetastoreIdAndStorageCredentialName(ctx context.Context, metastoreId string, storageCredentialName string) error {
-	return a.impl.Delete(ctx, DeleteAccountStorageCredentialRequest{
+	return a.AccountStorageCredentialsService.Delete(ctx, DeleteAccountStorageCredentialRequest{
 		MetastoreId:           metastoreId,
 		StorageCredentialName: storageCredentialName,
 	})
@@ -524,17 +444,8 @@ func (a *AccountStorageCredentialsAPI) DeleteByMetastoreIdAndStorageCredentialNa
 // Gets a storage credential from the metastore. The caller must be a metastore
 // admin, the owner of the storage credential, or have a level of privilege on
 // the storage credential.
-func (a *AccountStorageCredentialsAPI) Get(ctx context.Context, request GetAccountStorageCredentialRequest) (*AccountsStorageCredentialInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Gets the named storage credential.
-//
-// Gets a storage credential from the metastore. The caller must be a metastore
-// admin, the owner of the storage credential, or have a level of privilege on
-// the storage credential.
 func (a *AccountStorageCredentialsAPI) GetByMetastoreIdAndStorageCredentialName(ctx context.Context, metastoreId string, storageCredentialName string) (*AccountsStorageCredentialInfo, error) {
-	return a.impl.Get(ctx, GetAccountStorageCredentialRequest{
+	return a.AccountStorageCredentialsService.Get(ctx, GetAccountStorageCredentialRequest{
 		MetastoreId:           metastoreId,
 		StorageCredentialName: storageCredentialName,
 	})
@@ -550,7 +461,7 @@ func (a *AccountStorageCredentialsAPI) List(ctx context.Context, request ListAcc
 
 	getNextPage := func(ctx context.Context, req ListAccountStorageCredentialsRequest) (*ListAccountStorageCredentialsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.AccountStorageCredentialsService.List(ctx, req)
 	}
 	getItems := func(resp *ListAccountStorageCredentialsResponse) []StorageCredentialInfo {
 		return resp.StorageCredentials
@@ -580,18 +491,9 @@ func (a *AccountStorageCredentialsAPI) ListAll(ctx context.Context, request List
 // Gets a list of all storage credentials that have been assigned to given
 // metastore.
 func (a *AccountStorageCredentialsAPI) ListByMetastoreId(ctx context.Context, metastoreId string) (*ListAccountStorageCredentialsResponse, error) {
-	return a.impl.List(ctx, ListAccountStorageCredentialsRequest{
+	return a.AccountStorageCredentialsService.List(ctx, ListAccountStorageCredentialsRequest{
 		MetastoreId: metastoreId,
 	})
-}
-
-// Updates a storage credential.
-//
-// Updates a storage credential on the metastore. The caller must be the owner
-// of the storage credential. If the caller is a metastore admin, only the
-// __owner__ credential can be changed.
-func (a *AccountStorageCredentialsAPI) Update(ctx context.Context, request AccountsUpdateStorageCredential) (*AccountsStorageCredentialInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ArtifactAllowlistsInterface interface {
@@ -626,7 +528,7 @@ type ArtifactAllowlistsInterface interface {
 
 func NewArtifactAllowlists(client *client.DatabricksClient) *ArtifactAllowlistsAPI {
 	return &ArtifactAllowlistsAPI{
-		impl: &artifactAllowlistsImpl{
+		ArtifactAllowlistsService: &artifactAllowlistsImpl{
 			client: client,
 		},
 	}
@@ -638,29 +540,22 @@ func NewArtifactAllowlists(client *client.DatabricksClient) *ArtifactAllowlistsA
 type ArtifactAllowlistsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ArtifactAllowlistsService)
-	impl ArtifactAllowlistsService
+	ArtifactAllowlistsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockArtifactAllowlistsInterface instead.
 func (a *ArtifactAllowlistsAPI) WithImpl(impl ArtifactAllowlistsService) ArtifactAllowlistsInterface {
-	a.impl = impl
-	return a
+	return &ArtifactAllowlistsAPI{
+		ArtifactAllowlistsService: impl,
+	}
 }
 
 // Impl returns low-level ArtifactAllowlists API implementation
 // Deprecated: use MockArtifactAllowlistsInterface instead.
 func (a *ArtifactAllowlistsAPI) Impl() ArtifactAllowlistsService {
-	return a.impl
-}
-
-// Get an artifact allowlist.
-//
-// Get the artifact allowlist of a certain artifact type. The caller must be a
-// metastore admin or have the **MANAGE ALLOWLIST** privilege on the metastore.
-func (a *ArtifactAllowlistsAPI) Get(ctx context.Context, request GetArtifactAllowlistRequest) (*ArtifactAllowlistInfo, error) {
-	return a.impl.Get(ctx, request)
+	return a.ArtifactAllowlistsService
 }
 
 // Get an artifact allowlist.
@@ -668,18 +563,9 @@ func (a *ArtifactAllowlistsAPI) Get(ctx context.Context, request GetArtifactAllo
 // Get the artifact allowlist of a certain artifact type. The caller must be a
 // metastore admin or have the **MANAGE ALLOWLIST** privilege on the metastore.
 func (a *ArtifactAllowlistsAPI) GetByArtifactType(ctx context.Context, artifactType ArtifactType) (*ArtifactAllowlistInfo, error) {
-	return a.impl.Get(ctx, GetArtifactAllowlistRequest{
+	return a.ArtifactAllowlistsService.Get(ctx, GetArtifactAllowlistRequest{
 		ArtifactType: artifactType,
 	})
-}
-
-// Set an artifact allowlist.
-//
-// Set the artifact allowlist of a certain artifact type. The whole artifact
-// allowlist is replaced with the new allowlist. The caller must be a metastore
-// admin or have the **MANAGE ALLOWLIST** privilege on the metastore.
-func (a *ArtifactAllowlistsAPI) Update(ctx context.Context, request SetArtifactAllowlist) (*ArtifactAllowlistInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type CatalogsInterface interface {
@@ -756,7 +642,7 @@ type CatalogsInterface interface {
 
 func NewCatalogs(client *client.DatabricksClient) *CatalogsAPI {
 	return &CatalogsAPI{
-		impl: &catalogsImpl{
+		CatalogsService: &catalogsImpl{
 			client: client,
 		},
 	}
@@ -773,37 +659,22 @@ func NewCatalogs(client *client.DatabricksClient) *CatalogsAPI {
 type CatalogsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CatalogsService)
-	impl CatalogsService
+	CatalogsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCatalogsInterface instead.
 func (a *CatalogsAPI) WithImpl(impl CatalogsService) CatalogsInterface {
-	a.impl = impl
-	return a
+	return &CatalogsAPI{
+		CatalogsService: impl,
+	}
 }
 
 // Impl returns low-level Catalogs API implementation
 // Deprecated: use MockCatalogsInterface instead.
 func (a *CatalogsAPI) Impl() CatalogsService {
-	return a.impl
-}
-
-// Create a catalog.
-//
-// Creates a new catalog instance in the parent metastore if the caller is a
-// metastore admin or has the **CREATE_CATALOG** privilege.
-func (a *CatalogsAPI) Create(ctx context.Context, request CreateCatalog) (*CatalogInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a catalog.
-//
-// Deletes the catalog that matches the supplied name. The caller must be a
-// metastore admin or the owner of the catalog.
-func (a *CatalogsAPI) Delete(ctx context.Context, request DeleteCatalogRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.CatalogsService
 }
 
 // Delete a catalog.
@@ -811,7 +682,7 @@ func (a *CatalogsAPI) Delete(ctx context.Context, request DeleteCatalogRequest) 
 // Deletes the catalog that matches the supplied name. The caller must be a
 // metastore admin or the owner of the catalog.
 func (a *CatalogsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteCatalogRequest{
+	return a.CatalogsService.Delete(ctx, DeleteCatalogRequest{
 		Name: name,
 	})
 }
@@ -821,17 +692,8 @@ func (a *CatalogsAPI) DeleteByName(ctx context.Context, name string) error {
 // Gets the specified catalog in a metastore. The caller must be a metastore
 // admin, the owner of the catalog, or a user that has the **USE_CATALOG**
 // privilege set for their account.
-func (a *CatalogsAPI) Get(ctx context.Context, request GetCatalogRequest) (*CatalogInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a catalog.
-//
-// Gets the specified catalog in a metastore. The caller must be a metastore
-// admin, the owner of the catalog, or a user that has the **USE_CATALOG**
-// privilege set for their account.
 func (a *CatalogsAPI) GetByName(ctx context.Context, name string) (*CatalogInfo, error) {
-	return a.impl.Get(ctx, GetCatalogRequest{
+	return a.CatalogsService.Get(ctx, GetCatalogRequest{
 		Name: name,
 	})
 }
@@ -849,7 +711,7 @@ func (a *CatalogsAPI) List(ctx context.Context, request ListCatalogsRequest) lis
 
 	getNextPage := func(ctx context.Context, req ListCatalogsRequest) (*ListCatalogsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.CatalogsService.List(ctx, req)
 	}
 	getItems := func(resp *ListCatalogsResponse) []CatalogInfo {
 		return resp.Catalogs
@@ -882,15 +744,6 @@ func (a *CatalogsAPI) ListAll(ctx context.Context, request ListCatalogsRequest) 
 	iterator := a.List(ctx, request)
 	return listing.ToSliceN[CatalogInfo, int](ctx, iterator, request.MaxResults)
 
-}
-
-// Update a catalog.
-//
-// Updates the catalog that matches the supplied name. The caller must be either
-// the owner of the catalog, or a metastore admin (when changing the owner field
-// of the catalog).
-func (a *CatalogsAPI) Update(ctx context.Context, request UpdateCatalog) (*CatalogInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ConnectionsInterface interface {
@@ -963,7 +816,7 @@ type ConnectionsInterface interface {
 
 func NewConnections(client *client.DatabricksClient) *ConnectionsAPI {
 	return &ConnectionsAPI{
-		impl: &connectionsImpl{
+		ConnectionsService: &connectionsImpl{
 			client: client,
 		},
 	}
@@ -983,46 +836,29 @@ func NewConnections(client *client.DatabricksClient) *ConnectionsAPI {
 type ConnectionsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ConnectionsService)
-	impl ConnectionsService
+	ConnectionsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConnectionsInterface instead.
 func (a *ConnectionsAPI) WithImpl(impl ConnectionsService) ConnectionsInterface {
-	a.impl = impl
-	return a
+	return &ConnectionsAPI{
+		ConnectionsService: impl,
+	}
 }
 
 // Impl returns low-level Connections API implementation
 // Deprecated: use MockConnectionsInterface instead.
 func (a *ConnectionsAPI) Impl() ConnectionsService {
-	return a.impl
-}
-
-// Create a connection.
-//
-// # Creates a new connection
-//
-// Creates a new connection to an external data source. It allows users to
-// specify connection details and configurations for interaction with the
-// external server.
-func (a *ConnectionsAPI) Create(ctx context.Context, request CreateConnection) (*ConnectionInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a connection.
-//
-// Deletes the connection that matches the supplied name.
-func (a *ConnectionsAPI) Delete(ctx context.Context, request DeleteConnectionRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ConnectionsService
 }
 
 // Delete a connection.
 //
 // Deletes the connection that matches the supplied name.
 func (a *ConnectionsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteConnectionRequest{
+	return a.ConnectionsService.Delete(ctx, DeleteConnectionRequest{
 		Name: name,
 	})
 }
@@ -1030,15 +866,8 @@ func (a *ConnectionsAPI) DeleteByName(ctx context.Context, name string) error {
 // Get a connection.
 //
 // Gets a connection from it's name.
-func (a *ConnectionsAPI) Get(ctx context.Context, request GetConnectionRequest) (*ConnectionInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a connection.
-//
-// Gets a connection from it's name.
 func (a *ConnectionsAPI) GetByName(ctx context.Context, name string) (*ConnectionInfo, error) {
-	return a.impl.Get(ctx, GetConnectionRequest{
+	return a.ConnectionsService.Get(ctx, GetConnectionRequest{
 		Name: name,
 	})
 }
@@ -1052,7 +881,7 @@ func (a *ConnectionsAPI) List(ctx context.Context, request ListConnectionsReques
 
 	getNextPage := func(ctx context.Context, req ListConnectionsRequest) (*ListConnectionsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ConnectionsService.List(ctx, req)
 	}
 	getItems := func(resp *ListConnectionsResponse) []ConnectionInfo {
 		return resp.Connections
@@ -1106,13 +935,6 @@ func (a *ConnectionsAPI) ConnectionInfoNameToFullNameMap(ctx context.Context, re
 		mapping[key] = v.FullName
 	}
 	return mapping, nil
-}
-
-// Update a connection.
-//
-// Updates the connection that matches the supplied name.
-func (a *ConnectionsAPI) Update(ctx context.Context, request UpdateConnection) (*ConnectionInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ExternalLocationsInterface interface {
@@ -1190,7 +1012,7 @@ type ExternalLocationsInterface interface {
 
 func NewExternalLocations(client *client.DatabricksClient) *ExternalLocationsAPI {
 	return &ExternalLocationsAPI{
-		impl: &externalLocationsImpl{
+		ExternalLocationsService: &externalLocationsImpl{
 			client: client,
 		},
 	}
@@ -1212,38 +1034,22 @@ func NewExternalLocations(client *client.DatabricksClient) *ExternalLocationsAPI
 type ExternalLocationsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ExternalLocationsService)
-	impl ExternalLocationsService
+	ExternalLocationsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockExternalLocationsInterface instead.
 func (a *ExternalLocationsAPI) WithImpl(impl ExternalLocationsService) ExternalLocationsInterface {
-	a.impl = impl
-	return a
+	return &ExternalLocationsAPI{
+		ExternalLocationsService: impl,
+	}
 }
 
 // Impl returns low-level ExternalLocations API implementation
 // Deprecated: use MockExternalLocationsInterface instead.
 func (a *ExternalLocationsAPI) Impl() ExternalLocationsService {
-	return a.impl
-}
-
-// Create an external location.
-//
-// Creates a new external location entry in the metastore. The caller must be a
-// metastore admin or have the **CREATE_EXTERNAL_LOCATION** privilege on both
-// the metastore and the associated storage credential.
-func (a *ExternalLocationsAPI) Create(ctx context.Context, request CreateExternalLocation) (*ExternalLocationInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an external location.
-//
-// Deletes the specified external location from the metastore. The caller must
-// be the owner of the external location.
-func (a *ExternalLocationsAPI) Delete(ctx context.Context, request DeleteExternalLocationRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ExternalLocationsService
 }
 
 // Delete an external location.
@@ -1251,7 +1057,7 @@ func (a *ExternalLocationsAPI) Delete(ctx context.Context, request DeleteExterna
 // Deletes the specified external location from the metastore. The caller must
 // be the owner of the external location.
 func (a *ExternalLocationsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteExternalLocationRequest{
+	return a.ExternalLocationsService.Delete(ctx, DeleteExternalLocationRequest{
 		Name: name,
 	})
 }
@@ -1261,17 +1067,8 @@ func (a *ExternalLocationsAPI) DeleteByName(ctx context.Context, name string) er
 // Gets an external location from the metastore. The caller must be either a
 // metastore admin, the owner of the external location, or a user that has some
 // privilege on the external location.
-func (a *ExternalLocationsAPI) Get(ctx context.Context, request GetExternalLocationRequest) (*ExternalLocationInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get an external location.
-//
-// Gets an external location from the metastore. The caller must be either a
-// metastore admin, the owner of the external location, or a user that has some
-// privilege on the external location.
 func (a *ExternalLocationsAPI) GetByName(ctx context.Context, name string) (*ExternalLocationInfo, error) {
-	return a.impl.Get(ctx, GetExternalLocationRequest{
+	return a.ExternalLocationsService.Get(ctx, GetExternalLocationRequest{
 		Name: name,
 	})
 }
@@ -1289,7 +1086,7 @@ func (a *ExternalLocationsAPI) List(ctx context.Context, request ListExternalLoc
 
 	getNextPage := func(ctx context.Context, req ListExternalLocationsRequest) (*ListExternalLocationsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ExternalLocationsService.List(ctx, req)
 	}
 	getItems := func(resp *ListExternalLocationsResponse) []ExternalLocationInfo {
 		return resp.ExternalLocations
@@ -1322,15 +1119,6 @@ func (a *ExternalLocationsAPI) ListAll(ctx context.Context, request ListExternal
 	iterator := a.List(ctx, request)
 	return listing.ToSliceN[ExternalLocationInfo, int](ctx, iterator, request.MaxResults)
 
-}
-
-// Update an external location.
-//
-// Updates an external location in the metastore. The caller must be the owner
-// of the external location, or be a metastore admin. In the second case, the
-// admin can only update the name of the external location.
-func (a *ExternalLocationsAPI) Update(ctx context.Context, request UpdateExternalLocation) (*ExternalLocationInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type FunctionsInterface interface {
@@ -1448,7 +1236,7 @@ type FunctionsInterface interface {
 
 func NewFunctions(client *client.DatabricksClient) *FunctionsAPI {
 	return &FunctionsAPI{
-		impl: &functionsImpl{
+		FunctionsService: &functionsImpl{
 			client: client,
 		},
 	}
@@ -1463,47 +1251,22 @@ func NewFunctions(client *client.DatabricksClient) *FunctionsAPI {
 type FunctionsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(FunctionsService)
-	impl FunctionsService
+	FunctionsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockFunctionsInterface instead.
 func (a *FunctionsAPI) WithImpl(impl FunctionsService) FunctionsInterface {
-	a.impl = impl
-	return a
+	return &FunctionsAPI{
+		FunctionsService: impl,
+	}
 }
 
 // Impl returns low-level Functions API implementation
 // Deprecated: use MockFunctionsInterface instead.
 func (a *FunctionsAPI) Impl() FunctionsService {
-	return a.impl
-}
-
-// Create a function.
-//
-// **WARNING: This API is experimental and will change in future versions**
-//
-// # Creates a new function
-//
-// The user must have the following permissions in order for the function to be
-// created: - **USE_CATALOG** on the function's parent catalog - **USE_SCHEMA**
-// and **CREATE_FUNCTION** on the function's parent schema
-func (a *FunctionsAPI) Create(ctx context.Context, request CreateFunctionRequest) (*FunctionInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a function.
-//
-// Deletes the function that matches the supplied name. For the deletion to
-// succeed, the user must satisfy one of the following conditions: - Is the
-// owner of the function's parent catalog - Is the owner of the function's
-// parent schema and have the **USE_CATALOG** privilege on its parent catalog -
-// Is the owner of the function itself and have both the **USE_CATALOG**
-// privilege on its parent catalog and the **USE_SCHEMA** privilege on its
-// parent schema
-func (a *FunctionsAPI) Delete(ctx context.Context, request DeleteFunctionRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.FunctionsService
 }
 
 // Delete a function.
@@ -1516,7 +1279,7 @@ func (a *FunctionsAPI) Delete(ctx context.Context, request DeleteFunctionRequest
 // privilege on its parent catalog and the **USE_SCHEMA** privilege on its
 // parent schema
 func (a *FunctionsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteFunctionRequest{
+	return a.FunctionsService.Delete(ctx, DeleteFunctionRequest{
 		Name: name,
 	})
 }
@@ -1530,21 +1293,8 @@ func (a *FunctionsAPI) DeleteByName(ctx context.Context, name string) error {
 // of the function - Have the **USE_CATALOG** privilege on the function's parent
 // catalog, the **USE_SCHEMA** privilege on the function's parent schema, and
 // the **EXECUTE** privilege on the function itself
-func (a *FunctionsAPI) Get(ctx context.Context, request GetFunctionRequest) (*FunctionInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a function.
-//
-// Gets a function from within a parent catalog and schema. For the fetch to
-// succeed, the user must satisfy one of the following requirements: - Is a
-// metastore admin - Is an owner of the function's parent catalog - Have the
-// **USE_CATALOG** privilege on the function's parent catalog and be the owner
-// of the function - Have the **USE_CATALOG** privilege on the function's parent
-// catalog, the **USE_SCHEMA** privilege on the function's parent schema, and
-// the **EXECUTE** privilege on the function itself
 func (a *FunctionsAPI) GetByName(ctx context.Context, name string) (*FunctionInfo, error) {
-	return a.impl.Get(ctx, GetFunctionRequest{
+	return a.FunctionsService.Get(ctx, GetFunctionRequest{
 		Name: name,
 	})
 }
@@ -1564,7 +1314,7 @@ func (a *FunctionsAPI) List(ctx context.Context, request ListFunctionsRequest) l
 
 	getNextPage := func(ctx context.Context, req ListFunctionsRequest) (*ListFunctionsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.FunctionsService.List(ctx, req)
 	}
 	getItems := func(resp *ListFunctionsResponse) []FunctionInfo {
 		return resp.Functions
@@ -1626,20 +1376,6 @@ func (a *FunctionsAPI) FunctionInfoNameToFullNameMap(ctx context.Context, reques
 	return mapping, nil
 }
 
-// Update a function.
-//
-// Updates the function that matches the supplied name. Only the owner of the
-// function can be updated. If the user is not a metastore admin, the user must
-// be a member of the group that is the new function owner. - Is a metastore
-// admin - Is the owner of the function's parent catalog - Is the owner of the
-// function's parent schema and has the **USE_CATALOG** privilege on its parent
-// catalog - Is the owner of the function itself and has the **USE_CATALOG**
-// privilege on its parent catalog as well as the **USE_SCHEMA** privilege on
-// the function's parent schema.
-func (a *FunctionsAPI) Update(ctx context.Context, request UpdateFunction) (*FunctionInfo, error) {
-	return a.impl.Update(ctx, request)
-}
-
 type GrantsInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -1678,7 +1414,7 @@ type GrantsInterface interface {
 
 func NewGrants(client *client.DatabricksClient) *GrantsAPI {
 	return &GrantsAPI{
-		impl: &grantsImpl{
+		GrantsService: &grantsImpl{
 			client: client,
 		},
 	}
@@ -1698,62 +1434,42 @@ func NewGrants(client *client.DatabricksClient) *GrantsAPI {
 type GrantsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(GrantsService)
-	impl GrantsService
+	GrantsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGrantsInterface instead.
 func (a *GrantsAPI) WithImpl(impl GrantsService) GrantsInterface {
-	a.impl = impl
-	return a
+	return &GrantsAPI{
+		GrantsService: impl,
+	}
 }
 
 // Impl returns low-level Grants API implementation
 // Deprecated: use MockGrantsInterface instead.
 func (a *GrantsAPI) Impl() GrantsService {
-	return a.impl
-}
-
-// Get permissions.
-//
-// Gets the permissions for a securable.
-func (a *GrantsAPI) Get(ctx context.Context, request GetGrantRequest) (*PermissionsList, error) {
-	return a.impl.Get(ctx, request)
+	return a.GrantsService
 }
 
 // Get permissions.
 //
 // Gets the permissions for a securable.
 func (a *GrantsAPI) GetBySecurableTypeAndFullName(ctx context.Context, securableType SecurableType, fullName string) (*PermissionsList, error) {
-	return a.impl.Get(ctx, GetGrantRequest{
+	return a.GrantsService.Get(ctx, GetGrantRequest{
 		SecurableType: securableType,
 		FullName:      fullName,
 	})
-}
-
-// Get effective permissions.
-//
-// Gets the effective permissions for a securable.
-func (a *GrantsAPI) GetEffective(ctx context.Context, request GetEffectiveRequest) (*EffectivePermissionsList, error) {
-	return a.impl.GetEffective(ctx, request)
 }
 
 // Get effective permissions.
 //
 // Gets the effective permissions for a securable.
 func (a *GrantsAPI) GetEffectiveBySecurableTypeAndFullName(ctx context.Context, securableType SecurableType, fullName string) (*EffectivePermissionsList, error) {
-	return a.impl.GetEffective(ctx, GetEffectiveRequest{
+	return a.GrantsService.GetEffective(ctx, GetEffectiveRequest{
 		SecurableType: securableType,
 		FullName:      fullName,
 	})
-}
-
-// Update permissions.
-//
-// Updates the permissions for a securable.
-func (a *GrantsAPI) Update(ctx context.Context, request UpdatePermissions) (*PermissionsList, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type MetastoresInterface interface {
@@ -1880,7 +1596,7 @@ type MetastoresInterface interface {
 
 func NewMetastores(client *client.DatabricksClient) *MetastoresAPI {
 	return &MetastoresAPI{
-		impl: &metastoresImpl{
+		MetastoresService: &metastoresImpl{
 			client: client,
 		},
 	}
@@ -1903,62 +1619,29 @@ func NewMetastores(client *client.DatabricksClient) *MetastoresAPI {
 type MetastoresAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(MetastoresService)
-	impl MetastoresService
+	MetastoresService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockMetastoresInterface instead.
 func (a *MetastoresAPI) WithImpl(impl MetastoresService) MetastoresInterface {
-	a.impl = impl
-	return a
+	return &MetastoresAPI{
+		MetastoresService: impl,
+	}
 }
 
 // Impl returns low-level Metastores API implementation
 // Deprecated: use MockMetastoresInterface instead.
 func (a *MetastoresAPI) Impl() MetastoresService {
-	return a.impl
-}
-
-// Create an assignment.
-//
-// Creates a new metastore assignment. If an assignment for the same
-// __workspace_id__ exists, it will be overwritten by the new __metastore_id__
-// and __default_catalog_name__. The caller must be an account admin.
-func (a *MetastoresAPI) Assign(ctx context.Context, request CreateMetastoreAssignment) error {
-	return a.impl.Assign(ctx, request)
-}
-
-// Create a metastore.
-//
-// Creates a new metastore based on a provided name and optional storage root
-// path. By default (if the __owner__ field is not set), the owner of the new
-// metastore is the user calling the __createMetastore__ API. If the __owner__
-// field is set to the empty string (**""**), the ownership is assigned to the
-// System User instead.
-func (a *MetastoresAPI) Create(ctx context.Context, request CreateMetastore) (*MetastoreInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Get metastore assignment for workspace.
-//
-// Gets the metastore assignment for the workspace being accessed.
-func (a *MetastoresAPI) Current(ctx context.Context) (*MetastoreAssignment, error) {
-	return a.impl.Current(ctx)
-}
-
-// Delete a metastore.
-//
-// Deletes a metastore. The caller must be a metastore admin.
-func (a *MetastoresAPI) Delete(ctx context.Context, request DeleteMetastoreRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.MetastoresService
 }
 
 // Delete a metastore.
 //
 // Deletes a metastore. The caller must be a metastore admin.
 func (a *MetastoresAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteMetastoreRequest{
+	return a.MetastoresService.Delete(ctx, DeleteMetastoreRequest{
 		Id: id,
 	})
 }
@@ -1967,16 +1650,8 @@ func (a *MetastoresAPI) DeleteById(ctx context.Context, id string) error {
 //
 // Gets a metastore that matches the supplied ID. The caller must be a metastore
 // admin to retrieve this info.
-func (a *MetastoresAPI) Get(ctx context.Context, request GetMetastoreRequest) (*MetastoreInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a metastore.
-//
-// Gets a metastore that matches the supplied ID. The caller must be a metastore
-// admin to retrieve this info.
 func (a *MetastoresAPI) GetById(ctx context.Context, id string) (*MetastoreInfo, error) {
-	return a.impl.Get(ctx, GetMetastoreRequest{
+	return a.MetastoresService.Get(ctx, GetMetastoreRequest{
 		Id: id,
 	})
 }
@@ -1993,7 +1668,7 @@ func (a *MetastoresAPI) List(ctx context.Context) listing.Iterator[MetastoreInfo
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListMetastoresResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.MetastoresService.List(ctx)
 	}
 	getItems := func(resp *ListMetastoresResponse) []MetastoreInfo {
 		return resp.Metastores
@@ -2072,48 +1747,13 @@ func (a *MetastoresAPI) GetByName(ctx context.Context, name string) (*MetastoreI
 	return &alternatives[0], nil
 }
 
-// Get a metastore summary.
-//
-// Gets information about a metastore. This summary includes the storage
-// credential, the cloud vendor, the cloud region, and the global metastore ID.
-func (a *MetastoresAPI) Summary(ctx context.Context) (*GetMetastoreSummaryResponse, error) {
-	return a.impl.Summary(ctx)
-}
-
-// Delete an assignment.
-//
-// Deletes a metastore assignment. The caller must be an account administrator.
-func (a *MetastoresAPI) Unassign(ctx context.Context, request UnassignRequest) error {
-	return a.impl.Unassign(ctx, request)
-}
-
 // Delete an assignment.
 //
 // Deletes a metastore assignment. The caller must be an account administrator.
 func (a *MetastoresAPI) UnassignByWorkspaceId(ctx context.Context, workspaceId int64) error {
-	return a.impl.Unassign(ctx, UnassignRequest{
+	return a.MetastoresService.Unassign(ctx, UnassignRequest{
 		WorkspaceId: workspaceId,
 	})
-}
-
-// Update a metastore.
-//
-// Updates information for a specific metastore. The caller must be a metastore
-// admin. If the __owner__ field is set to the empty string (**""**), the
-// ownership is updated to the System User.
-func (a *MetastoresAPI) Update(ctx context.Context, request UpdateMetastore) (*MetastoreInfo, error) {
-	return a.impl.Update(ctx, request)
-}
-
-// Update an assignment.
-//
-// Updates a metastore assignment. This operation can be used to update
-// __metastore_id__ or __default_catalog_name__ for a specified Workspace, if
-// the Workspace is already assigned a metastore. The caller must be an account
-// admin to update __metastore_id__; otherwise, the caller can be a Workspace
-// admin.
-func (a *MetastoresAPI) UpdateAssignment(ctx context.Context, request UpdateMetastoreAssignment) error {
-	return a.impl.UpdateAssignment(ctx, request)
 }
 
 type ModelVersionsInterface interface {
@@ -2258,7 +1898,7 @@ type ModelVersionsInterface interface {
 
 func NewModelVersions(client *client.DatabricksClient) *ModelVersionsAPI {
 	return &ModelVersionsAPI{
-		impl: &modelVersionsImpl{
+		ModelVersionsService: &modelVersionsImpl{
 			client: client,
 		},
 	}
@@ -2274,34 +1914,22 @@ func NewModelVersions(client *client.DatabricksClient) *ModelVersionsAPI {
 type ModelVersionsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ModelVersionsService)
-	impl ModelVersionsService
+	ModelVersionsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockModelVersionsInterface instead.
 func (a *ModelVersionsAPI) WithImpl(impl ModelVersionsService) ModelVersionsInterface {
-	a.impl = impl
-	return a
+	return &ModelVersionsAPI{
+		ModelVersionsService: impl,
+	}
 }
 
 // Impl returns low-level ModelVersions API implementation
 // Deprecated: use MockModelVersionsInterface instead.
 func (a *ModelVersionsAPI) Impl() ModelVersionsService {
-	return a.impl
-}
-
-// Delete a Model Version.
-//
-// Deletes a model version from the specified registered model. Any aliases
-// assigned to the model version will also be deleted.
-//
-// The caller must be a metastore admin or an owner of the parent registered
-// model. For the latter case, the caller must also be the owner or have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
-func (a *ModelVersionsAPI) Delete(ctx context.Context, request DeleteModelVersionRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ModelVersionsService
 }
 
 // Delete a Model Version.
@@ -2314,22 +1942,10 @@ func (a *ModelVersionsAPI) Delete(ctx context.Context, request DeleteModelVersio
 // **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
 // privilege on the parent schema.
 func (a *ModelVersionsAPI) DeleteByFullNameAndVersion(ctx context.Context, fullName string, version int) error {
-	return a.impl.Delete(ctx, DeleteModelVersionRequest{
+	return a.ModelVersionsService.Delete(ctx, DeleteModelVersionRequest{
 		FullName: fullName,
 		Version:  version,
 	})
-}
-
-// Get a Model Version.
-//
-// Get a model version.
-//
-// The caller must be a metastore admin or an owner of (or have the **EXECUTE**
-// privilege on) the parent registered model. For the latter case, the caller
-// must also be the owner or have the **USE_CATALOG** privilege on the parent
-// catalog and the **USE_SCHEMA** privilege on the parent schema.
-func (a *ModelVersionsAPI) Get(ctx context.Context, request GetModelVersionRequest) (*RegisteredModelInfo, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a Model Version.
@@ -2341,7 +1957,7 @@ func (a *ModelVersionsAPI) Get(ctx context.Context, request GetModelVersionReque
 // must also be the owner or have the **USE_CATALOG** privilege on the parent
 // catalog and the **USE_SCHEMA** privilege on the parent schema.
 func (a *ModelVersionsAPI) GetByFullNameAndVersion(ctx context.Context, fullName string, version int) (*RegisteredModelInfo, error) {
-	return a.impl.Get(ctx, GetModelVersionRequest{
+	return a.ModelVersionsService.Get(ctx, GetModelVersionRequest{
 		FullName: fullName,
 		Version:  version,
 	})
@@ -2355,20 +1971,8 @@ func (a *ModelVersionsAPI) GetByFullNameAndVersion(ctx context.Context, fullName
 // privilege on) the registered model. For the latter case, the caller must also
 // be the owner or have the **USE_CATALOG** privilege on the parent catalog and
 // the **USE_SCHEMA** privilege on the parent schema.
-func (a *ModelVersionsAPI) GetByAlias(ctx context.Context, request GetByAliasRequest) (*ModelVersionInfo, error) {
-	return a.impl.GetByAlias(ctx, request)
-}
-
-// Get Model Version By Alias.
-//
-// Get a model version by alias.
-//
-// The caller must be a metastore admin or an owner of (or have the **EXECUTE**
-// privilege on) the registered model. For the latter case, the caller must also
-// be the owner or have the **USE_CATALOG** privilege on the parent catalog and
-// the **USE_SCHEMA** privilege on the parent schema.
 func (a *ModelVersionsAPI) GetByAliasByFullNameAndAlias(ctx context.Context, fullName string, alias string) (*ModelVersionInfo, error) {
-	return a.impl.GetByAlias(ctx, GetByAliasRequest{
+	return a.ModelVersionsService.GetByAlias(ctx, GetByAliasRequest{
 		FullName: fullName,
 		Alias:    alias,
 	})
@@ -2395,7 +1999,7 @@ func (a *ModelVersionsAPI) List(ctx context.Context, request ListModelVersionsRe
 
 	getNextPage := func(ctx context.Context, req ListModelVersionsRequest) (*ListModelVersionsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ModelVersionsService.List(ctx, req)
 	}
 	getItems := func(resp *ListModelVersionsResponse) []ModelVersionInfo {
 		return resp.ModelVersions
@@ -2454,23 +2058,9 @@ func (a *ModelVersionsAPI) ListAll(ctx context.Context, request ListModelVersion
 // There is no guarantee of a specific ordering of the elements in the response.
 // The elements in the response will not contain any aliases or tags.
 func (a *ModelVersionsAPI) ListByFullName(ctx context.Context, fullName string) (*ListModelVersionsResponse, error) {
-	return a.impl.List(ctx, ListModelVersionsRequest{
+	return a.ModelVersionsService.List(ctx, ListModelVersionsRequest{
 		FullName: fullName,
 	})
-}
-
-// Update a Model Version.
-//
-// Updates the specified model version.
-//
-// The caller must be a metastore admin or an owner of the parent registered
-// model. For the latter case, the caller must also be the owner or have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
-//
-// Currently only the comment of the model version can be updated.
-func (a *ModelVersionsAPI) Update(ctx context.Context, request UpdateModelVersionRequest) (*ModelVersionInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type OnlineTablesInterface interface {
@@ -2515,7 +2105,7 @@ type OnlineTablesInterface interface {
 
 func NewOnlineTables(client *client.DatabricksClient) *OnlineTablesAPI {
 	return &OnlineTablesAPI{
-		impl: &onlineTablesImpl{
+		OnlineTablesService: &onlineTablesImpl{
 			client: client,
 		},
 	}
@@ -2526,37 +2116,22 @@ func NewOnlineTables(client *client.DatabricksClient) *OnlineTablesAPI {
 type OnlineTablesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(OnlineTablesService)
-	impl OnlineTablesService
+	OnlineTablesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockOnlineTablesInterface instead.
 func (a *OnlineTablesAPI) WithImpl(impl OnlineTablesService) OnlineTablesInterface {
-	a.impl = impl
-	return a
+	return &OnlineTablesAPI{
+		OnlineTablesService: impl,
+	}
 }
 
 // Impl returns low-level OnlineTables API implementation
 // Deprecated: use MockOnlineTablesInterface instead.
 func (a *OnlineTablesAPI) Impl() OnlineTablesService {
-	return a.impl
-}
-
-// Create an Online Table.
-//
-// Create a new Online Table.
-func (a *OnlineTablesAPI) Create(ctx context.Context, request CreateOnlineTableRequest) (*OnlineTable, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an Online Table.
-//
-// Delete an online table. Warning: This will delete all the data in the online
-// table. If the source Delta table was deleted or modified since this Online
-// Table was created, this will lose the data forever!
-func (a *OnlineTablesAPI) Delete(ctx context.Context, request DeleteOnlineTableRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.OnlineTablesService
 }
 
 // Delete an Online Table.
@@ -2565,7 +2140,7 @@ func (a *OnlineTablesAPI) Delete(ctx context.Context, request DeleteOnlineTableR
 // table. If the source Delta table was deleted or modified since this Online
 // Table was created, this will lose the data forever!
 func (a *OnlineTablesAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteOnlineTableRequest{
+	return a.OnlineTablesService.Delete(ctx, DeleteOnlineTableRequest{
 		Name: name,
 	})
 }
@@ -2573,15 +2148,8 @@ func (a *OnlineTablesAPI) DeleteByName(ctx context.Context, name string) error {
 // Get an Online Table.
 //
 // Get information about an existing online table and its status.
-func (a *OnlineTablesAPI) Get(ctx context.Context, request GetOnlineTableRequest) (*OnlineTable, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get an Online Table.
-//
-// Get information about an existing online table and its status.
 func (a *OnlineTablesAPI) GetByName(ctx context.Context, name string) (*OnlineTable, error) {
-	return a.impl.Get(ctx, GetOnlineTableRequest{
+	return a.OnlineTablesService.Get(ctx, GetOnlineTableRequest{
 		Name: name,
 	})
 }
@@ -2785,7 +2353,7 @@ type QualityMonitorsInterface interface {
 
 func NewQualityMonitors(client *client.DatabricksClient) *QualityMonitorsAPI {
 	return &QualityMonitorsAPI{
-		impl: &qualityMonitorsImpl{
+		QualityMonitorsService: &qualityMonitorsImpl{
 			client: client,
 		},
 	}
@@ -2802,74 +2370,22 @@ func NewQualityMonitors(client *client.DatabricksClient) *QualityMonitorsAPI {
 type QualityMonitorsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(QualityMonitorsService)
-	impl QualityMonitorsService
+	QualityMonitorsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQualityMonitorsInterface instead.
 func (a *QualityMonitorsAPI) WithImpl(impl QualityMonitorsService) QualityMonitorsInterface {
-	a.impl = impl
-	return a
+	return &QualityMonitorsAPI{
+		QualityMonitorsService: impl,
+	}
 }
 
 // Impl returns low-level QualityMonitors API implementation
 // Deprecated: use MockQualityMonitorsInterface instead.
 func (a *QualityMonitorsAPI) Impl() QualityMonitorsService {
-	return a.impl
-}
-
-// Cancel refresh.
-//
-// Cancel an active monitor refresh for the given refresh ID.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema - be an
-// owner of the table
-//
-// Additionally, the call must be made from the workspace where the monitor was
-// created.
-func (a *QualityMonitorsAPI) CancelRefresh(ctx context.Context, request CancelRefreshRequest) error {
-	return a.impl.CancelRefresh(ctx, request)
-}
-
-// Create a table monitor.
-//
-// Creates a new monitor for the specified table.
-//
-// The caller must either: 1. be an owner of the table's parent catalog, have
-// **USE_SCHEMA** on the table's parent schema, and have **SELECT** access on
-// the table 2. have **USE_CATALOG** on the table's parent catalog, be an owner
-// of the table's parent schema, and have **SELECT** access on the table. 3.
-// have the following permissions: - **USE_CATALOG** on the table's parent
-// catalog - **USE_SCHEMA** on the table's parent schema - be an owner of the
-// table.
-//
-// Workspace assets, such as the dashboard, will be created in the workspace
-// where this call was made.
-func (a *QualityMonitorsAPI) Create(ctx context.Context, request CreateMonitor) (*MonitorInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a table monitor.
-//
-// Deletes a monitor for the specified table.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema - be an
-// owner of the table.
-//
-// Additionally, the call must be made from the workspace where the monitor was
-// created.
-//
-// Note that the metric tables and dashboard will not be deleted as part of this
-// call; those assets must be manually cleaned up (if desired).
-func (a *QualityMonitorsAPI) Delete(ctx context.Context, request DeleteQualityMonitorRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.QualityMonitorsService
 }
 
 // Delete a table monitor.
@@ -2888,27 +2404,9 @@ func (a *QualityMonitorsAPI) Delete(ctx context.Context, request DeleteQualityMo
 // Note that the metric tables and dashboard will not be deleted as part of this
 // call; those assets must be manually cleaned up (if desired).
 func (a *QualityMonitorsAPI) DeleteByTableName(ctx context.Context, tableName string) error {
-	return a.impl.Delete(ctx, DeleteQualityMonitorRequest{
+	return a.QualityMonitorsService.Delete(ctx, DeleteQualityMonitorRequest{
 		TableName: tableName,
 	})
-}
-
-// Get a table monitor.
-//
-// Gets a monitor for the specified table.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema. 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema -
-// **SELECT** privilege on the table.
-//
-// The returned information includes configuration values, as well as
-// information on assets created by the monitor. Some information (e.g.,
-// dashboard) may be filtered out if the caller is in a different workspace than
-// where the monitor was created.
-func (a *QualityMonitorsAPI) Get(ctx context.Context, request GetQualityMonitorRequest) (*MonitorInfo, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a table monitor.
@@ -2926,7 +2424,7 @@ func (a *QualityMonitorsAPI) Get(ctx context.Context, request GetQualityMonitorR
 // dashboard) may be filtered out if the caller is in a different workspace than
 // where the monitor was created.
 func (a *QualityMonitorsAPI) GetByTableName(ctx context.Context, tableName string) (*MonitorInfo, error) {
-	return a.impl.Get(ctx, GetQualityMonitorRequest{
+	return a.QualityMonitorsService.Get(ctx, GetQualityMonitorRequest{
 		TableName: tableName,
 	})
 }
@@ -2943,24 +2441,8 @@ func (a *QualityMonitorsAPI) GetByTableName(ctx context.Context, tableName strin
 //
 // Additionally, the call must be made from the workspace where the monitor was
 // created.
-func (a *QualityMonitorsAPI) GetRefresh(ctx context.Context, request GetRefreshRequest) (*MonitorRefreshInfo, error) {
-	return a.impl.GetRefresh(ctx, request)
-}
-
-// Get refresh.
-//
-// Gets info about a specific monitor refresh using the given refresh ID.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema -
-// **SELECT** privilege on the table.
-//
-// Additionally, the call must be made from the workspace where the monitor was
-// created.
 func (a *QualityMonitorsAPI) GetRefreshByTableNameAndRefreshId(ctx context.Context, tableName string, refreshId string) (*MonitorRefreshInfo, error) {
-	return a.impl.GetRefresh(ctx, GetRefreshRequest{
+	return a.QualityMonitorsService.GetRefresh(ctx, GetRefreshRequest{
 		TableName: tableName,
 		RefreshId: refreshId,
 	})
@@ -2979,63 +2461,10 @@ func (a *QualityMonitorsAPI) GetRefreshByTableNameAndRefreshId(ctx context.Conte
 //
 // Additionally, the call must be made from the workspace where the monitor was
 // created.
-func (a *QualityMonitorsAPI) ListRefreshes(ctx context.Context, request ListRefreshesRequest) (*MonitorRefreshListResponse, error) {
-	return a.impl.ListRefreshes(ctx, request)
-}
-
-// List refreshes.
-//
-// Gets an array containing the history of the most recent refreshes (up to 25)
-// for this table.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema -
-// **SELECT** privilege on the table.
-//
-// Additionally, the call must be made from the workspace where the monitor was
-// created.
 func (a *QualityMonitorsAPI) ListRefreshesByTableName(ctx context.Context, tableName string) (*MonitorRefreshListResponse, error) {
-	return a.impl.ListRefreshes(ctx, ListRefreshesRequest{
+	return a.QualityMonitorsService.ListRefreshes(ctx, ListRefreshesRequest{
 		TableName: tableName,
 	})
-}
-
-// Queue a metric refresh for a monitor.
-//
-// Queues a metric refresh on the monitor for the specified table. The refresh
-// will execute in the background.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema - be an
-// owner of the table
-//
-// Additionally, the call must be made from the workspace where the monitor was
-// created.
-func (a *QualityMonitorsAPI) RunRefresh(ctx context.Context, request RunRefreshRequest) (*MonitorRefreshInfo, error) {
-	return a.impl.RunRefresh(ctx, request)
-}
-
-// Update a table monitor.
-//
-// Updates a monitor for the specified table.
-//
-// The caller must either: 1. be an owner of the table's parent catalog 2. have
-// **USE_CATALOG** on the table's parent catalog and be an owner of the table's
-// parent schema 3. have the following permissions: - **USE_CATALOG** on the
-// table's parent catalog - **USE_SCHEMA** on the table's parent schema - be an
-// owner of the table.
-//
-// Additionally, the call must be made from the workspace where the monitor was
-// created, and the caller must be the original creator of the monitor.
-//
-// Certain configuration fields, such as output asset identifiers, cannot be
-// updated.
-func (a *QualityMonitorsAPI) Update(ctx context.Context, request UpdateMonitor) (*MonitorInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type RegisteredModelsInterface interface {
@@ -3206,7 +2635,7 @@ type RegisteredModelsInterface interface {
 
 func NewRegisteredModels(client *client.DatabricksClient) *RegisteredModelsAPI {
 	return &RegisteredModelsAPI{
-		impl: &registeredModelsImpl{
+		RegisteredModelsService: &registeredModelsImpl{
 			client: client,
 		},
 	}
@@ -3244,52 +2673,22 @@ func NewRegisteredModels(client *client.DatabricksClient) *RegisteredModelsAPI {
 type RegisteredModelsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(RegisteredModelsService)
-	impl RegisteredModelsService
+	RegisteredModelsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRegisteredModelsInterface instead.
 func (a *RegisteredModelsAPI) WithImpl(impl RegisteredModelsService) RegisteredModelsInterface {
-	a.impl = impl
-	return a
+	return &RegisteredModelsAPI{
+		RegisteredModelsService: impl,
+	}
 }
 
 // Impl returns low-level RegisteredModels API implementation
 // Deprecated: use MockRegisteredModelsInterface instead.
 func (a *RegisteredModelsAPI) Impl() RegisteredModelsService {
-	return a.impl
-}
-
-// Create a Registered Model.
-//
-// Creates a new registered model in Unity Catalog.
-//
-// File storage for model versions in the registered model will be located in
-// the default location which is specified by the parent schema, or the parent
-// catalog, or the Metastore.
-//
-// For registered model creation to succeed, the user must satisfy the following
-// conditions: - The caller must be a metastore admin, or be the owner of the
-// parent catalog and schema, or have the **USE_CATALOG** privilege on the
-// parent catalog and the **USE_SCHEMA** privilege on the parent schema. - The
-// caller must have the **CREATE MODEL** or **CREATE FUNCTION** privilege on the
-// parent schema.
-func (a *RegisteredModelsAPI) Create(ctx context.Context, request CreateRegisteredModelRequest) (*RegisteredModelInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a Registered Model.
-//
-// Deletes a registered model and all its model versions from the specified
-// parent catalog and schema.
-//
-// The caller must be a metastore admin or an owner of the registered model. For
-// the latter case, the caller must also be the owner or have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
-func (a *RegisteredModelsAPI) Delete(ctx context.Context, request DeleteRegisteredModelRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.RegisteredModelsService
 }
 
 // Delete a Registered Model.
@@ -3302,7 +2701,7 @@ func (a *RegisteredModelsAPI) Delete(ctx context.Context, request DeleteRegister
 // **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
 // privilege on the parent schema.
 func (a *RegisteredModelsAPI) DeleteByFullName(ctx context.Context, fullName string) error {
-	return a.impl.Delete(ctx, DeleteRegisteredModelRequest{
+	return a.RegisteredModelsService.Delete(ctx, DeleteRegisteredModelRequest{
 		FullName: fullName,
 	})
 }
@@ -3315,20 +2714,8 @@ func (a *RegisteredModelsAPI) DeleteByFullName(ctx context.Context, fullName str
 // the latter case, the caller must also be the owner or have the
 // **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
 // privilege on the parent schema.
-func (a *RegisteredModelsAPI) DeleteAlias(ctx context.Context, request DeleteAliasRequest) error {
-	return a.impl.DeleteAlias(ctx, request)
-}
-
-// Delete a Registered Model Alias.
-//
-// Deletes a registered model alias.
-//
-// The caller must be a metastore admin or an owner of the registered model. For
-// the latter case, the caller must also be the owner or have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
 func (a *RegisteredModelsAPI) DeleteAliasByFullNameAndAlias(ctx context.Context, fullName string, alias string) error {
-	return a.impl.DeleteAlias(ctx, DeleteAliasRequest{
+	return a.RegisteredModelsService.DeleteAlias(ctx, DeleteAliasRequest{
 		FullName: fullName,
 		Alias:    alias,
 	})
@@ -3342,20 +2729,8 @@ func (a *RegisteredModelsAPI) DeleteAliasByFullNameAndAlias(ctx context.Context,
 // privilege on) the registered model. For the latter case, the caller must also
 // be the owner or have the **USE_CATALOG** privilege on the parent catalog and
 // the **USE_SCHEMA** privilege on the parent schema.
-func (a *RegisteredModelsAPI) Get(ctx context.Context, request GetRegisteredModelRequest) (*RegisteredModelInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a Registered Model.
-//
-// Get a registered model.
-//
-// The caller must be a metastore admin or an owner of (or have the **EXECUTE**
-// privilege on) the registered model. For the latter case, the caller must also
-// be the owner or have the **USE_CATALOG** privilege on the parent catalog and
-// the **USE_SCHEMA** privilege on the parent schema.
 func (a *RegisteredModelsAPI) GetByFullName(ctx context.Context, fullName string) (*RegisteredModelInfo, error) {
-	return a.impl.Get(ctx, GetRegisteredModelRequest{
+	return a.RegisteredModelsService.Get(ctx, GetRegisteredModelRequest{
 		FullName: fullName,
 	})
 }
@@ -3380,7 +2755,7 @@ func (a *RegisteredModelsAPI) List(ctx context.Context, request ListRegisteredMo
 
 	getNextPage := func(ctx context.Context, req ListRegisteredModelsRequest) (*ListRegisteredModelsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.RegisteredModelsService.List(ctx, req)
 	}
 	getItems := func(resp *ListRegisteredModelsResponse) []RegisteredModelInfo {
 		return resp.RegisteredModels
@@ -3473,33 +2848,6 @@ func (a *RegisteredModelsAPI) GetByName(ctx context.Context, name string) (*Regi
 		return nil, fmt.Errorf("there are %d instances of RegisteredModelInfo named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Set a Registered Model Alias.
-//
-// Set an alias on the specified registered model.
-//
-// The caller must be a metastore admin or an owner of the registered model. For
-// the latter case, the caller must also be the owner or have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
-func (a *RegisteredModelsAPI) SetAlias(ctx context.Context, request SetRegisteredModelAliasRequest) (*RegisteredModelAlias, error) {
-	return a.impl.SetAlias(ctx, request)
-}
-
-// Update a Registered Model.
-//
-// Updates the specified registered model.
-//
-// The caller must be a metastore admin or an owner of the registered model. For
-// the latter case, the caller must also be the owner or have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
-//
-// Currently only the name, the owner or the comment of the registered model can
-// be updated.
-func (a *RegisteredModelsAPI) Update(ctx context.Context, request UpdateRegisteredModelRequest) (*RegisteredModelInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type SchemasInterface interface {
@@ -3597,7 +2945,7 @@ type SchemasInterface interface {
 
 func NewSchemas(client *client.DatabricksClient) *SchemasAPI {
 	return &SchemasAPI{
-		impl: &schemasImpl{
+		SchemasService: &schemasImpl{
 			client: client,
 		},
 	}
@@ -3611,38 +2959,22 @@ func NewSchemas(client *client.DatabricksClient) *SchemasAPI {
 type SchemasAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(SchemasService)
-	impl SchemasService
+	SchemasService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSchemasInterface instead.
 func (a *SchemasAPI) WithImpl(impl SchemasService) SchemasInterface {
-	a.impl = impl
-	return a
+	return &SchemasAPI{
+		SchemasService: impl,
+	}
 }
 
 // Impl returns low-level Schemas API implementation
 // Deprecated: use MockSchemasInterface instead.
 func (a *SchemasAPI) Impl() SchemasService {
-	return a.impl
-}
-
-// Create a schema.
-//
-// Creates a new schema for catalog in the Metatastore. The caller must be a
-// metastore admin, or have the **CREATE_SCHEMA** privilege in the parent
-// catalog.
-func (a *SchemasAPI) Create(ctx context.Context, request CreateSchema) (*SchemaInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a schema.
-//
-// Deletes the specified schema from the parent catalog. The caller must be the
-// owner of the schema or an owner of the parent catalog.
-func (a *SchemasAPI) Delete(ctx context.Context, request DeleteSchemaRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.SchemasService
 }
 
 // Delete a schema.
@@ -3650,7 +2982,7 @@ func (a *SchemasAPI) Delete(ctx context.Context, request DeleteSchemaRequest) er
 // Deletes the specified schema from the parent catalog. The caller must be the
 // owner of the schema or an owner of the parent catalog.
 func (a *SchemasAPI) DeleteByFullName(ctx context.Context, fullName string) error {
-	return a.impl.Delete(ctx, DeleteSchemaRequest{
+	return a.SchemasService.Delete(ctx, DeleteSchemaRequest{
 		FullName: fullName,
 	})
 }
@@ -3660,17 +2992,8 @@ func (a *SchemasAPI) DeleteByFullName(ctx context.Context, fullName string) erro
 // Gets the specified schema within the metastore. The caller must be a
 // metastore admin, the owner of the schema, or a user that has the
 // **USE_SCHEMA** privilege on the schema.
-func (a *SchemasAPI) Get(ctx context.Context, request GetSchemaRequest) (*SchemaInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a schema.
-//
-// Gets the specified schema within the metastore. The caller must be a
-// metastore admin, the owner of the schema, or a user that has the
-// **USE_SCHEMA** privilege on the schema.
 func (a *SchemasAPI) GetByFullName(ctx context.Context, fullName string) (*SchemaInfo, error) {
-	return a.impl.Get(ctx, GetSchemaRequest{
+	return a.SchemasService.Get(ctx, GetSchemaRequest{
 		FullName: fullName,
 	})
 }
@@ -3688,7 +3011,7 @@ func (a *SchemasAPI) List(ctx context.Context, request ListSchemasRequest) listi
 
 	getNextPage := func(ctx context.Context, req ListSchemasRequest) (*ListSchemasResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.SchemasService.List(ctx, req)
 	}
 	getItems := func(resp *ListSchemasResponse) []SchemaInfo {
 		return resp.Schemas
@@ -3774,17 +3097,6 @@ func (a *SchemasAPI) GetByName(ctx context.Context, name string) (*SchemaInfo, e
 		return nil, fmt.Errorf("there are %d instances of SchemaInfo named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update a schema.
-//
-// Updates a schema for a catalog. The caller must be the owner of the schema or
-// a metastore admin. If the caller is a metastore admin, only the __owner__
-// field can be changed in the update. If the __name__ field must be updated,
-// the caller must be a metastore admin or have the **CREATE_SCHEMA** privilege
-// on the parent catalog.
-func (a *SchemasAPI) Update(ctx context.Context, request UpdateSchema) (*SchemaInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type StorageCredentialsInterface interface {
@@ -3883,7 +3195,7 @@ type StorageCredentialsInterface interface {
 
 func NewStorageCredentials(client *client.DatabricksClient) *StorageCredentialsAPI {
 	return &StorageCredentialsAPI{
-		impl: &storageCredentialsImpl{
+		StorageCredentialsService: &storageCredentialsImpl{
 			client: client,
 		},
 	}
@@ -3905,36 +3217,22 @@ func NewStorageCredentials(client *client.DatabricksClient) *StorageCredentialsA
 type StorageCredentialsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(StorageCredentialsService)
-	impl StorageCredentialsService
+	StorageCredentialsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockStorageCredentialsInterface instead.
 func (a *StorageCredentialsAPI) WithImpl(impl StorageCredentialsService) StorageCredentialsInterface {
-	a.impl = impl
-	return a
+	return &StorageCredentialsAPI{
+		StorageCredentialsService: impl,
+	}
 }
 
 // Impl returns low-level StorageCredentials API implementation
 // Deprecated: use MockStorageCredentialsInterface instead.
 func (a *StorageCredentialsAPI) Impl() StorageCredentialsService {
-	return a.impl
-}
-
-// Create a storage credential.
-//
-// Creates a new storage credential.
-func (a *StorageCredentialsAPI) Create(ctx context.Context, request CreateStorageCredential) (*StorageCredentialInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a credential.
-//
-// Deletes a storage credential from the metastore. The caller must be an owner
-// of the storage credential.
-func (a *StorageCredentialsAPI) Delete(ctx context.Context, request DeleteStorageCredentialRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.StorageCredentialsService
 }
 
 // Delete a credential.
@@ -3942,7 +3240,7 @@ func (a *StorageCredentialsAPI) Delete(ctx context.Context, request DeleteStorag
 // Deletes a storage credential from the metastore. The caller must be an owner
 // of the storage credential.
 func (a *StorageCredentialsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteStorageCredentialRequest{
+	return a.StorageCredentialsService.Delete(ctx, DeleteStorageCredentialRequest{
 		Name: name,
 	})
 }
@@ -3952,17 +3250,8 @@ func (a *StorageCredentialsAPI) DeleteByName(ctx context.Context, name string) e
 // Gets a storage credential from the metastore. The caller must be a metastore
 // admin, the owner of the storage credential, or have some permission on the
 // storage credential.
-func (a *StorageCredentialsAPI) Get(ctx context.Context, request GetStorageCredentialRequest) (*StorageCredentialInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a credential.
-//
-// Gets a storage credential from the metastore. The caller must be a metastore
-// admin, the owner of the storage credential, or have some permission on the
-// storage credential.
 func (a *StorageCredentialsAPI) GetByName(ctx context.Context, name string) (*StorageCredentialInfo, error) {
-	return a.impl.Get(ctx, GetStorageCredentialRequest{
+	return a.StorageCredentialsService.Get(ctx, GetStorageCredentialRequest{
 		Name: name,
 	})
 }
@@ -3980,7 +3269,7 @@ func (a *StorageCredentialsAPI) List(ctx context.Context, request ListStorageCre
 
 	getNextPage := func(ctx context.Context, req ListStorageCredentialsRequest) (*ListStorageCredentialsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.StorageCredentialsService.List(ctx, req)
 	}
 	getItems := func(resp *ListStorageCredentialsResponse) []StorageCredentialInfo {
 		return resp.StorageCredentials
@@ -4040,31 +3329,6 @@ func (a *StorageCredentialsAPI) StorageCredentialInfoNameToIdMap(ctx context.Con
 	return mapping, nil
 }
 
-// Update a credential.
-//
-// Updates a storage credential on the metastore.
-func (a *StorageCredentialsAPI) Update(ctx context.Context, request UpdateStorageCredential) (*StorageCredentialInfo, error) {
-	return a.impl.Update(ctx, request)
-}
-
-// Validate a storage credential.
-//
-// Validates a storage credential. At least one of __external_location_name__
-// and __url__ need to be provided. If only one of them is provided, it will be
-// used for validation. And if both are provided, the __url__ will be used for
-// validation, and __external_location_name__ will be ignored when checking
-// overlapping urls.
-//
-// Either the __storage_credential_name__ or the cloud-specific credential must
-// be provided.
-//
-// The caller must be a metastore admin or the storage credential owner or have
-// the **CREATE_EXTERNAL_LOCATION** privilege on the metastore and the storage
-// credential.
-func (a *StorageCredentialsAPI) Validate(ctx context.Context, request ValidateStorageCredential) (*ValidateStorageCredentialResponse, error) {
-	return a.impl.Validate(ctx, request)
-}
-
 type SystemSchemasInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -4118,7 +3382,7 @@ type SystemSchemasInterface interface {
 
 func NewSystemSchemas(client *client.DatabricksClient) *SystemSchemasAPI {
 	return &SystemSchemasAPI{
-		impl: &systemSchemasImpl{
+		SystemSchemasService: &systemSchemasImpl{
 			client: client,
 		},
 	}
@@ -4130,29 +3394,22 @@ func NewSystemSchemas(client *client.DatabricksClient) *SystemSchemasAPI {
 type SystemSchemasAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(SystemSchemasService)
-	impl SystemSchemasService
+	SystemSchemasService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSystemSchemasInterface instead.
 func (a *SystemSchemasAPI) WithImpl(impl SystemSchemasService) SystemSchemasInterface {
-	a.impl = impl
-	return a
+	return &SystemSchemasAPI{
+		SystemSchemasService: impl,
+	}
 }
 
 // Impl returns low-level SystemSchemas API implementation
 // Deprecated: use MockSystemSchemasInterface instead.
 func (a *SystemSchemasAPI) Impl() SystemSchemasService {
-	return a.impl
-}
-
-// Disable a system schema.
-//
-// Disables the system schema and removes it from the system catalog. The caller
-// must be an account admin or a metastore admin.
-func (a *SystemSchemasAPI) Disable(ctx context.Context, request DisableRequest) error {
-	return a.impl.Disable(ctx, request)
+	return a.SystemSchemasService
 }
 
 // Disable a system schema.
@@ -4160,18 +3417,10 @@ func (a *SystemSchemasAPI) Disable(ctx context.Context, request DisableRequest) 
 // Disables the system schema and removes it from the system catalog. The caller
 // must be an account admin or a metastore admin.
 func (a *SystemSchemasAPI) DisableByMetastoreIdAndSchemaName(ctx context.Context, metastoreId string, schemaName string) error {
-	return a.impl.Disable(ctx, DisableRequest{
+	return a.SystemSchemasService.Disable(ctx, DisableRequest{
 		MetastoreId: metastoreId,
 		SchemaName:  schemaName,
 	})
-}
-
-// Enable a system schema.
-//
-// Enables the system schema and adds it to the system catalog. The caller must
-// be an account admin or a metastore admin.
-func (a *SystemSchemasAPI) Enable(ctx context.Context, request EnableRequest) error {
-	return a.impl.Enable(ctx, request)
 }
 
 // List system schemas.
@@ -4184,7 +3433,7 @@ func (a *SystemSchemasAPI) List(ctx context.Context, request ListSystemSchemasRe
 
 	getNextPage := func(ctx context.Context, req ListSystemSchemasRequest) (*ListSystemSchemasResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.SystemSchemasService.List(ctx, req)
 	}
 	getItems := func(resp *ListSystemSchemasResponse) []SystemSchemaInfo {
 		return resp.Schemas
@@ -4214,7 +3463,7 @@ func (a *SystemSchemasAPI) ListAll(ctx context.Context, request ListSystemSchema
 // Gets an array of system schemas for a metastore. The caller must be an
 // account admin or a metastore admin.
 func (a *SystemSchemasAPI) ListByMetastoreId(ctx context.Context, metastoreId string) (*ListSystemSchemasResponse, error) {
-	return a.impl.List(ctx, ListSystemSchemasRequest{
+	return a.SystemSchemasService.List(ctx, ListSystemSchemasRequest{
 		MetastoreId: metastoreId,
 	})
 }
@@ -4272,7 +3521,7 @@ type TableConstraintsInterface interface {
 
 func NewTableConstraints(client *client.DatabricksClient) *TableConstraintsAPI {
 	return &TableConstraintsAPI{
-		impl: &tableConstraintsImpl{
+		TableConstraintsService: &tableConstraintsImpl{
 			client: client,
 		},
 	}
@@ -4294,52 +3543,22 @@ func NewTableConstraints(client *client.DatabricksClient) *TableConstraintsAPI {
 type TableConstraintsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(TableConstraintsService)
-	impl TableConstraintsService
+	TableConstraintsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTableConstraintsInterface instead.
 func (a *TableConstraintsAPI) WithImpl(impl TableConstraintsService) TableConstraintsInterface {
-	a.impl = impl
-	return a
+	return &TableConstraintsAPI{
+		TableConstraintsService: impl,
+	}
 }
 
 // Impl returns low-level TableConstraints API implementation
 // Deprecated: use MockTableConstraintsInterface instead.
 func (a *TableConstraintsAPI) Impl() TableConstraintsService {
-	return a.impl
-}
-
-// Create a table constraint.
-//
-// Creates a new table constraint.
-//
-// For the table constraint creation to succeed, the user must satisfy both of
-// these conditions: - the user must have the **USE_CATALOG** privilege on the
-// table's parent catalog, the **USE_SCHEMA** privilege on the table's parent
-// schema, and be the owner of the table. - if the new constraint is a
-// __ForeignKeyConstraint__, the user must have the **USE_CATALOG** privilege on
-// the referenced parent table's catalog, the **USE_SCHEMA** privilege on the
-// referenced parent table's schema, and be the owner of the referenced parent
-// table.
-func (a *TableConstraintsAPI) Create(ctx context.Context, request CreateTableConstraint) (*TableConstraint, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a table constraint.
-//
-// Deletes a table constraint.
-//
-// For the table constraint deletion to succeed, the user must satisfy both of
-// these conditions: - the user must have the **USE_CATALOG** privilege on the
-// table's parent catalog, the **USE_SCHEMA** privilege on the table's parent
-// schema, and be the owner of the table. - if __cascade__ argument is **true**,
-// the user must have the following permissions on all of the child tables: the
-// **USE_CATALOG** privilege on the table's catalog, the **USE_SCHEMA**
-// privilege on the table's schema, and be the owner of the table.
-func (a *TableConstraintsAPI) Delete(ctx context.Context, request DeleteTableConstraintRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.TableConstraintsService
 }
 
 // Delete a table constraint.
@@ -4354,7 +3573,7 @@ func (a *TableConstraintsAPI) Delete(ctx context.Context, request DeleteTableCon
 // **USE_CATALOG** privilege on the table's catalog, the **USE_SCHEMA**
 // privilege on the table's schema, and be the owner of the table.
 func (a *TableConstraintsAPI) DeleteByFullName(ctx context.Context, fullName string) error {
-	return a.impl.Delete(ctx, DeleteTableConstraintRequest{
+	return a.TableConstraintsService.Delete(ctx, DeleteTableConstraintRequest{
 		FullName: fullName,
 	})
 }
@@ -4521,7 +3740,7 @@ type TablesInterface interface {
 
 func NewTables(client *client.DatabricksClient) *TablesAPI {
 	return &TablesAPI{
-		impl: &tablesImpl{
+		TablesService: &tablesImpl{
 			client: client,
 		},
 	}
@@ -4540,32 +3759,22 @@ func NewTables(client *client.DatabricksClient) *TablesAPI {
 type TablesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(TablesService)
-	impl TablesService
+	TablesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTablesInterface instead.
 func (a *TablesAPI) WithImpl(impl TablesService) TablesInterface {
-	a.impl = impl
-	return a
+	return &TablesAPI{
+		TablesService: impl,
+	}
 }
 
 // Impl returns low-level Tables API implementation
 // Deprecated: use MockTablesInterface instead.
 func (a *TablesAPI) Impl() TablesService {
-	return a.impl
-}
-
-// Delete a table.
-//
-// Deletes a table from the specified parent catalog and schema. The caller must
-// be the owner of the parent catalog, have the **USE_CATALOG** privilege on the
-// parent catalog and be the owner of the parent schema, or be the owner of the
-// table and have the **USE_CATALOG** privilege on the parent catalog and the
-// **USE_SCHEMA** privilege on the parent schema.
-func (a *TablesAPI) Delete(ctx context.Context, request DeleteTableRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.TablesService
 }
 
 // Delete a table.
@@ -4576,23 +3785,9 @@ func (a *TablesAPI) Delete(ctx context.Context, request DeleteTableRequest) erro
 // table and have the **USE_CATALOG** privilege on the parent catalog and the
 // **USE_SCHEMA** privilege on the parent schema.
 func (a *TablesAPI) DeleteByFullName(ctx context.Context, fullName string) error {
-	return a.impl.Delete(ctx, DeleteTableRequest{
+	return a.TablesService.Delete(ctx, DeleteTableRequest{
 		FullName: fullName,
 	})
-}
-
-// Get boolean reflecting if table exists.
-//
-// Gets if a table exists in the metastore for a specific catalog and schema.
-// The caller must satisfy one of the following requirements: * Be a metastore
-// admin * Be the owner of the parent catalog * Be the owner of the parent
-// schema and have the USE_CATALOG privilege on the parent catalog * Have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema, and either be the table owner or have the
-// SELECT privilege on the table. * Have BROWSE privilege on the parent catalog
-// * Have BROWSE privilege on the parent schema.
-func (a *TablesAPI) Exists(ctx context.Context, request ExistsRequest) (*TableExistsResponse, error) {
-	return a.impl.Exists(ctx, request)
 }
 
 // Get boolean reflecting if table exists.
@@ -4606,7 +3801,7 @@ func (a *TablesAPI) Exists(ctx context.Context, request ExistsRequest) (*TableEx
 // SELECT privilege on the table. * Have BROWSE privilege on the parent catalog
 // * Have BROWSE privilege on the parent schema.
 func (a *TablesAPI) ExistsByFullName(ctx context.Context, fullName string) (*TableExistsResponse, error) {
-	return a.impl.Exists(ctx, ExistsRequest{
+	return a.TablesService.Exists(ctx, ExistsRequest{
 		FullName: fullName,
 	})
 }
@@ -4620,21 +3815,8 @@ func (a *TablesAPI) ExistsByFullName(ctx context.Context, fullName string) (*Tab
 // privilege on the parent catalog and the **USE_SCHEMA** privilege on the
 // parent schema, and either be the table owner or have the SELECT privilege on
 // the table.
-func (a *TablesAPI) Get(ctx context.Context, request GetTableRequest) (*TableInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a table.
-//
-// Gets a table from the metastore for a specific catalog and schema. The caller
-// must satisfy one of the following requirements: * Be a metastore admin * Be
-// the owner of the parent catalog * Be the owner of the parent schema and have
-// the USE_CATALOG privilege on the parent catalog * Have the **USE_CATALOG**
-// privilege on the parent catalog and the **USE_SCHEMA** privilege on the
-// parent schema, and either be the table owner or have the SELECT privilege on
-// the table.
 func (a *TablesAPI) GetByFullName(ctx context.Context, fullName string) (*TableInfo, error) {
-	return a.impl.Get(ctx, GetTableRequest{
+	return a.TablesService.Get(ctx, GetTableRequest{
 		FullName: fullName,
 	})
 }
@@ -4653,7 +3835,7 @@ func (a *TablesAPI) List(ctx context.Context, request ListTablesRequest) listing
 
 	getNextPage := func(ctx context.Context, req ListTablesRequest) (*ListTablesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.TablesService.List(ctx, req)
 	}
 	getItems := func(resp *ListTablesResponse) []TableInfo {
 		return resp.Tables
@@ -4761,7 +3943,7 @@ func (a *TablesAPI) ListSummaries(ctx context.Context, request ListSummariesRequ
 
 	getNextPage := func(ctx context.Context, req ListSummariesRequest) (*ListTableSummariesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListSummaries(ctx, req)
+		return a.TablesService.ListSummaries(ctx, req)
 	}
 	getItems := func(resp *ListTableSummariesResponse) []TableSummary {
 		return resp.Tables
@@ -4800,17 +3982,6 @@ func (a *TablesAPI) ListSummariesAll(ctx context.Context, request ListSummariesR
 	iterator := a.ListSummaries(ctx, request)
 	return listing.ToSliceN[TableSummary, int](ctx, iterator, request.MaxResults)
 
-}
-
-// Update a table owner.
-//
-// Change the owner of the table. The caller must be the owner of the parent
-// catalog, have the **USE_CATALOG** privilege on the parent catalog and be the
-// owner of the parent schema, or be the owner of the table and have the
-// **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-// privilege on the parent schema.
-func (a *TablesAPI) Update(ctx context.Context, request UpdateTableRequest) error {
-	return a.impl.Update(ctx, request)
 }
 
 type VolumesInterface interface {
@@ -4953,7 +4124,7 @@ type VolumesInterface interface {
 
 func NewVolumes(client *client.DatabricksClient) *VolumesAPI {
 	return &VolumesAPI{
-		impl: &volumesImpl{
+		VolumesService: &volumesImpl{
 			client: client,
 		},
 	}
@@ -4970,57 +4141,22 @@ func NewVolumes(client *client.DatabricksClient) *VolumesAPI {
 type VolumesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(VolumesService)
-	impl VolumesService
+	VolumesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVolumesInterface instead.
 func (a *VolumesAPI) WithImpl(impl VolumesService) VolumesInterface {
-	a.impl = impl
-	return a
+	return &VolumesAPI{
+		VolumesService: impl,
+	}
 }
 
 // Impl returns low-level Volumes API implementation
 // Deprecated: use MockVolumesInterface instead.
 func (a *VolumesAPI) Impl() VolumesService {
-	return a.impl
-}
-
-// Create a Volume.
-//
-// Creates a new volume.
-//
-// The user could create either an external volume or a managed volume. An
-// external volume will be created in the specified external location, while a
-// managed volume will be located in the default location which is specified by
-// the parent schema, or the parent catalog, or the Metastore.
-//
-// For the volume creation to succeed, the user must satisfy following
-// conditions: - The caller must be a metastore admin, or be the owner of the
-// parent catalog and schema, or have the **USE_CATALOG** privilege on the
-// parent catalog and the **USE_SCHEMA** privilege on the parent schema. - The
-// caller must have **CREATE VOLUME** privilege on the parent schema.
-//
-// For an external volume, following conditions also need to satisfy - The
-// caller must have **CREATE EXTERNAL VOLUME** privilege on the external
-// location. - There are no other tables, nor volumes existing in the specified
-// storage location. - The specified storage location is not under the location
-// of other tables, nor volumes, or catalogs or schemas.
-func (a *VolumesAPI) Create(ctx context.Context, request CreateVolumeRequestContent) (*VolumeInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a Volume.
-//
-// Deletes a volume from the specified parent catalog and schema.
-//
-// The caller must be a metastore admin or an owner of the volume. For the
-// latter case, the caller must also be the owner or have the **USE_CATALOG**
-// privilege on the parent catalog and the **USE_SCHEMA** privilege on the
-// parent schema.
-func (a *VolumesAPI) Delete(ctx context.Context, request DeleteVolumeRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.VolumesService
 }
 
 // Delete a Volume.
@@ -5032,7 +4168,7 @@ func (a *VolumesAPI) Delete(ctx context.Context, request DeleteVolumeRequest) er
 // privilege on the parent catalog and the **USE_SCHEMA** privilege on the
 // parent schema.
 func (a *VolumesAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteVolumeRequest{
+	return a.VolumesService.Delete(ctx, DeleteVolumeRequest{
 		Name: name,
 	})
 }
@@ -5056,7 +4192,7 @@ func (a *VolumesAPI) List(ctx context.Context, request ListVolumesRequest) listi
 
 	getNextPage := func(ctx context.Context, req ListVolumesRequest) (*ListVolumesResponseContent, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.VolumesService.List(ctx, req)
 	}
 	getItems := func(resp *ListVolumesResponseContent) []VolumeInfo {
 		return resp.Volumes
@@ -5158,37 +4294,10 @@ func (a *VolumesAPI) GetByName(ctx context.Context, name string) (*VolumeInfo, e
 // VOLUME** privilege on) the volume. For the latter case, the caller must also
 // be the owner or have the **USE_CATALOG** privilege on the parent catalog and
 // the **USE_SCHEMA** privilege on the parent schema.
-func (a *VolumesAPI) Read(ctx context.Context, request ReadVolumeRequest) (*VolumeInfo, error) {
-	return a.impl.Read(ctx, request)
-}
-
-// Get a Volume.
-//
-// Gets a volume from the metastore for a specific catalog and schema.
-//
-// The caller must be a metastore admin or an owner of (or have the **READ
-// VOLUME** privilege on) the volume. For the latter case, the caller must also
-// be the owner or have the **USE_CATALOG** privilege on the parent catalog and
-// the **USE_SCHEMA** privilege on the parent schema.
 func (a *VolumesAPI) ReadByName(ctx context.Context, name string) (*VolumeInfo, error) {
-	return a.impl.Read(ctx, ReadVolumeRequest{
+	return a.VolumesService.Read(ctx, ReadVolumeRequest{
 		Name: name,
 	})
-}
-
-// Update a Volume.
-//
-// Updates the specified volume under the specified parent catalog and schema.
-//
-// The caller must be a metastore admin or an owner of the volume. For the
-// latter case, the caller must also be the owner or have the **USE_CATALOG**
-// privilege on the parent catalog and the **USE_SCHEMA** privilege on the
-// parent schema.
-//
-// Currently only the name, the owner or the comment of the volume could be
-// updated.
-func (a *VolumesAPI) Update(ctx context.Context, request UpdateVolumeRequestContent) (*VolumeInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type WorkspaceBindingsInterface interface {
@@ -5240,7 +4349,7 @@ type WorkspaceBindingsInterface interface {
 
 func NewWorkspaceBindings(client *client.DatabricksClient) *WorkspaceBindingsAPI {
 	return &WorkspaceBindingsAPI{
-		impl: &workspaceBindingsImpl{
+		WorkspaceBindingsService: &workspaceBindingsImpl{
 			client: client,
 		},
 	}
@@ -5268,29 +4377,22 @@ func NewWorkspaceBindings(client *client.DatabricksClient) *WorkspaceBindingsAPI
 type WorkspaceBindingsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(WorkspaceBindingsService)
-	impl WorkspaceBindingsService
+	WorkspaceBindingsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceBindingsInterface instead.
 func (a *WorkspaceBindingsAPI) WithImpl(impl WorkspaceBindingsService) WorkspaceBindingsInterface {
-	a.impl = impl
-	return a
+	return &WorkspaceBindingsAPI{
+		WorkspaceBindingsService: impl,
+	}
 }
 
 // Impl returns low-level WorkspaceBindings API implementation
 // Deprecated: use MockWorkspaceBindingsInterface instead.
 func (a *WorkspaceBindingsAPI) Impl() WorkspaceBindingsService {
-	return a.impl
-}
-
-// Get catalog workspace bindings.
-//
-// Gets workspace bindings of the catalog. The caller must be a metastore admin
-// or an owner of the catalog.
-func (a *WorkspaceBindingsAPI) Get(ctx context.Context, request GetWorkspaceBindingRequest) (*CurrentWorkspaceBindings, error) {
-	return a.impl.Get(ctx, request)
+	return a.WorkspaceBindingsService
 }
 
 // Get catalog workspace bindings.
@@ -5298,7 +4400,7 @@ func (a *WorkspaceBindingsAPI) Get(ctx context.Context, request GetWorkspaceBind
 // Gets workspace bindings of the catalog. The caller must be a metastore admin
 // or an owner of the catalog.
 func (a *WorkspaceBindingsAPI) GetByName(ctx context.Context, name string) (*CurrentWorkspaceBindings, error) {
-	return a.impl.Get(ctx, GetWorkspaceBindingRequest{
+	return a.WorkspaceBindingsService.Get(ctx, GetWorkspaceBindingRequest{
 		Name: name,
 	})
 }
@@ -5307,33 +4409,9 @@ func (a *WorkspaceBindingsAPI) GetByName(ctx context.Context, name string) (*Cur
 //
 // Gets workspace bindings of the securable. The caller must be a metastore
 // admin or an owner of the securable.
-func (a *WorkspaceBindingsAPI) GetBindings(ctx context.Context, request GetBindingsRequest) (*WorkspaceBindingsResponse, error) {
-	return a.impl.GetBindings(ctx, request)
-}
-
-// Get securable workspace bindings.
-//
-// Gets workspace bindings of the securable. The caller must be a metastore
-// admin or an owner of the securable.
 func (a *WorkspaceBindingsAPI) GetBindingsBySecurableTypeAndSecurableName(ctx context.Context, securableType GetBindingsSecurableType, securableName string) (*WorkspaceBindingsResponse, error) {
-	return a.impl.GetBindings(ctx, GetBindingsRequest{
+	return a.WorkspaceBindingsService.GetBindings(ctx, GetBindingsRequest{
 		SecurableType: securableType,
 		SecurableName: securableName,
 	})
-}
-
-// Update catalog workspace bindings.
-//
-// Updates workspace bindings of the catalog. The caller must be a metastore
-// admin or an owner of the catalog.
-func (a *WorkspaceBindingsAPI) Update(ctx context.Context, request UpdateWorkspaceBindings) (*CurrentWorkspaceBindings, error) {
-	return a.impl.Update(ctx, request)
-}
-
-// Update securable workspace bindings.
-//
-// Updates workspace bindings of the securable. The caller must be a metastore
-// admin or an owner of the securable.
-func (a *WorkspaceBindingsAPI) UpdateBindings(ctx context.Context, request UpdateWorkspaceBindingsParameters) (*WorkspaceBindingsResponse, error) {
-	return a.impl.UpdateBindings(ctx, request)
 }

--- a/service/catalog/api.go
+++ b/service/catalog/api.go
@@ -103,9 +103,8 @@ type AccountMetastoreAssignmentsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountMetastoreAssignmentsInterface instead.
 func (a *AccountMetastoreAssignmentsAPI) WithImpl(impl AccountMetastoreAssignmentsService) AccountMetastoreAssignmentsInterface {
-	return &AccountMetastoreAssignmentsAPI{
-		AccountMetastoreAssignmentsService: impl,
-	}
+	a.AccountMetastoreAssignmentsService = impl
+	return a
 }
 
 // Impl returns low-level AccountMetastoreAssignments API implementation
@@ -257,9 +256,8 @@ type AccountMetastoresAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountMetastoresInterface instead.
 func (a *AccountMetastoresAPI) WithImpl(impl AccountMetastoresService) AccountMetastoresInterface {
-	return &AccountMetastoresAPI{
-		AccountMetastoresService: impl,
-	}
+	a.AccountMetastoresService = impl
+	return a
 }
 
 // Impl returns low-level AccountMetastores API implementation
@@ -417,9 +415,8 @@ type AccountStorageCredentialsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountStorageCredentialsInterface instead.
 func (a *AccountStorageCredentialsAPI) WithImpl(impl AccountStorageCredentialsService) AccountStorageCredentialsInterface {
-	return &AccountStorageCredentialsAPI{
-		AccountStorageCredentialsService: impl,
-	}
+	a.AccountStorageCredentialsService = impl
+	return a
 }
 
 // Impl returns low-level AccountStorageCredentials API implementation
@@ -547,9 +544,8 @@ type ArtifactAllowlistsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockArtifactAllowlistsInterface instead.
 func (a *ArtifactAllowlistsAPI) WithImpl(impl ArtifactAllowlistsService) ArtifactAllowlistsInterface {
-	return &ArtifactAllowlistsAPI{
-		ArtifactAllowlistsService: impl,
-	}
+	a.ArtifactAllowlistsService = impl
+	return a
 }
 
 // Impl returns low-level ArtifactAllowlists API implementation
@@ -666,9 +662,8 @@ type CatalogsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCatalogsInterface instead.
 func (a *CatalogsAPI) WithImpl(impl CatalogsService) CatalogsInterface {
-	return &CatalogsAPI{
-		CatalogsService: impl,
-	}
+	a.CatalogsService = impl
+	return a
 }
 
 // Impl returns low-level Catalogs API implementation
@@ -843,9 +838,8 @@ type ConnectionsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConnectionsInterface instead.
 func (a *ConnectionsAPI) WithImpl(impl ConnectionsService) ConnectionsInterface {
-	return &ConnectionsAPI{
-		ConnectionsService: impl,
-	}
+	a.ConnectionsService = impl
+	return a
 }
 
 // Impl returns low-level Connections API implementation
@@ -1041,9 +1035,8 @@ type ExternalLocationsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockExternalLocationsInterface instead.
 func (a *ExternalLocationsAPI) WithImpl(impl ExternalLocationsService) ExternalLocationsInterface {
-	return &ExternalLocationsAPI{
-		ExternalLocationsService: impl,
-	}
+	a.ExternalLocationsService = impl
+	return a
 }
 
 // Impl returns low-level ExternalLocations API implementation
@@ -1258,9 +1251,8 @@ type FunctionsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockFunctionsInterface instead.
 func (a *FunctionsAPI) WithImpl(impl FunctionsService) FunctionsInterface {
-	return &FunctionsAPI{
-		FunctionsService: impl,
-	}
+	a.FunctionsService = impl
+	return a
 }
 
 // Impl returns low-level Functions API implementation
@@ -1441,9 +1433,8 @@ type GrantsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGrantsInterface instead.
 func (a *GrantsAPI) WithImpl(impl GrantsService) GrantsInterface {
-	return &GrantsAPI{
-		GrantsService: impl,
-	}
+	a.GrantsService = impl
+	return a
 }
 
 // Impl returns low-level Grants API implementation
@@ -1626,9 +1617,8 @@ type MetastoresAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockMetastoresInterface instead.
 func (a *MetastoresAPI) WithImpl(impl MetastoresService) MetastoresInterface {
-	return &MetastoresAPI{
-		MetastoresService: impl,
-	}
+	a.MetastoresService = impl
+	return a
 }
 
 // Impl returns low-level Metastores API implementation
@@ -1921,9 +1911,8 @@ type ModelVersionsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockModelVersionsInterface instead.
 func (a *ModelVersionsAPI) WithImpl(impl ModelVersionsService) ModelVersionsInterface {
-	return &ModelVersionsAPI{
-		ModelVersionsService: impl,
-	}
+	a.ModelVersionsService = impl
+	return a
 }
 
 // Impl returns low-level ModelVersions API implementation
@@ -2123,9 +2112,8 @@ type OnlineTablesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockOnlineTablesInterface instead.
 func (a *OnlineTablesAPI) WithImpl(impl OnlineTablesService) OnlineTablesInterface {
-	return &OnlineTablesAPI{
-		OnlineTablesService: impl,
-	}
+	a.OnlineTablesService = impl
+	return a
 }
 
 // Impl returns low-level OnlineTables API implementation
@@ -2377,9 +2365,8 @@ type QualityMonitorsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQualityMonitorsInterface instead.
 func (a *QualityMonitorsAPI) WithImpl(impl QualityMonitorsService) QualityMonitorsInterface {
-	return &QualityMonitorsAPI{
-		QualityMonitorsService: impl,
-	}
+	a.QualityMonitorsService = impl
+	return a
 }
 
 // Impl returns low-level QualityMonitors API implementation
@@ -2680,9 +2667,8 @@ type RegisteredModelsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRegisteredModelsInterface instead.
 func (a *RegisteredModelsAPI) WithImpl(impl RegisteredModelsService) RegisteredModelsInterface {
-	return &RegisteredModelsAPI{
-		RegisteredModelsService: impl,
-	}
+	a.RegisteredModelsService = impl
+	return a
 }
 
 // Impl returns low-level RegisteredModels API implementation
@@ -2966,9 +2952,8 @@ type SchemasAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSchemasInterface instead.
 func (a *SchemasAPI) WithImpl(impl SchemasService) SchemasInterface {
-	return &SchemasAPI{
-		SchemasService: impl,
-	}
+	a.SchemasService = impl
+	return a
 }
 
 // Impl returns low-level Schemas API implementation
@@ -3224,9 +3209,8 @@ type StorageCredentialsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockStorageCredentialsInterface instead.
 func (a *StorageCredentialsAPI) WithImpl(impl StorageCredentialsService) StorageCredentialsInterface {
-	return &StorageCredentialsAPI{
-		StorageCredentialsService: impl,
-	}
+	a.StorageCredentialsService = impl
+	return a
 }
 
 // Impl returns low-level StorageCredentials API implementation
@@ -3401,9 +3385,8 @@ type SystemSchemasAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSystemSchemasInterface instead.
 func (a *SystemSchemasAPI) WithImpl(impl SystemSchemasService) SystemSchemasInterface {
-	return &SystemSchemasAPI{
-		SystemSchemasService: impl,
-	}
+	a.SystemSchemasService = impl
+	return a
 }
 
 // Impl returns low-level SystemSchemas API implementation
@@ -3550,9 +3533,8 @@ type TableConstraintsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTableConstraintsInterface instead.
 func (a *TableConstraintsAPI) WithImpl(impl TableConstraintsService) TableConstraintsInterface {
-	return &TableConstraintsAPI{
-		TableConstraintsService: impl,
-	}
+	a.TableConstraintsService = impl
+	return a
 }
 
 // Impl returns low-level TableConstraints API implementation
@@ -3766,9 +3748,8 @@ type TablesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTablesInterface instead.
 func (a *TablesAPI) WithImpl(impl TablesService) TablesInterface {
-	return &TablesAPI{
-		TablesService: impl,
-	}
+	a.TablesService = impl
+	return a
 }
 
 // Impl returns low-level Tables API implementation
@@ -4148,9 +4129,8 @@ type VolumesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVolumesInterface instead.
 func (a *VolumesAPI) WithImpl(impl VolumesService) VolumesInterface {
-	return &VolumesAPI{
-		VolumesService: impl,
-	}
+	a.VolumesService = impl
+	return a
 }
 
 // Impl returns low-level Volumes API implementation
@@ -4384,9 +4364,8 @@ type WorkspaceBindingsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceBindingsInterface instead.
 func (a *WorkspaceBindingsAPI) WithImpl(impl WorkspaceBindingsService) WorkspaceBindingsInterface {
-	return &WorkspaceBindingsAPI{
-		WorkspaceBindingsService: impl,
-	}
+	a.WorkspaceBindingsService = impl
+	return a
 }
 
 // Impl returns low-level WorkspaceBindings API implementation

--- a/service/compute/api.go
+++ b/service/compute/api.go
@@ -167,9 +167,8 @@ type ClusterPoliciesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockClusterPoliciesInterface instead.
 func (a *ClusterPoliciesAPI) WithImpl(impl ClusterPoliciesService) ClusterPoliciesInterface {
-	return &ClusterPoliciesAPI{
-		ClusterPoliciesService: impl,
-	}
+	a.ClusterPoliciesService = impl
+	return a
 }
 
 // Impl returns low-level ClusterPolicies API implementation
@@ -672,9 +671,8 @@ type ClustersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockClustersInterface instead.
 func (a *ClustersAPI) WithImpl(impl ClustersService) ClustersInterface {
-	return &ClustersAPI{
-		ClustersService: impl,
-	}
+	a.ClustersService = impl
+	return a
 }
 
 // Impl returns low-level Clusters API implementation
@@ -1454,9 +1452,8 @@ type CommandExecutionAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCommandExecutionInterface instead.
 func (a *CommandExecutionAPI) WithImpl(impl CommandExecutionService) CommandExecutionInterface {
-	return &CommandExecutionAPI{
-		CommandExecutionService: impl,
-	}
+	a.CommandExecutionService = impl
+	return a
 }
 
 // Impl returns low-level CommandExecution API implementation
@@ -1899,9 +1896,8 @@ type GlobalInitScriptsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGlobalInitScriptsInterface instead.
 func (a *GlobalInitScriptsAPI) WithImpl(impl GlobalInitScriptsService) GlobalInitScriptsInterface {
-	return &GlobalInitScriptsAPI{
-		GlobalInitScriptsService: impl,
-	}
+	a.GlobalInitScriptsService = impl
+	return a
 }
 
 // Impl returns low-level GlobalInitScripts API implementation
@@ -2166,9 +2162,8 @@ type InstancePoolsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockInstancePoolsInterface instead.
 func (a *InstancePoolsAPI) WithImpl(impl InstancePoolsService) InstancePoolsInterface {
-	return &InstancePoolsAPI{
-		InstancePoolsService: impl,
-	}
+	a.InstancePoolsService = impl
+	return a
 }
 
 // Impl returns low-level InstancePools API implementation
@@ -2396,9 +2391,8 @@ type InstanceProfilesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockInstanceProfilesInterface instead.
 func (a *InstanceProfilesAPI) WithImpl(impl InstanceProfilesService) InstanceProfilesInterface {
-	return &InstanceProfilesAPI{
-		InstanceProfilesService: impl,
-	}
+	a.InstanceProfilesService = impl
+	return a
 }
 
 // Impl returns low-level InstanceProfiles API implementation
@@ -2569,9 +2563,8 @@ type LibrariesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockLibrariesInterface instead.
 func (a *LibrariesAPI) WithImpl(impl LibrariesService) LibrariesInterface {
-	return &LibrariesAPI{
-		LibrariesService: impl,
-	}
+	a.LibrariesService = impl
+	return a
 }
 
 // Impl returns low-level Libraries API implementation
@@ -2738,9 +2731,8 @@ type PolicyFamiliesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPolicyFamiliesInterface instead.
 func (a *PolicyFamiliesAPI) WithImpl(impl PolicyFamiliesService) PolicyFamiliesInterface {
-	return &PolicyFamiliesAPI{
-		PolicyFamiliesService: impl,
-	}
+	a.PolicyFamiliesService = impl
+	return a
 }
 
 // Impl returns low-level PolicyFamilies API implementation

--- a/service/compute/api.go
+++ b/service/compute/api.go
@@ -128,7 +128,7 @@ type ClusterPoliciesInterface interface {
 
 func NewClusterPolicies(client *client.DatabricksClient) *ClusterPoliciesAPI {
 	return &ClusterPoliciesAPI{
-		impl: &clusterPoliciesImpl{
+		ClusterPoliciesService: &clusterPoliciesImpl{
 			client: client,
 		},
 	}
@@ -160,36 +160,22 @@ func NewClusterPolicies(client *client.DatabricksClient) *ClusterPoliciesAPI {
 type ClusterPoliciesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ClusterPoliciesService)
-	impl ClusterPoliciesService
+	ClusterPoliciesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockClusterPoliciesInterface instead.
 func (a *ClusterPoliciesAPI) WithImpl(impl ClusterPoliciesService) ClusterPoliciesInterface {
-	a.impl = impl
-	return a
+	return &ClusterPoliciesAPI{
+		ClusterPoliciesService: impl,
+	}
 }
 
 // Impl returns low-level ClusterPolicies API implementation
 // Deprecated: use MockClusterPoliciesInterface instead.
 func (a *ClusterPoliciesAPI) Impl() ClusterPoliciesService {
-	return a.impl
-}
-
-// Create a new policy.
-//
-// Creates a new policy with prescribed settings.
-func (a *ClusterPoliciesAPI) Create(ctx context.Context, request CreatePolicy) (*CreatePolicyResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a cluster policy.
-//
-// Delete a policy for a cluster. Clusters governed by this policy can still
-// run, but cannot be edited.
-func (a *ClusterPoliciesAPI) Delete(ctx context.Context, request DeletePolicy) error {
-	return a.impl.Delete(ctx, request)
+	return a.ClusterPoliciesService
 }
 
 // Delete a cluster policy.
@@ -197,25 +183,9 @@ func (a *ClusterPoliciesAPI) Delete(ctx context.Context, request DeletePolicy) e
 // Delete a policy for a cluster. Clusters governed by this policy can still
 // run, but cannot be edited.
 func (a *ClusterPoliciesAPI) DeleteByPolicyId(ctx context.Context, policyId string) error {
-	return a.impl.Delete(ctx, DeletePolicy{
+	return a.ClusterPoliciesService.Delete(ctx, DeletePolicy{
 		PolicyId: policyId,
 	})
-}
-
-// Update a cluster policy.
-//
-// Update an existing policy for cluster. This operation may make some clusters
-// governed by the previous policy invalid.
-func (a *ClusterPoliciesAPI) Edit(ctx context.Context, request EditPolicy) error {
-	return a.impl.Edit(ctx, request)
-}
-
-// Get a cluster policy.
-//
-// Get a cluster policy entity. Creation and editing is available to admins
-// only.
-func (a *ClusterPoliciesAPI) Get(ctx context.Context, request GetClusterPolicyRequest) (*Policy, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a cluster policy.
@@ -223,7 +193,7 @@ func (a *ClusterPoliciesAPI) Get(ctx context.Context, request GetClusterPolicyRe
 // Get a cluster policy entity. Creation and editing is available to admins
 // only.
 func (a *ClusterPoliciesAPI) GetByPolicyId(ctx context.Context, policyId string) (*Policy, error) {
-	return a.impl.Get(ctx, GetClusterPolicyRequest{
+	return a.ClusterPoliciesService.Get(ctx, GetClusterPolicyRequest{
 		PolicyId: policyId,
 	})
 }
@@ -231,15 +201,8 @@ func (a *ClusterPoliciesAPI) GetByPolicyId(ctx context.Context, policyId string)
 // Get cluster policy permission levels.
 //
 // Gets the permission levels that a user can have on an object.
-func (a *ClusterPoliciesAPI) GetPermissionLevels(ctx context.Context, request GetClusterPolicyPermissionLevelsRequest) (*GetClusterPolicyPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
-}
-
-// Get cluster policy permission levels.
-//
-// Gets the permission levels that a user can have on an object.
 func (a *ClusterPoliciesAPI) GetPermissionLevelsByClusterPolicyId(ctx context.Context, clusterPolicyId string) (*GetClusterPolicyPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetClusterPolicyPermissionLevelsRequest{
+	return a.ClusterPoliciesService.GetPermissionLevels(ctx, GetClusterPolicyPermissionLevelsRequest{
 		ClusterPolicyId: clusterPolicyId,
 	})
 }
@@ -248,16 +211,8 @@ func (a *ClusterPoliciesAPI) GetPermissionLevelsByClusterPolicyId(ctx context.Co
 //
 // Gets the permissions of a cluster policy. Cluster policies can inherit
 // permissions from their root object.
-func (a *ClusterPoliciesAPI) GetPermissions(ctx context.Context, request GetClusterPolicyPermissionsRequest) (*ClusterPolicyPermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
-}
-
-// Get cluster policy permissions.
-//
-// Gets the permissions of a cluster policy. Cluster policies can inherit
-// permissions from their root object.
 func (a *ClusterPoliciesAPI) GetPermissionsByClusterPolicyId(ctx context.Context, clusterPolicyId string) (*ClusterPolicyPermissions, error) {
-	return a.impl.GetPermissions(ctx, GetClusterPolicyPermissionsRequest{
+	return a.ClusterPoliciesService.GetPermissions(ctx, GetClusterPolicyPermissionsRequest{
 		ClusterPolicyId: clusterPolicyId,
 	})
 }
@@ -271,7 +226,7 @@ func (a *ClusterPoliciesAPI) List(ctx context.Context, request ListClusterPolici
 
 	getNextPage := func(ctx context.Context, req ListClusterPoliciesRequest) (*ListPoliciesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ClusterPoliciesService.List(ctx, req)
 	}
 	getItems := func(resp *ListPoliciesResponse) []Policy {
 		return resp.Policies
@@ -346,22 +301,6 @@ func (a *ClusterPoliciesAPI) GetByName(ctx context.Context, name string) (*Polic
 		return nil, fmt.Errorf("there are %d instances of Policy named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Set cluster policy permissions.
-//
-// Sets permissions on a cluster policy. Cluster policies can inherit
-// permissions from their root object.
-func (a *ClusterPoliciesAPI) SetPermissions(ctx context.Context, request ClusterPolicyPermissionsRequest) (*ClusterPolicyPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Update cluster policy permissions.
-//
-// Updates the permissions on a cluster policy. Cluster policies can inherit
-// permissions from their root object.
-func (a *ClusterPoliciesAPI) UpdatePermissions(ctx context.Context, request ClusterPolicyPermissionsRequest) (*ClusterPolicyPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }
 
 type ClustersInterface interface {
@@ -691,7 +630,7 @@ type ClustersInterface interface {
 
 func NewClusters(client *client.DatabricksClient) *ClustersAPI {
 	return &ClustersAPI{
-		impl: &clustersImpl{
+		ClustersService: &clustersImpl{
 			client: client,
 		},
 	}
@@ -726,21 +665,22 @@ func NewClusters(client *client.DatabricksClient) *ClustersAPI {
 type ClustersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ClustersService)
-	impl ClustersService
+	ClustersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockClustersInterface instead.
 func (a *ClustersAPI) WithImpl(impl ClustersService) ClustersInterface {
-	a.impl = impl
-	return a
+	return &ClustersAPI{
+		ClustersService: impl,
+	}
 }
 
 // Impl returns low-level Clusters API implementation
 // Deprecated: use MockClustersInterface instead.
 func (a *ClustersAPI) Impl() ClustersService {
-	return a.impl
+	return a.ClustersService
 }
 
 // WaitGetClusterRunning repeatedly calls [ClustersAPI.Get] and waits to reach RUNNING state
@@ -851,15 +791,6 @@ func (w *WaitGetClusterTerminated[R]) GetWithTimeout(timeout time.Duration) (*Cl
 	return w.Poll(timeout, w.callback)
 }
 
-// Change cluster owner.
-//
-// Change the owner of the cluster. You must be an admin and the cluster must be
-// terminated to perform this operation. The service principal application ID
-// can be supplied as an argument to `owner_username`.
-func (a *ClustersAPI) ChangeOwner(ctx context.Context, request ChangeClusterOwner) error {
-	return a.impl.ChangeOwner(ctx, request)
-}
-
 // Create new cluster.
 //
 // Creates a new Spark cluster. This method will acquire new instances from the
@@ -871,7 +802,7 @@ func (a *ClustersAPI) ChangeOwner(ctx context.Context, request ChangeClusterOwne
 // creation will succeed. Otherwise the cluster will terminate with an
 // informative error message.
 func (a *ClustersAPI) Create(ctx context.Context, createCluster CreateCluster) (*WaitGetClusterRunning[CreateClusterResponse], error) {
-	createClusterResponse, err := a.impl.Create(ctx, createCluster)
+	createClusterResponse, err := a.ClustersService.Create(ctx, createCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -920,7 +851,7 @@ func (a *ClustersAPI) CreateAndWait(ctx context.Context, createCluster CreateClu
 // `TERMINATED` state. If the cluster is already in a `TERMINATING` or
 // `TERMINATED` state, nothing will happen.
 func (a *ClustersAPI) Delete(ctx context.Context, deleteCluster DeleteCluster) (*WaitGetClusterTerminated[struct{}], error) {
-	err := a.impl.Delete(ctx, deleteCluster)
+	err := a.ClustersService.Delete(ctx, deleteCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -969,7 +900,7 @@ func (a *ClustersAPI) DeleteAndWait(ctx context.Context, deleteCluster DeleteClu
 // `TERMINATED` state. If the cluster is already in a `TERMINATING` or
 // `TERMINATED` state, nothing will happen.
 func (a *ClustersAPI) DeleteByClusterId(ctx context.Context, clusterId string) error {
-	return a.impl.Delete(ctx, DeleteCluster{
+	return a.ClustersService.Delete(ctx, DeleteCluster{
 		ClusterId: clusterId,
 	})
 }
@@ -995,7 +926,7 @@ func (a *ClustersAPI) DeleteByClusterIdAndWait(ctx context.Context, clusterId st
 //
 // Clusters created by the Databricks Jobs service cannot be edited.
 func (a *ClustersAPI) Edit(ctx context.Context, editCluster EditCluster) (*WaitGetClusterRunning[struct{}], error) {
-	err := a.impl.Edit(ctx, editCluster)
+	err := a.ClustersService.Edit(ctx, editCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -1048,7 +979,7 @@ func (a *ClustersAPI) Events(ctx context.Context, request GetEvents) listing.Ite
 
 	getNextPage := func(ctx context.Context, req GetEvents) (*GetEventsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.Events(ctx, req)
+		return a.ClustersService.Events(ctx, req)
 	}
 	getItems := func(resp *GetEventsResponse) []ClusterEvent {
 		return resp.Events
@@ -1086,42 +1017,19 @@ func (a *ClustersAPI) EventsAll(ctx context.Context, request GetEvents) ([]Clust
 //
 // Retrieves the information for a cluster given its identifier. Clusters can be
 // described while they are running, or up to 60 days after they are terminated.
-func (a *ClustersAPI) Get(ctx context.Context, request GetClusterRequest) (*ClusterDetails, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get cluster info.
-//
-// Retrieves the information for a cluster given its identifier. Clusters can be
-// described while they are running, or up to 60 days after they are terminated.
 func (a *ClustersAPI) GetByClusterId(ctx context.Context, clusterId string) (*ClusterDetails, error) {
-	return a.impl.Get(ctx, GetClusterRequest{
+	return a.ClustersService.Get(ctx, GetClusterRequest{
 		ClusterId: clusterId,
 	})
-}
-
-// Get cluster permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *ClustersAPI) GetPermissionLevels(ctx context.Context, request GetClusterPermissionLevelsRequest) (*GetClusterPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
 }
 
 // Get cluster permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *ClustersAPI) GetPermissionLevelsByClusterId(ctx context.Context, clusterId string) (*GetClusterPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetClusterPermissionLevelsRequest{
+	return a.ClustersService.GetPermissionLevels(ctx, GetClusterPermissionLevelsRequest{
 		ClusterId: clusterId,
 	})
-}
-
-// Get cluster permissions.
-//
-// Gets the permissions of a cluster. Clusters can inherit permissions from
-// their root object.
-func (a *ClustersAPI) GetPermissions(ctx context.Context, request GetClusterPermissionsRequest) (*ClusterPermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get cluster permissions.
@@ -1129,7 +1037,7 @@ func (a *ClustersAPI) GetPermissions(ctx context.Context, request GetClusterPerm
 // Gets the permissions of a cluster. Clusters can inherit permissions from
 // their root object.
 func (a *ClustersAPI) GetPermissionsByClusterId(ctx context.Context, clusterId string) (*ClusterPermissions, error) {
-	return a.impl.GetPermissions(ctx, GetClusterPermissionsRequest{
+	return a.ClustersService.GetPermissions(ctx, GetClusterPermissionsRequest{
 		ClusterId: clusterId,
 	})
 }
@@ -1145,7 +1053,7 @@ func (a *ClustersAPI) List(ctx context.Context, request ListClustersRequest) lis
 
 	getNextPage := func(ctx context.Context, req ListClustersRequest) (*ListClustersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ClustersService.List(ctx, req)
 	}
 	getItems := func(resp *ListClustersResponse) []ClusterDetails {
 		return resp.Clusters
@@ -1231,34 +1139,6 @@ func (a *ClustersAPI) GetByClusterName(ctx context.Context, name string) (*Clust
 	return &alternatives[0], nil
 }
 
-// List node types.
-//
-// Returns a list of supported Spark node types. These node types can be used to
-// launch a cluster.
-func (a *ClustersAPI) ListNodeTypes(ctx context.Context) (*ListNodeTypesResponse, error) {
-	return a.impl.ListNodeTypes(ctx)
-}
-
-// List availability zones.
-//
-// Returns a list of availability zones where clusters can be created in (For
-// example, us-west-2a). These zones can be used to launch a cluster.
-func (a *ClustersAPI) ListZones(ctx context.Context) (*ListAvailableZonesResponse, error) {
-	return a.impl.ListZones(ctx)
-}
-
-// Permanently delete cluster.
-//
-// Permanently deletes a Spark cluster. This cluster is terminated and resources
-// are asynchronously removed.
-//
-// In addition, users will no longer see permanently deleted clusters in the
-// cluster list, and API users can no longer perform any action on permanently
-// deleted clusters.
-func (a *ClustersAPI) PermanentDelete(ctx context.Context, request PermanentDeleteCluster) error {
-	return a.impl.PermanentDelete(ctx, request)
-}
-
 // Permanently delete cluster.
 //
 // Permanently deletes a Spark cluster. This cluster is terminated and resources
@@ -1268,7 +1148,7 @@ func (a *ClustersAPI) PermanentDelete(ctx context.Context, request PermanentDele
 // cluster list, and API users can no longer perform any action on permanently
 // deleted clusters.
 func (a *ClustersAPI) PermanentDeleteByClusterId(ctx context.Context, clusterId string) error {
-	return a.impl.PermanentDelete(ctx, PermanentDeleteCluster{
+	return a.ClustersService.PermanentDelete(ctx, PermanentDeleteCluster{
 		ClusterId: clusterId,
 	})
 }
@@ -1278,17 +1158,8 @@ func (a *ClustersAPI) PermanentDeleteByClusterId(ctx context.Context, clusterId 
 // Pinning a cluster ensures that the cluster will always be returned by the
 // ListClusters API. Pinning a cluster that is already pinned will have no
 // effect. This API can only be called by workspace admins.
-func (a *ClustersAPI) Pin(ctx context.Context, request PinCluster) error {
-	return a.impl.Pin(ctx, request)
-}
-
-// Pin cluster.
-//
-// Pinning a cluster ensures that the cluster will always be returned by the
-// ListClusters API. Pinning a cluster that is already pinned will have no
-// effect. This API can only be called by workspace admins.
 func (a *ClustersAPI) PinByClusterId(ctx context.Context, clusterId string) error {
-	return a.impl.Pin(ctx, PinCluster{
+	return a.ClustersService.Pin(ctx, PinCluster{
 		ClusterId: clusterId,
 	})
 }
@@ -1298,7 +1169,7 @@ func (a *ClustersAPI) PinByClusterId(ctx context.Context, clusterId string) erro
 // Resizes a cluster to have a desired number of workers. This will fail unless
 // the cluster is in a `RUNNING` state.
 func (a *ClustersAPI) Resize(ctx context.Context, resizeCluster ResizeCluster) (*WaitGetClusterRunning[struct{}], error) {
-	err := a.impl.Resize(ctx, resizeCluster)
+	err := a.ClustersService.Resize(ctx, resizeCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -1345,7 +1216,7 @@ func (a *ClustersAPI) ResizeAndWait(ctx context.Context, resizeCluster ResizeClu
 // Restarts a Spark cluster with the supplied ID. If the cluster is not
 // currently in a `RUNNING` state, nothing will happen.
 func (a *ClustersAPI) Restart(ctx context.Context, restartCluster RestartCluster) (*WaitGetClusterRunning[struct{}], error) {
-	err := a.impl.Restart(ctx, restartCluster)
+	err := a.ClustersService.Restart(ctx, restartCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -1387,22 +1258,6 @@ func (a *ClustersAPI) RestartAndWait(ctx context.Context, restartCluster Restart
 	return wait.Get()
 }
 
-// Set cluster permissions.
-//
-// Sets permissions on a cluster. Clusters can inherit permissions from their
-// root object.
-func (a *ClustersAPI) SetPermissions(ctx context.Context, request ClusterPermissionsRequest) (*ClusterPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// List available Spark versions.
-//
-// Returns the list of available Spark versions. These versions can be used to
-// launch a cluster.
-func (a *ClustersAPI) SparkVersions(ctx context.Context) (*GetSparkVersionsResponse, error) {
-	return a.impl.SparkVersions(ctx)
-}
-
 // Start terminated cluster.
 //
 // Starts a terminated Spark cluster with the supplied ID. This works similar to
@@ -1414,7 +1269,7 @@ func (a *ClustersAPI) SparkVersions(ctx context.Context) (*GetSparkVersionsRespo
 // nodes. * If the cluster is not currently in a `TERMINATED` state, nothing
 // will happen. * Clusters launched to run a job cannot be started.
 func (a *ClustersAPI) Start(ctx context.Context, startCluster StartCluster) (*WaitGetClusterRunning[struct{}], error) {
-	err := a.impl.Start(ctx, startCluster)
+	err := a.ClustersService.Start(ctx, startCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -1467,7 +1322,7 @@ func (a *ClustersAPI) StartAndWait(ctx context.Context, startCluster StartCluste
 // nodes. * If the cluster is not currently in a `TERMINATED` state, nothing
 // will happen. * Clusters launched to run a job cannot be started.
 func (a *ClustersAPI) StartByClusterId(ctx context.Context, clusterId string) error {
-	return a.impl.Start(ctx, StartCluster{
+	return a.ClustersService.Start(ctx, StartCluster{
 		ClusterId: clusterId,
 	})
 }
@@ -1483,27 +1338,10 @@ func (a *ClustersAPI) StartByClusterIdAndWait(ctx context.Context, clusterId str
 // Unpinning a cluster will allow the cluster to eventually be removed from the
 // ListClusters API. Unpinning a cluster that is not pinned will have no effect.
 // This API can only be called by workspace admins.
-func (a *ClustersAPI) Unpin(ctx context.Context, request UnpinCluster) error {
-	return a.impl.Unpin(ctx, request)
-}
-
-// Unpin cluster.
-//
-// Unpinning a cluster will allow the cluster to eventually be removed from the
-// ListClusters API. Unpinning a cluster that is not pinned will have no effect.
-// This API can only be called by workspace admins.
 func (a *ClustersAPI) UnpinByClusterId(ctx context.Context, clusterId string) error {
-	return a.impl.Unpin(ctx, UnpinCluster{
+	return a.ClustersService.Unpin(ctx, UnpinCluster{
 		ClusterId: clusterId,
 	})
-}
-
-// Update cluster permissions.
-//
-// Updates the permissions on a cluster. Clusters can inherit permissions from
-// their root object.
-func (a *ClustersAPI) UpdatePermissions(ctx context.Context, request ClusterPermissionsRequest) (*ClusterPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }
 
 type CommandExecutionInterface interface {
@@ -1597,7 +1435,7 @@ type CommandExecutionInterface interface {
 
 func NewCommandExecution(client *client.DatabricksClient) *CommandExecutionAPI {
 	return &CommandExecutionAPI{
-		impl: &commandExecutionImpl{
+		CommandExecutionService: &commandExecutionImpl{
 			client: client,
 		},
 	}
@@ -1609,21 +1447,22 @@ func NewCommandExecution(client *client.DatabricksClient) *CommandExecutionAPI {
 type CommandExecutionAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CommandExecutionService)
-	impl CommandExecutionService
+	CommandExecutionService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCommandExecutionInterface instead.
 func (a *CommandExecutionAPI) WithImpl(impl CommandExecutionService) CommandExecutionInterface {
-	a.impl = impl
-	return a
+	return &CommandExecutionAPI{
+		CommandExecutionService: impl,
+	}
 }
 
 // Impl returns low-level CommandExecution API implementation
 // Deprecated: use MockCommandExecutionInterface instead.
 func (a *CommandExecutionAPI) Impl() CommandExecutionService {
-	return a.impl
+	return a.CommandExecutionService
 }
 
 // WaitCommandStatusCommandExecutionCancelled repeatedly calls [CommandExecutionAPI.CommandStatus] and waits to reach Cancelled state
@@ -1807,7 +1646,7 @@ func (w *WaitContextStatusCommandExecutionRunning[R]) GetWithTimeout(timeout tim
 //
 // The command ID is obtained from a prior successful call to __execute__.
 func (a *CommandExecutionAPI) Cancel(ctx context.Context, cancelCommand CancelCommand) (*WaitCommandStatusCommandExecutionCancelled[struct{}], error) {
-	err := a.impl.Cancel(ctx, cancelCommand)
+	err := a.CommandExecutionService.Cancel(ctx, cancelCommand)
 	if err != nil {
 		return nil, err
 	}
@@ -1851,30 +1690,13 @@ func (a *CommandExecutionAPI) CancelAndWait(ctx context.Context, cancelCommand C
 	return wait.Get()
 }
 
-// Get command info.
-//
-// Gets the status of and, if available, the results from a currently executing
-// command.
-//
-// The command ID is obtained from a prior successful call to __execute__.
-func (a *CommandExecutionAPI) CommandStatus(ctx context.Context, request CommandStatusRequest) (*CommandStatusResponse, error) {
-	return a.impl.CommandStatus(ctx, request)
-}
-
-// Get status.
-//
-// Gets the status for an execution context.
-func (a *CommandExecutionAPI) ContextStatus(ctx context.Context, request ContextStatusRequest) (*ContextStatusResponse, error) {
-	return a.impl.ContextStatus(ctx, request)
-}
-
 // Create an execution context.
 //
 // Creates an execution context for running cluster commands.
 //
 // If successful, this method returns the ID of the new execution context.
 func (a *CommandExecutionAPI) Create(ctx context.Context, createContext CreateContext) (*WaitContextStatusCommandExecutionRunning[Created], error) {
-	created, err := a.impl.Create(ctx, createContext)
+	created, err := a.CommandExecutionService.Create(ctx, createContext)
 	if err != nil {
 		return nil, err
 	}
@@ -1917,13 +1739,6 @@ func (a *CommandExecutionAPI) CreateAndWait(ctx context.Context, createContext C
 	return wait.Get()
 }
 
-// Delete an execution context.
-//
-// Deletes an execution context.
-func (a *CommandExecutionAPI) Destroy(ctx context.Context, request DestroyContext) error {
-	return a.impl.Destroy(ctx, request)
-}
-
 // Run a command.
 //
 // Runs a cluster command in the given execution context, using the provided
@@ -1932,7 +1747,7 @@ func (a *CommandExecutionAPI) Destroy(ctx context.Context, request DestroyContex
 // If successful, it returns an ID for tracking the status of the command's
 // execution.
 func (a *CommandExecutionAPI) Execute(ctx context.Context, command Command) (*WaitCommandStatusCommandExecutionFinishedOrError[Created], error) {
-	created, err := a.impl.Execute(ctx, command)
+	created, err := a.CommandExecutionService.Execute(ctx, command)
 	if err != nil {
 		return nil, err
 	}
@@ -2058,7 +1873,7 @@ type GlobalInitScriptsInterface interface {
 
 func NewGlobalInitScripts(client *client.DatabricksClient) *GlobalInitScriptsAPI {
 	return &GlobalInitScriptsAPI{
-		impl: &globalInitScriptsImpl{
+		GlobalInitScriptsService: &globalInitScriptsImpl{
 			client: client,
 		},
 	}
@@ -2077,42 +1892,29 @@ func NewGlobalInitScripts(client *client.DatabricksClient) *GlobalInitScriptsAPI
 type GlobalInitScriptsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(GlobalInitScriptsService)
-	impl GlobalInitScriptsService
+	GlobalInitScriptsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGlobalInitScriptsInterface instead.
 func (a *GlobalInitScriptsAPI) WithImpl(impl GlobalInitScriptsService) GlobalInitScriptsInterface {
-	a.impl = impl
-	return a
+	return &GlobalInitScriptsAPI{
+		GlobalInitScriptsService: impl,
+	}
 }
 
 // Impl returns low-level GlobalInitScripts API implementation
 // Deprecated: use MockGlobalInitScriptsInterface instead.
 func (a *GlobalInitScriptsAPI) Impl() GlobalInitScriptsService {
-	return a.impl
-}
-
-// Create init script.
-//
-// Creates a new global init script in this workspace.
-func (a *GlobalInitScriptsAPI) Create(ctx context.Context, request GlobalInitScriptCreateRequest) (*CreateResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete init script.
-//
-// Deletes a global init script.
-func (a *GlobalInitScriptsAPI) Delete(ctx context.Context, request DeleteGlobalInitScriptRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.GlobalInitScriptsService
 }
 
 // Delete init script.
 //
 // Deletes a global init script.
 func (a *GlobalInitScriptsAPI) DeleteByScriptId(ctx context.Context, scriptId string) error {
-	return a.impl.Delete(ctx, DeleteGlobalInitScriptRequest{
+	return a.GlobalInitScriptsService.Delete(ctx, DeleteGlobalInitScriptRequest{
 		ScriptId: scriptId,
 	})
 }
@@ -2120,15 +1922,8 @@ func (a *GlobalInitScriptsAPI) DeleteByScriptId(ctx context.Context, scriptId st
 // Get an init script.
 //
 // Gets all the details of a script, including its Base64-encoded contents.
-func (a *GlobalInitScriptsAPI) Get(ctx context.Context, request GetGlobalInitScriptRequest) (*GlobalInitScriptDetailsWithContent, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get an init script.
-//
-// Gets all the details of a script, including its Base64-encoded contents.
 func (a *GlobalInitScriptsAPI) GetByScriptId(ctx context.Context, scriptId string) (*GlobalInitScriptDetailsWithContent, error) {
-	return a.impl.Get(ctx, GetGlobalInitScriptRequest{
+	return a.GlobalInitScriptsService.Get(ctx, GetGlobalInitScriptRequest{
 		ScriptId: scriptId,
 	})
 }
@@ -2146,7 +1941,7 @@ func (a *GlobalInitScriptsAPI) List(ctx context.Context) listing.Iterator[Global
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListGlobalInitScriptsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.GlobalInitScriptsService.List(ctx)
 	}
 	getItems := func(resp *ListGlobalInitScriptsResponse) []GlobalInitScriptDetails {
 		return resp.Scripts
@@ -2224,14 +2019,6 @@ func (a *GlobalInitScriptsAPI) GetByName(ctx context.Context, name string) (*Glo
 		return nil, fmt.Errorf("there are %d instances of GlobalInitScriptDetails named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update init script.
-//
-// Updates a global init script, specifying only the fields to change. All
-// fields are optional. Unspecified fields retain their current value.
-func (a *GlobalInitScriptsAPI) Update(ctx context.Context, request GlobalInitScriptUpdateRequest) error {
-	return a.impl.Update(ctx, request)
 }
 
 type InstancePoolsInterface interface {
@@ -2345,7 +2132,7 @@ type InstancePoolsInterface interface {
 
 func NewInstancePools(client *client.DatabricksClient) *InstancePoolsAPI {
 	return &InstancePoolsAPI{
-		impl: &instancePoolsImpl{
+		InstancePoolsService: &instancePoolsImpl{
 			client: client,
 		},
 	}
@@ -2372,36 +2159,22 @@ func NewInstancePools(client *client.DatabricksClient) *InstancePoolsAPI {
 type InstancePoolsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(InstancePoolsService)
-	impl InstancePoolsService
+	InstancePoolsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockInstancePoolsInterface instead.
 func (a *InstancePoolsAPI) WithImpl(impl InstancePoolsService) InstancePoolsInterface {
-	a.impl = impl
-	return a
+	return &InstancePoolsAPI{
+		InstancePoolsService: impl,
+	}
 }
 
 // Impl returns low-level InstancePools API implementation
 // Deprecated: use MockInstancePoolsInterface instead.
 func (a *InstancePoolsAPI) Impl() InstancePoolsService {
-	return a.impl
-}
-
-// Create a new instance pool.
-//
-// Creates a new instance pool using idle and ready-to-use cloud instances.
-func (a *InstancePoolsAPI) Create(ctx context.Context, request CreateInstancePool) (*CreateInstancePoolResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an instance pool.
-//
-// Deletes the instance pool permanently. The idle instances in the pool are
-// terminated asynchronously.
-func (a *InstancePoolsAPI) Delete(ctx context.Context, request DeleteInstancePool) error {
-	return a.impl.Delete(ctx, request)
+	return a.InstancePoolsService
 }
 
 // Delete an instance pool.
@@ -2409,56 +2182,27 @@ func (a *InstancePoolsAPI) Delete(ctx context.Context, request DeleteInstancePoo
 // Deletes the instance pool permanently. The idle instances in the pool are
 // terminated asynchronously.
 func (a *InstancePoolsAPI) DeleteByInstancePoolId(ctx context.Context, instancePoolId string) error {
-	return a.impl.Delete(ctx, DeleteInstancePool{
+	return a.InstancePoolsService.Delete(ctx, DeleteInstancePool{
 		InstancePoolId: instancePoolId,
 	})
-}
-
-// Edit an existing instance pool.
-//
-// Modifies the configuration of an existing instance pool.
-func (a *InstancePoolsAPI) Edit(ctx context.Context, request EditInstancePool) error {
-	return a.impl.Edit(ctx, request)
-}
-
-// Get instance pool information.
-//
-// Retrieve the information for an instance pool based on its identifier.
-func (a *InstancePoolsAPI) Get(ctx context.Context, request GetInstancePoolRequest) (*GetInstancePool, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get instance pool information.
 //
 // Retrieve the information for an instance pool based on its identifier.
 func (a *InstancePoolsAPI) GetByInstancePoolId(ctx context.Context, instancePoolId string) (*GetInstancePool, error) {
-	return a.impl.Get(ctx, GetInstancePoolRequest{
+	return a.InstancePoolsService.Get(ctx, GetInstancePoolRequest{
 		InstancePoolId: instancePoolId,
 	})
-}
-
-// Get instance pool permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *InstancePoolsAPI) GetPermissionLevels(ctx context.Context, request GetInstancePoolPermissionLevelsRequest) (*GetInstancePoolPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
 }
 
 // Get instance pool permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *InstancePoolsAPI) GetPermissionLevelsByInstancePoolId(ctx context.Context, instancePoolId string) (*GetInstancePoolPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetInstancePoolPermissionLevelsRequest{
+	return a.InstancePoolsService.GetPermissionLevels(ctx, GetInstancePoolPermissionLevelsRequest{
 		InstancePoolId: instancePoolId,
 	})
-}
-
-// Get instance pool permissions.
-//
-// Gets the permissions of an instance pool. Instance pools can inherit
-// permissions from their root object.
-func (a *InstancePoolsAPI) GetPermissions(ctx context.Context, request GetInstancePoolPermissionsRequest) (*InstancePoolPermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get instance pool permissions.
@@ -2466,7 +2210,7 @@ func (a *InstancePoolsAPI) GetPermissions(ctx context.Context, request GetInstan
 // Gets the permissions of an instance pool. Instance pools can inherit
 // permissions from their root object.
 func (a *InstancePoolsAPI) GetPermissionsByInstancePoolId(ctx context.Context, instancePoolId string) (*InstancePoolPermissions, error) {
-	return a.impl.GetPermissions(ctx, GetInstancePoolPermissionsRequest{
+	return a.InstancePoolsService.GetPermissions(ctx, GetInstancePoolPermissionsRequest{
 		InstancePoolId: instancePoolId,
 	})
 }
@@ -2481,7 +2225,7 @@ func (a *InstancePoolsAPI) List(ctx context.Context) listing.Iterator[InstancePo
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListInstancePools, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.InstancePoolsService.List(ctx)
 	}
 	getItems := func(resp *ListInstancePools) []InstancePoolAndStats {
 		return resp.InstancePools
@@ -2558,22 +2302,6 @@ func (a *InstancePoolsAPI) GetByInstancePoolName(ctx context.Context, name strin
 	return &alternatives[0], nil
 }
 
-// Set instance pool permissions.
-//
-// Sets permissions on an instance pool. Instance pools can inherit permissions
-// from their root object.
-func (a *InstancePoolsAPI) SetPermissions(ctx context.Context, request InstancePoolPermissionsRequest) (*InstancePoolPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Update instance pool permissions.
-//
-// Updates the permissions on an instance pool. Instance pools can inherit
-// permissions from their root object.
-func (a *InstancePoolsAPI) UpdatePermissions(ctx context.Context, request InstancePoolPermissionsRequest) (*InstancePoolPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
-}
-
 type InstanceProfilesInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -2646,7 +2374,7 @@ type InstanceProfilesInterface interface {
 
 func NewInstanceProfiles(client *client.DatabricksClient) *InstanceProfilesAPI {
 	return &InstanceProfilesAPI{
-		impl: &instanceProfilesImpl{
+		InstanceProfilesService: &instanceProfilesImpl{
 			client: client,
 		},
 	}
@@ -2661,50 +2389,22 @@ func NewInstanceProfiles(client *client.DatabricksClient) *InstanceProfilesAPI {
 type InstanceProfilesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(InstanceProfilesService)
-	impl InstanceProfilesService
+	InstanceProfilesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockInstanceProfilesInterface instead.
 func (a *InstanceProfilesAPI) WithImpl(impl InstanceProfilesService) InstanceProfilesInterface {
-	a.impl = impl
-	return a
+	return &InstanceProfilesAPI{
+		InstanceProfilesService: impl,
+	}
 }
 
 // Impl returns low-level InstanceProfiles API implementation
 // Deprecated: use MockInstanceProfilesInterface instead.
 func (a *InstanceProfilesAPI) Impl() InstanceProfilesService {
-	return a.impl
-}
-
-// Register an instance profile.
-//
-// In the UI, you can select the instance profile when launching clusters. This
-// API is only available to admin users.
-func (a *InstanceProfilesAPI) Add(ctx context.Context, request AddInstanceProfile) error {
-	return a.impl.Add(ctx, request)
-}
-
-// Edit an instance profile.
-//
-// The only supported field to change is the optional IAM role ARN associated
-// with the instance profile. It is required to specify the IAM role ARN if both
-// of the following are true:
-//
-// * Your role name and instance profile name do not match. The name is the part
-// after the last slash in each ARN. * You want to use the instance profile with
-// [Databricks SQL Serverless].
-//
-// To understand where these fields are in the AWS console, see [Enable
-// serverless SQL warehouses].
-//
-// This API is only available to admin users.
-//
-// [Databricks SQL Serverless]: https://docs.databricks.com/sql/admin/serverless.html
-// [Enable serverless SQL warehouses]: https://docs.databricks.com/sql/admin/serverless.html
-func (a *InstanceProfilesAPI) Edit(ctx context.Context, request InstanceProfile) error {
-	return a.impl.Edit(ctx, request)
+	return a.InstanceProfilesService
 }
 
 // List available instance profiles.
@@ -2719,7 +2419,7 @@ func (a *InstanceProfilesAPI) List(ctx context.Context) listing.Iterator[Instanc
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListInstanceProfilesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.InstanceProfilesService.List(ctx)
 	}
 	getItems := func(resp *ListInstanceProfilesResponse) []InstanceProfile {
 		return resp.InstanceProfiles
@@ -2751,18 +2451,8 @@ func (a *InstanceProfilesAPI) ListAll(ctx context.Context) ([]InstanceProfile, e
 // this instance profile will continue to function.
 //
 // This API is only accessible to admin users.
-func (a *InstanceProfilesAPI) Remove(ctx context.Context, request RemoveInstanceProfile) error {
-	return a.impl.Remove(ctx, request)
-}
-
-// Remove the instance profile.
-//
-// Remove the instance profile with the provided ARN. Existing clusters with
-// this instance profile will continue to function.
-//
-// This API is only accessible to admin users.
 func (a *InstanceProfilesAPI) RemoveByInstanceProfileArn(ctx context.Context, instanceProfileArn string) error {
-	return a.impl.Remove(ctx, RemoveInstanceProfile{
+	return a.InstanceProfilesService.Remove(ctx, RemoveInstanceProfile{
 		InstanceProfileArn: instanceProfileArn,
 	})
 }
@@ -2847,7 +2537,7 @@ type LibrariesInterface interface {
 
 func NewLibraries(client *client.DatabricksClient) *LibrariesAPI {
 	return &LibrariesAPI{
-		impl: &librariesImpl{
+		LibrariesService: &librariesImpl{
 			client: client,
 		},
 	}
@@ -2872,21 +2562,22 @@ func NewLibraries(client *client.DatabricksClient) *LibrariesAPI {
 type LibrariesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(LibrariesService)
-	impl LibrariesService
+	LibrariesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockLibrariesInterface instead.
 func (a *LibrariesAPI) WithImpl(impl LibrariesService) LibrariesInterface {
-	a.impl = impl
-	return a
+	return &LibrariesAPI{
+		LibrariesService: impl,
+	}
 }
 
 // Impl returns low-level Libraries API implementation
 // Deprecated: use MockLibrariesInterface instead.
 func (a *LibrariesAPI) Impl() LibrariesService {
-	return a.impl
+	return a.LibrariesService
 }
 
 // Get all statuses.
@@ -2900,7 +2591,7 @@ func (a *LibrariesAPI) AllClusterStatuses(ctx context.Context) listing.Iterator[
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListAllClusterLibraryStatusesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.AllClusterStatuses(ctx)
+		return a.LibrariesService.AllClusterStatuses(ctx)
 	}
 	getItems := func(resp *ListAllClusterLibraryStatusesResponse) []ClusterLibraryStatuses {
 		return resp.Statuses
@@ -2940,7 +2631,7 @@ func (a *LibrariesAPI) ClusterStatus(ctx context.Context, request ClusterStatus)
 
 	getNextPage := func(ctx context.Context, req ClusterStatus) (*ClusterLibraryStatuses, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ClusterStatus(ctx, req)
+		return a.LibrariesService.ClusterStatus(ctx, req)
 	}
 	getItems := func(resp *ClusterLibraryStatuses) []LibraryFullStatus {
 		return resp.LibraryStatuses
@@ -2980,26 +2671,9 @@ func (a *LibrariesAPI) ClusterStatusAll(ctx context.Context, request ClusterStat
 // installed on this cluster or, but are now marked for removal, in no
 // particular order, are returned last.
 func (a *LibrariesAPI) ClusterStatusByClusterId(ctx context.Context, clusterId string) (*ClusterLibraryStatuses, error) {
-	return a.impl.ClusterStatus(ctx, ClusterStatus{
+	return a.LibrariesService.ClusterStatus(ctx, ClusterStatus{
 		ClusterId: clusterId,
 	})
-}
-
-// Add a library.
-//
-// Add libraries to install on a cluster. The installation is asynchronous; it
-// happens in the background after the completion of this request.
-func (a *LibrariesAPI) Install(ctx context.Context, request InstallLibraries) error {
-	return a.impl.Install(ctx, request)
-}
-
-// Uninstall libraries.
-//
-// Set libraries to uninstall from a cluster. The libraries won't be uninstalled
-// until the cluster is restarted. A request to uninstall a library that is not
-// currently installed is ignored.
-func (a *LibrariesAPI) Uninstall(ctx context.Context, request UninstallLibraries) error {
-	return a.impl.Uninstall(ctx, request)
 }
 
 type PolicyFamiliesInterface interface {
@@ -3039,7 +2713,7 @@ type PolicyFamiliesInterface interface {
 
 func NewPolicyFamilies(client *client.DatabricksClient) *PolicyFamiliesAPI {
 	return &PolicyFamiliesAPI{
-		impl: &policyFamiliesImpl{
+		PolicyFamiliesService: &policyFamiliesImpl{
 			client: client,
 		},
 	}
@@ -3057,35 +2731,29 @@ func NewPolicyFamilies(client *client.DatabricksClient) *PolicyFamiliesAPI {
 type PolicyFamiliesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PolicyFamiliesService)
-	impl PolicyFamiliesService
+	PolicyFamiliesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPolicyFamiliesInterface instead.
 func (a *PolicyFamiliesAPI) WithImpl(impl PolicyFamiliesService) PolicyFamiliesInterface {
-	a.impl = impl
-	return a
+	return &PolicyFamiliesAPI{
+		PolicyFamiliesService: impl,
+	}
 }
 
 // Impl returns low-level PolicyFamilies API implementation
 // Deprecated: use MockPolicyFamiliesInterface instead.
 func (a *PolicyFamiliesAPI) Impl() PolicyFamiliesService {
-	return a.impl
-}
-
-// Get policy family information.
-//
-// Retrieve the information for an policy family based on its identifier.
-func (a *PolicyFamiliesAPI) Get(ctx context.Context, request GetPolicyFamilyRequest) (*PolicyFamily, error) {
-	return a.impl.Get(ctx, request)
+	return a.PolicyFamiliesService
 }
 
 // Get policy family information.
 //
 // Retrieve the information for an policy family based on its identifier.
 func (a *PolicyFamiliesAPI) GetByPolicyFamilyId(ctx context.Context, policyFamilyId string) (*PolicyFamily, error) {
-	return a.impl.Get(ctx, GetPolicyFamilyRequest{
+	return a.PolicyFamiliesService.Get(ctx, GetPolicyFamilyRequest{
 		PolicyFamilyId: policyFamilyId,
 	})
 }
@@ -3099,7 +2767,7 @@ func (a *PolicyFamiliesAPI) List(ctx context.Context, request ListPolicyFamilies
 
 	getNextPage := func(ctx context.Context, req ListPolicyFamiliesRequest) (*ListPolicyFamiliesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.PolicyFamiliesService.List(ctx, req)
 	}
 	getItems := func(resp *ListPolicyFamiliesResponse) []PolicyFamily {
 		return resp.PolicyFamilies

--- a/service/compute/commands.go
+++ b/service/compute/commands.go
@@ -23,9 +23,9 @@ type commandExecutionAPIUtilities interface {
 
 // Start the command execution context on a cluster and ensure it transitions to a running state
 func (a *CommandExecutionAPI) Start(ctx context.Context, clusterID string, language Language) (*CommandExecutorV2, error) {
-	executionImpl, ok := a.impl.(*commandExecutionImpl)
+	executionImpl, ok := a.CommandExecutionService.(*commandExecutionImpl)
 	if !ok {
-		return nil, fmt.Errorf("unknown command execution implementation: %v", a.impl)
+		return nil, fmt.Errorf("unknown command execution implementation: %v", a.CommandExecutionService)
 	}
 	// re-initializing clusters API here, so that we have less IF's in the generator for WorkspaceClient
 	clustersAPI := NewClusters(executionImpl.client)

--- a/service/compute/spark_version.go
+++ b/service/compute/spark_version.go
@@ -82,7 +82,7 @@ func (sv GetSparkVersionsResponse) Select(req SparkVersionRequest) (string, erro
 }
 
 func (a *ClustersAPI) SelectSparkVersion(ctx context.Context, r SparkVersionRequest) (string, error) {
-	sv, err := a.impl.SparkVersions(ctx)
+	sv, err := a.SparkVersions(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/service/compute/utilities.go
+++ b/service/compute/utilities.go
@@ -152,7 +152,7 @@ func (a *ClustersAPI) GetOrCreateRunningCluster(ctx context.Context, name string
 		NodeTypeId:             smallestNodeType,
 		AutoterminationMinutes: 10,
 	}
-	api, ok := a.impl.(*clustersImpl)
+	api, ok := a.ClustersService.(*clustersImpl)
 	if !ok {
 		return nil, fmt.Errorf("cannot get raw clusters API")
 	}

--- a/service/dashboards/api.go
+++ b/service/dashboards/api.go
@@ -108,9 +108,8 @@ type GenieAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGenieInterface instead.
 func (a *GenieAPI) WithImpl(impl GenieService) GenieInterface {
-	return &GenieAPI{
-		GenieService: impl,
-	}
+	a.GenieService = impl
+	return a
 }
 
 // Impl returns low-level Genie API implementation
@@ -459,9 +458,8 @@ type LakeviewAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockLakeviewInterface instead.
 func (a *LakeviewAPI) WithImpl(impl LakeviewService) LakeviewInterface {
-	return &LakeviewAPI{
-		LakeviewService: impl,
-	}
+	a.LakeviewService = impl
+	return a
 }
 
 // Impl returns low-level Lakeview API implementation

--- a/service/dashboards/api.go
+++ b/service/dashboards/api.go
@@ -87,7 +87,7 @@ type GenieInterface interface {
 
 func NewGenie(client *client.DatabricksClient) *GenieAPI {
 	return &GenieAPI{
-		impl: &genieImpl{
+		GenieService: &genieImpl{
 			client: client,
 		},
 	}
@@ -101,21 +101,22 @@ func NewGenie(client *client.DatabricksClient) *GenieAPI {
 type GenieAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(GenieService)
-	impl GenieService
+	GenieService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGenieInterface instead.
 func (a *GenieAPI) WithImpl(impl GenieService) GenieInterface {
-	a.impl = impl
-	return a
+	return &GenieAPI{
+		GenieService: impl,
+	}
 }
 
 // Impl returns low-level Genie API implementation
 // Deprecated: use MockGenieInterface instead.
 func (a *GenieAPI) Impl() GenieService {
-	return a.impl
+	return a.GenieService
 }
 
 // WaitGetMessageGenieCompleted repeatedly calls [GenieAPI.GetMessage] and waits to reach COMPLETED state
@@ -181,7 +182,7 @@ func (w *WaitGetMessageGenieCompleted[R]) GetWithTimeout(timeout time.Duration) 
 // Create new message in [conversation](:method:genie/startconversation). The AI
 // response uses all previously created messages in the conversation to respond.
 func (a *GenieAPI) CreateMessage(ctx context.Context, genieCreateConversationMessageRequest GenieCreateConversationMessageRequest) (*WaitGetMessageGenieCompleted[GenieMessage], error) {
-	genieMessage, err := a.impl.CreateMessage(ctx, genieCreateConversationMessageRequest)
+	genieMessage, err := a.GenieService.CreateMessage(ctx, genieCreateConversationMessageRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -225,25 +226,11 @@ func (a *GenieAPI) CreateMessageAndWait(ctx context.Context, genieCreateConversa
 	return wait.Get()
 }
 
-// Execute SQL query in a conversation message.
-//
-// Execute the SQL query in the message.
-func (a *GenieAPI) ExecuteMessageQuery(ctx context.Context, request ExecuteMessageQueryRequest) (*GenieGetMessageQueryResultResponse, error) {
-	return a.impl.ExecuteMessageQuery(ctx, request)
-}
-
-// Get conversation message.
-//
-// Get message from conversation.
-func (a *GenieAPI) GetMessage(ctx context.Context, request GenieGetConversationMessageRequest) (*GenieMessage, error) {
-	return a.impl.GetMessage(ctx, request)
-}
-
 // Get conversation message.
 //
 // Get message from conversation.
 func (a *GenieAPI) GetMessageBySpaceIdAndConversationIdAndMessageId(ctx context.Context, spaceId string, conversationId string, messageId string) (*GenieMessage, error) {
-	return a.impl.GetMessage(ctx, GenieGetConversationMessageRequest{
+	return a.GenieService.GetMessage(ctx, GenieGetConversationMessageRequest{
 		SpaceId:        spaceId,
 		ConversationId: conversationId,
 		MessageId:      messageId,
@@ -255,17 +242,8 @@ func (a *GenieAPI) GetMessageBySpaceIdAndConversationIdAndMessageId(ctx context.
 // Get the result of SQL query if the message has a query attachment. This is
 // only available if a message has a query attachment and the message status is
 // `EXECUTING_QUERY`.
-func (a *GenieAPI) GetMessageQueryResult(ctx context.Context, request GenieGetMessageQueryResultRequest) (*GenieGetMessageQueryResultResponse, error) {
-	return a.impl.GetMessageQueryResult(ctx, request)
-}
-
-// Get conversation message SQL query result.
-//
-// Get the result of SQL query if the message has a query attachment. This is
-// only available if a message has a query attachment and the message status is
-// `EXECUTING_QUERY`.
 func (a *GenieAPI) GetMessageQueryResultBySpaceIdAndConversationIdAndMessageId(ctx context.Context, spaceId string, conversationId string, messageId string) (*GenieGetMessageQueryResultResponse, error) {
-	return a.impl.GetMessageQueryResult(ctx, GenieGetMessageQueryResultRequest{
+	return a.GenieService.GetMessageQueryResult(ctx, GenieGetMessageQueryResultRequest{
 		SpaceId:        spaceId,
 		ConversationId: conversationId,
 		MessageId:      messageId,
@@ -276,7 +254,7 @@ func (a *GenieAPI) GetMessageQueryResultBySpaceIdAndConversationIdAndMessageId(c
 //
 // Start a new conversation.
 func (a *GenieAPI) StartConversation(ctx context.Context, genieStartConversationMessageRequest GenieStartConversationMessageRequest) (*WaitGetMessageGenieCompleted[GenieStartConversationResponse], error) {
-	genieStartConversationResponse, err := a.impl.StartConversation(ctx, genieStartConversationMessageRequest)
+	genieStartConversationResponse, err := a.GenieService.StartConversation(ctx, genieStartConversationMessageRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -462,7 +440,7 @@ type LakeviewInterface interface {
 
 func NewLakeview(client *client.DatabricksClient) *LakeviewAPI {
 	return &LakeviewAPI{
-		impl: &lakeviewImpl{
+		LakeviewService: &lakeviewImpl{
 			client: client,
 		},
 	}
@@ -474,61 +452,35 @@ func NewLakeview(client *client.DatabricksClient) *LakeviewAPI {
 type LakeviewAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(LakeviewService)
-	impl LakeviewService
+	LakeviewService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockLakeviewInterface instead.
 func (a *LakeviewAPI) WithImpl(impl LakeviewService) LakeviewInterface {
-	a.impl = impl
-	return a
+	return &LakeviewAPI{
+		LakeviewService: impl,
+	}
 }
 
 // Impl returns low-level Lakeview API implementation
 // Deprecated: use MockLakeviewInterface instead.
 func (a *LakeviewAPI) Impl() LakeviewService {
-	return a.impl
-}
-
-// Create dashboard.
-//
-// Create a draft dashboard.
-func (a *LakeviewAPI) Create(ctx context.Context, request CreateDashboardRequest) (*Dashboard, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Create dashboard schedule.
-func (a *LakeviewAPI) CreateSchedule(ctx context.Context, request CreateScheduleRequest) (*Schedule, error) {
-	return a.impl.CreateSchedule(ctx, request)
-}
-
-// Create schedule subscription.
-func (a *LakeviewAPI) CreateSubscription(ctx context.Context, request CreateSubscriptionRequest) (*Subscription, error) {
-	return a.impl.CreateSubscription(ctx, request)
-}
-
-// Delete dashboard schedule.
-func (a *LakeviewAPI) DeleteSchedule(ctx context.Context, request DeleteScheduleRequest) error {
-	return a.impl.DeleteSchedule(ctx, request)
+	return a.LakeviewService
 }
 
 // Delete dashboard schedule.
 func (a *LakeviewAPI) DeleteScheduleByDashboardIdAndScheduleId(ctx context.Context, dashboardId string, scheduleId string) error {
-	return a.impl.DeleteSchedule(ctx, DeleteScheduleRequest{
+	return a.LakeviewService.DeleteSchedule(ctx, DeleteScheduleRequest{
 		DashboardId: dashboardId,
 		ScheduleId:  scheduleId,
 	})
 }
 
 // Delete schedule subscription.
-func (a *LakeviewAPI) DeleteSubscription(ctx context.Context, request DeleteSubscriptionRequest) error {
-	return a.impl.DeleteSubscription(ctx, request)
-}
-
-// Delete schedule subscription.
 func (a *LakeviewAPI) DeleteSubscriptionByDashboardIdAndScheduleIdAndSubscriptionId(ctx context.Context, dashboardId string, scheduleId string, subscriptionId string) error {
-	return a.impl.DeleteSubscription(ctx, DeleteSubscriptionRequest{
+	return a.LakeviewService.DeleteSubscription(ctx, DeleteSubscriptionRequest{
 		DashboardId:    dashboardId,
 		ScheduleId:     scheduleId,
 		SubscriptionId: subscriptionId,
@@ -538,56 +490,32 @@ func (a *LakeviewAPI) DeleteSubscriptionByDashboardIdAndScheduleIdAndSubscriptio
 // Get dashboard.
 //
 // Get a draft dashboard.
-func (a *LakeviewAPI) Get(ctx context.Context, request GetDashboardRequest) (*Dashboard, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get dashboard.
-//
-// Get a draft dashboard.
 func (a *LakeviewAPI) GetByDashboardId(ctx context.Context, dashboardId string) (*Dashboard, error) {
-	return a.impl.Get(ctx, GetDashboardRequest{
+	return a.LakeviewService.Get(ctx, GetDashboardRequest{
 		DashboardId: dashboardId,
 	})
-}
-
-// Get published dashboard.
-//
-// Get the current published dashboard.
-func (a *LakeviewAPI) GetPublished(ctx context.Context, request GetPublishedDashboardRequest) (*PublishedDashboard, error) {
-	return a.impl.GetPublished(ctx, request)
 }
 
 // Get published dashboard.
 //
 // Get the current published dashboard.
 func (a *LakeviewAPI) GetPublishedByDashboardId(ctx context.Context, dashboardId string) (*PublishedDashboard, error) {
-	return a.impl.GetPublished(ctx, GetPublishedDashboardRequest{
+	return a.LakeviewService.GetPublished(ctx, GetPublishedDashboardRequest{
 		DashboardId: dashboardId,
 	})
 }
 
 // Get dashboard schedule.
-func (a *LakeviewAPI) GetSchedule(ctx context.Context, request GetScheduleRequest) (*Schedule, error) {
-	return a.impl.GetSchedule(ctx, request)
-}
-
-// Get dashboard schedule.
 func (a *LakeviewAPI) GetScheduleByDashboardIdAndScheduleId(ctx context.Context, dashboardId string, scheduleId string) (*Schedule, error) {
-	return a.impl.GetSchedule(ctx, GetScheduleRequest{
+	return a.LakeviewService.GetSchedule(ctx, GetScheduleRequest{
 		DashboardId: dashboardId,
 		ScheduleId:  scheduleId,
 	})
 }
 
 // Get schedule subscription.
-func (a *LakeviewAPI) GetSubscription(ctx context.Context, request GetSubscriptionRequest) (*Subscription, error) {
-	return a.impl.GetSubscription(ctx, request)
-}
-
-// Get schedule subscription.
 func (a *LakeviewAPI) GetSubscriptionByDashboardIdAndScheduleIdAndSubscriptionId(ctx context.Context, dashboardId string, scheduleId string, subscriptionId string) (*Subscription, error) {
-	return a.impl.GetSubscription(ctx, GetSubscriptionRequest{
+	return a.LakeviewService.GetSubscription(ctx, GetSubscriptionRequest{
 		DashboardId:    dashboardId,
 		ScheduleId:     scheduleId,
 		SubscriptionId: subscriptionId,
@@ -601,7 +529,7 @@ func (a *LakeviewAPI) List(ctx context.Context, request ListDashboardsRequest) l
 
 	getNextPage := func(ctx context.Context, req ListDashboardsRequest) (*ListDashboardsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.LakeviewService.List(ctx, req)
 	}
 	getItems := func(resp *ListDashboardsResponse) []Dashboard {
 		return resp.Dashboards
@@ -636,7 +564,7 @@ func (a *LakeviewAPI) ListSchedules(ctx context.Context, request ListSchedulesRe
 
 	getNextPage := func(ctx context.Context, req ListSchedulesRequest) (*ListSchedulesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListSchedules(ctx, req)
+		return a.LakeviewService.ListSchedules(ctx, req)
 	}
 	getItems := func(resp *ListSchedulesResponse) []Schedule {
 		return resp.Schedules
@@ -666,7 +594,7 @@ func (a *LakeviewAPI) ListSchedulesAll(ctx context.Context, request ListSchedule
 
 // List dashboard schedules.
 func (a *LakeviewAPI) ListSchedulesByDashboardId(ctx context.Context, dashboardId string) (*ListSchedulesResponse, error) {
-	return a.impl.ListSchedules(ctx, ListSchedulesRequest{
+	return a.LakeviewService.ListSchedules(ctx, ListSchedulesRequest{
 		DashboardId: dashboardId,
 	})
 }
@@ -678,7 +606,7 @@ func (a *LakeviewAPI) ListSubscriptions(ctx context.Context, request ListSubscri
 
 	getNextPage := func(ctx context.Context, req ListSubscriptionsRequest) (*ListSubscriptionsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListSubscriptions(ctx, req)
+		return a.LakeviewService.ListSubscriptions(ctx, req)
 	}
 	getItems := func(resp *ListSubscriptionsResponse) []Subscription {
 		return resp.Subscriptions
@@ -708,66 +636,26 @@ func (a *LakeviewAPI) ListSubscriptionsAll(ctx context.Context, request ListSubs
 
 // List schedule subscriptions.
 func (a *LakeviewAPI) ListSubscriptionsByDashboardIdAndScheduleId(ctx context.Context, dashboardId string, scheduleId string) (*ListSubscriptionsResponse, error) {
-	return a.impl.ListSubscriptions(ctx, ListSubscriptionsRequest{
+	return a.LakeviewService.ListSubscriptions(ctx, ListSubscriptionsRequest{
 		DashboardId: dashboardId,
 		ScheduleId:  scheduleId,
 	})
-}
-
-// Migrate dashboard.
-//
-// Migrates a classic SQL dashboard to Lakeview.
-func (a *LakeviewAPI) Migrate(ctx context.Context, request MigrateDashboardRequest) (*Dashboard, error) {
-	return a.impl.Migrate(ctx, request)
-}
-
-// Publish dashboard.
-//
-// Publish the current draft dashboard.
-func (a *LakeviewAPI) Publish(ctx context.Context, request PublishRequest) (*PublishedDashboard, error) {
-	return a.impl.Publish(ctx, request)
-}
-
-// Trash dashboard.
-//
-// Trash a dashboard.
-func (a *LakeviewAPI) Trash(ctx context.Context, request TrashDashboardRequest) error {
-	return a.impl.Trash(ctx, request)
 }
 
 // Trash dashboard.
 //
 // Trash a dashboard.
 func (a *LakeviewAPI) TrashByDashboardId(ctx context.Context, dashboardId string) error {
-	return a.impl.Trash(ctx, TrashDashboardRequest{
+	return a.LakeviewService.Trash(ctx, TrashDashboardRequest{
 		DashboardId: dashboardId,
 	})
-}
-
-// Unpublish dashboard.
-//
-// Unpublish the dashboard.
-func (a *LakeviewAPI) Unpublish(ctx context.Context, request UnpublishDashboardRequest) error {
-	return a.impl.Unpublish(ctx, request)
 }
 
 // Unpublish dashboard.
 //
 // Unpublish the dashboard.
 func (a *LakeviewAPI) UnpublishByDashboardId(ctx context.Context, dashboardId string) error {
-	return a.impl.Unpublish(ctx, UnpublishDashboardRequest{
+	return a.LakeviewService.Unpublish(ctx, UnpublishDashboardRequest{
 		DashboardId: dashboardId,
 	})
-}
-
-// Update dashboard.
-//
-// Update a draft dashboard.
-func (a *LakeviewAPI) Update(ctx context.Context, request UpdateDashboardRequest) (*Dashboard, error) {
-	return a.impl.Update(ctx, request)
-}
-
-// Update dashboard schedule.
-func (a *LakeviewAPI) UpdateSchedule(ctx context.Context, request UpdateScheduleRequest) (*Schedule, error) {
-	return a.impl.UpdateSchedule(ctx, request)
 }

--- a/service/files/api.go
+++ b/service/files/api.go
@@ -217,9 +217,8 @@ type DbfsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDbfsInterface instead.
 func (a *DbfsAPI) WithImpl(impl DbfsService) DbfsInterface {
-	return &DbfsAPI{
-		DbfsService: impl,
-	}
+	a.DbfsService = impl
+	return a
 }
 
 // Impl returns low-level Dbfs API implementation
@@ -495,9 +494,8 @@ type FilesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockFilesInterface instead.
 func (a *FilesAPI) WithImpl(impl FilesService) FilesInterface {
-	return &FilesAPI{
-		FilesService: impl,
-	}
+	a.FilesService = impl
+	return a
 }
 
 // Impl returns low-level Files API implementation

--- a/service/files/api.go
+++ b/service/files/api.go
@@ -199,7 +199,7 @@ type DbfsInterface interface {
 
 func NewDbfs(client *client.DatabricksClient) *DbfsAPI {
 	return &DbfsAPI{
-		impl: &dbfsImpl{
+		DbfsService: &dbfsImpl{
 			client: client,
 		},
 	}
@@ -210,41 +210,22 @@ func NewDbfs(client *client.DatabricksClient) *DbfsAPI {
 type DbfsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(DbfsService)
-	impl DbfsService
+	DbfsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDbfsInterface instead.
 func (a *DbfsAPI) WithImpl(impl DbfsService) DbfsInterface {
-	a.impl = impl
-	return a
+	return &DbfsAPI{
+		DbfsService: impl,
+	}
 }
 
 // Impl returns low-level Dbfs API implementation
 // Deprecated: use MockDbfsInterface instead.
 func (a *DbfsAPI) Impl() DbfsService {
-	return a.impl
-}
-
-// Append data block.
-//
-// Appends a block of data to the stream specified by the input handle. If the
-// handle does not exist, this call will throw an exception with
-// “RESOURCE_DOES_NOT_EXIST“.
-//
-// If the block of data exceeds 1 MB, this call will throw an exception with
-// “MAX_BLOCK_SIZE_EXCEEDED“.
-func (a *DbfsAPI) AddBlock(ctx context.Context, request AddBlock) error {
-	return a.impl.AddBlock(ctx, request)
-}
-
-// Close the stream.
-//
-// Closes the stream specified by the input handle. If the handle does not
-// exist, this call throws an exception with “RESOURCE_DOES_NOT_EXIST“.
-func (a *DbfsAPI) Close(ctx context.Context, request Close) error {
-	return a.impl.Close(ctx, request)
+	return a.DbfsService
 }
 
 // Close the stream.
@@ -252,57 +233,9 @@ func (a *DbfsAPI) Close(ctx context.Context, request Close) error {
 // Closes the stream specified by the input handle. If the handle does not
 // exist, this call throws an exception with “RESOURCE_DOES_NOT_EXIST“.
 func (a *DbfsAPI) CloseByHandle(ctx context.Context, handle int64) error {
-	return a.impl.Close(ctx, Close{
+	return a.DbfsService.Close(ctx, Close{
 		Handle: handle,
 	})
-}
-
-// Open a stream.
-//
-// Opens a stream to write to a file and returns a handle to this stream. There
-// is a 10 minute idle timeout on this handle. If a file or directory already
-// exists on the given path and __overwrite__ is set to false, this call will
-// throw an exception with “RESOURCE_ALREADY_EXISTS“.
-//
-// A typical workflow for file upload would be:
-//
-// 1. Issue a “create“ call and get a handle. 2. Issue one or more
-// “add-block“ calls with the handle you have. 3. Issue a “close“ call with
-// the handle you have.
-func (a *DbfsAPI) Create(ctx context.Context, request Create) (*CreateResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a file/directory.
-//
-// Delete the file or directory (optionally recursively delete all files in the
-// directory). This call throws an exception with `IO_ERROR` if the path is a
-// non-empty directory and `recursive` is set to `false` or on other similar
-// errors.
-//
-// When you delete a large number of files, the delete operation is done in
-// increments. The call returns a response after approximately 45 seconds with
-// an error message (503 Service Unavailable) asking you to re-invoke the delete
-// operation until the directory structure is fully deleted.
-//
-// For operations that delete more than 10K files, we discourage using the DBFS
-// REST API, but advise you to perform such operations in the context of a
-// cluster, using the [File system utility
-// (dbutils.fs)](/dev-tools/databricks-utils.html#dbutils-fs). `dbutils.fs`
-// covers the functional scope of the DBFS REST API, but from notebooks. Running
-// such operations using notebooks provides better control and manageability,
-// such as selective deletes, and the possibility to automate periodic delete
-// jobs.
-func (a *DbfsAPI) Delete(ctx context.Context, request Delete) error {
-	return a.impl.Delete(ctx, request)
-}
-
-// Get the information of a file or directory.
-//
-// Gets the file information for a file or directory. If the file or directory
-// does not exist, this call throws an exception with `RESOURCE_DOES_NOT_EXIST`.
-func (a *DbfsAPI) GetStatus(ctx context.Context, request GetStatusRequest) (*FileInfo, error) {
-	return a.impl.GetStatus(ctx, request)
 }
 
 // Get the information of a file or directory.
@@ -310,7 +243,7 @@ func (a *DbfsAPI) GetStatus(ctx context.Context, request GetStatusRequest) (*Fil
 // Gets the file information for a file or directory. If the file or directory
 // does not exist, this call throws an exception with `RESOURCE_DOES_NOT_EXIST`.
 func (a *DbfsAPI) GetStatusByPath(ctx context.Context, path string) (*FileInfo, error) {
-	return a.impl.GetStatus(ctx, GetStatusRequest{
+	return a.DbfsService.GetStatus(ctx, GetStatusRequest{
 		Path: path,
 	})
 }
@@ -334,7 +267,7 @@ func (a *DbfsAPI) List(ctx context.Context, request ListDbfsRequest) listing.Ite
 
 	getNextPage := func(ctx context.Context, req ListDbfsRequest) (*ListStatusResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.DbfsService.List(ctx, req)
 	}
 	getItems := func(resp *ListStatusResponse) []FileInfo {
 		return resp.Files
@@ -382,20 +315,9 @@ func (a *DbfsAPI) ListAll(ctx context.Context, request ListDbfsRequest) ([]FileI
 // system utility (dbutils.fs)](/dev-tools/databricks-utils.html#dbutils-fs),
 // which provides the same functionality without timing out.
 func (a *DbfsAPI) ListByPath(ctx context.Context, path string) (*ListStatusResponse, error) {
-	return a.impl.List(ctx, ListDbfsRequest{
+	return a.DbfsService.List(ctx, ListDbfsRequest{
 		Path: path,
 	})
-}
-
-// Create a directory.
-//
-// Creates the given directory and necessary parent directories if they do not
-// exist. If a file (not a directory) exists at any prefix of the input path,
-// this call throws an exception with `RESOURCE_ALREADY_EXISTS`. **Note**: If
-// this operation fails, it might have succeeded in creating some of the
-// necessary parent directories.
-func (a *DbfsAPI) Mkdirs(ctx context.Context, request MkDirs) error {
-	return a.impl.Mkdirs(ctx, request)
 }
 
 // Create a directory.
@@ -406,52 +328,9 @@ func (a *DbfsAPI) Mkdirs(ctx context.Context, request MkDirs) error {
 // this operation fails, it might have succeeded in creating some of the
 // necessary parent directories.
 func (a *DbfsAPI) MkdirsByPath(ctx context.Context, path string) error {
-	return a.impl.Mkdirs(ctx, MkDirs{
+	return a.DbfsService.Mkdirs(ctx, MkDirs{
 		Path: path,
 	})
-}
-
-// Move a file.
-//
-// Moves a file from one location to another location within DBFS. If the source
-// file does not exist, this call throws an exception with
-// `RESOURCE_DOES_NOT_EXIST`. If a file already exists in the destination path,
-// this call throws an exception with `RESOURCE_ALREADY_EXISTS`. If the given
-// source path is a directory, this call always recursively moves all files.
-func (a *DbfsAPI) Move(ctx context.Context, request Move) error {
-	return a.impl.Move(ctx, request)
-}
-
-// Upload a file.
-//
-// Uploads a file through the use of multipart form post. It is mainly used for
-// streaming uploads, but can also be used as a convenient single call for data
-// upload.
-//
-// Alternatively you can pass contents as base64 string.
-//
-// The amount of data that can be passed (when not streaming) using the
-// __contents__ parameter is limited to 1 MB. `MAX_BLOCK_SIZE_EXCEEDED` will be
-// thrown if this limit is exceeded.
-//
-// If you want to upload large files, use the streaming upload. For details, see
-// :method:dbfs/create, :method:dbfs/addBlock, :method:dbfs/close.
-func (a *DbfsAPI) Put(ctx context.Context, request Put) error {
-	return a.impl.Put(ctx, request)
-}
-
-// Get the contents of a file.
-//
-// Returns the contents of a file. If the file does not exist, this call throws
-// an exception with `RESOURCE_DOES_NOT_EXIST`. If the path is a directory, the
-// read length is negative, or if the offset is negative, this call throws an
-// exception with `INVALID_PARAMETER_VALUE`. If the read length exceeds 1 MB,
-// this call throws an exception with `MAX_READ_SIZE_EXCEEDED`.
-//
-// If `offset + length` exceeds the number of bytes in a file, it reads the
-// contents until the end of file.
-func (a *DbfsAPI) Read(ctx context.Context, request ReadDbfsRequest) (*ReadResponse, error) {
-	return a.impl.Read(ctx, request)
 }
 
 type FilesInterface interface {
@@ -584,7 +463,7 @@ type FilesInterface interface {
 
 func NewFiles(client *client.DatabricksClient) *FilesAPI {
 	return &FilesAPI{
-		impl: &filesImpl{
+		FilesService: &filesImpl{
 			client: client,
 		},
 	}
@@ -609,58 +488,31 @@ func NewFiles(client *client.DatabricksClient) *FilesAPI {
 type FilesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(FilesService)
-	impl FilesService
+	FilesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockFilesInterface instead.
 func (a *FilesAPI) WithImpl(impl FilesService) FilesInterface {
-	a.impl = impl
-	return a
+	return &FilesAPI{
+		FilesService: impl,
+	}
 }
 
 // Impl returns low-level Files API implementation
 // Deprecated: use MockFilesInterface instead.
 func (a *FilesAPI) Impl() FilesService {
-	return a.impl
-}
-
-// Create a directory.
-//
-// Creates an empty directory. If necessary, also creates any parent directories
-// of the new, empty directory (like the shell command `mkdir -p`). If called on
-// an existing directory, returns a success response; this method is idempotent
-// (it will succeed if the directory already exists).
-func (a *FilesAPI) CreateDirectory(ctx context.Context, request CreateDirectoryRequest) error {
-	return a.impl.CreateDirectory(ctx, request)
-}
-
-// Delete a file.
-//
-// Deletes a file. If the request is successful, there is no response body.
-func (a *FilesAPI) Delete(ctx context.Context, request DeleteFileRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.FilesService
 }
 
 // Delete a file.
 //
 // Deletes a file. If the request is successful, there is no response body.
 func (a *FilesAPI) DeleteByFilePath(ctx context.Context, filePath string) error {
-	return a.impl.Delete(ctx, DeleteFileRequest{
+	return a.FilesService.Delete(ctx, DeleteFileRequest{
 		FilePath: filePath,
 	})
-}
-
-// Delete a directory.
-//
-// Deletes an empty directory.
-//
-// To delete a non-empty directory, first delete all of its contents. This can
-// be done by listing the directory contents and deleting each file and
-// subdirectory recursively.
-func (a *FilesAPI) DeleteDirectory(ctx context.Context, request DeleteDirectoryRequest) error {
-	return a.impl.DeleteDirectory(ctx, request)
 }
 
 // Delete a directory.
@@ -671,7 +523,7 @@ func (a *FilesAPI) DeleteDirectory(ctx context.Context, request DeleteDirectoryR
 // be done by listing the directory contents and deleting each file and
 // subdirectory recursively.
 func (a *FilesAPI) DeleteDirectoryByDirectoryPath(ctx context.Context, directoryPath string) error {
-	return a.impl.DeleteDirectory(ctx, DeleteDirectoryRequest{
+	return a.FilesService.DeleteDirectory(ctx, DeleteDirectoryRequest{
 		DirectoryPath: directoryPath,
 	})
 }
@@ -680,33 +532,10 @@ func (a *FilesAPI) DeleteDirectoryByDirectoryPath(ctx context.Context, directory
 //
 // Downloads a file of up to 5 GiB. The file contents are the response body.
 // This is a standard HTTP file download, not a JSON RPC.
-func (a *FilesAPI) Download(ctx context.Context, request DownloadRequest) (*DownloadResponse, error) {
-	return a.impl.Download(ctx, request)
-}
-
-// Download a file.
-//
-// Downloads a file of up to 5 GiB. The file contents are the response body.
-// This is a standard HTTP file download, not a JSON RPC.
 func (a *FilesAPI) DownloadByFilePath(ctx context.Context, filePath string) (*DownloadResponse, error) {
-	return a.impl.Download(ctx, DownloadRequest{
+	return a.FilesService.Download(ctx, DownloadRequest{
 		FilePath: filePath,
 	})
-}
-
-// Get directory metadata.
-//
-// Get the metadata of a directory. The response HTTP headers contain the
-// metadata. There is no response body.
-//
-// This method is useful to check if a directory exists and the caller has
-// access to it.
-//
-// If you wish to ensure the directory exists, you can instead use `PUT`, which
-// will create the directory if it does not exist, and is idempotent (it will
-// succeed if the directory already exists).
-func (a *FilesAPI) GetDirectoryMetadata(ctx context.Context, request GetDirectoryMetadataRequest) error {
-	return a.impl.GetDirectoryMetadata(ctx, request)
 }
 
 // Get directory metadata.
@@ -721,7 +550,7 @@ func (a *FilesAPI) GetDirectoryMetadata(ctx context.Context, request GetDirector
 // will create the directory if it does not exist, and is idempotent (it will
 // succeed if the directory already exists).
 func (a *FilesAPI) GetDirectoryMetadataByDirectoryPath(ctx context.Context, directoryPath string) error {
-	return a.impl.GetDirectoryMetadata(ctx, GetDirectoryMetadataRequest{
+	return a.FilesService.GetDirectoryMetadata(ctx, GetDirectoryMetadataRequest{
 		DirectoryPath: directoryPath,
 	})
 }
@@ -730,16 +559,8 @@ func (a *FilesAPI) GetDirectoryMetadataByDirectoryPath(ctx context.Context, dire
 //
 // Get the metadata of a file. The response HTTP headers contain the metadata.
 // There is no response body.
-func (a *FilesAPI) GetMetadata(ctx context.Context, request GetMetadataRequest) (*GetMetadataResponse, error) {
-	return a.impl.GetMetadata(ctx, request)
-}
-
-// Get file metadata.
-//
-// Get the metadata of a file. The response HTTP headers contain the metadata.
-// There is no response body.
 func (a *FilesAPI) GetMetadataByFilePath(ctx context.Context, filePath string) (*GetMetadataResponse, error) {
-	return a.impl.GetMetadata(ctx, GetMetadataRequest{
+	return a.FilesService.GetMetadata(ctx, GetMetadataRequest{
 		FilePath: filePath,
 	})
 }
@@ -754,7 +575,7 @@ func (a *FilesAPI) ListDirectoryContents(ctx context.Context, request ListDirect
 
 	getNextPage := func(ctx context.Context, req ListDirectoryContentsRequest) (*ListDirectoryResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListDirectoryContents(ctx, req)
+		return a.FilesService.ListDirectoryContents(ctx, req)
 	}
 	getItems := func(resp *ListDirectoryResponse) []DirectoryEntry {
 		return resp.Contents
@@ -791,18 +612,7 @@ func (a *FilesAPI) ListDirectoryContentsAll(ctx context.Context, request ListDir
 // Returns the contents of a directory. If there is no directory at the
 // specified path, the API returns a HTTP 404 error.
 func (a *FilesAPI) ListDirectoryContentsByDirectoryPath(ctx context.Context, directoryPath string) (*ListDirectoryResponse, error) {
-	return a.impl.ListDirectoryContents(ctx, ListDirectoryContentsRequest{
+	return a.FilesService.ListDirectoryContents(ctx, ListDirectoryContentsRequest{
 		DirectoryPath: directoryPath,
 	})
-}
-
-// Upload a file.
-//
-// Uploads a file of up to 5 GiB. The file contents should be sent as the
-// request body as raw bytes (an octet stream); do not encode or otherwise
-// modify the bytes before sending. The contents of the resulting file will be
-// exactly the bytes sent in the request body. If the request is successful,
-// there is no response body.
-func (a *FilesAPI) Upload(ctx context.Context, request UploadRequest) error {
-	return a.impl.Upload(ctx, request)
 }

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -65,9 +65,8 @@ type AccountAccessControlAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountAccessControlInterface instead.
 func (a *AccountAccessControlAPI) WithImpl(impl AccountAccessControlService) AccountAccessControlInterface {
-	return &AccountAccessControlAPI{
-		AccountAccessControlService: impl,
-	}
+	a.AccountAccessControlService = impl
+	return a
 }
 
 // Impl returns low-level AccountAccessControl API implementation
@@ -130,9 +129,8 @@ type AccountAccessControlProxyAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountAccessControlProxyInterface instead.
 func (a *AccountAccessControlProxyAPI) WithImpl(impl AccountAccessControlProxyService) AccountAccessControlProxyInterface {
-	return &AccountAccessControlProxyAPI{
-		AccountAccessControlProxyService: impl,
-	}
+	a.AccountAccessControlProxyService = impl
+	return a
 }
 
 // Impl returns low-level AccountAccessControlProxy API implementation
@@ -245,9 +243,8 @@ type AccountGroupsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountGroupsInterface instead.
 func (a *AccountGroupsAPI) WithImpl(impl AccountGroupsService) AccountGroupsInterface {
-	return &AccountGroupsAPI{
-		AccountGroupsService: impl,
-	}
+	a.AccountGroupsService = impl
+	return a
 }
 
 // Impl returns low-level AccountGroups API implementation
@@ -483,9 +480,8 @@ type AccountServicePrincipalsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountServicePrincipalsInterface instead.
 func (a *AccountServicePrincipalsAPI) WithImpl(impl AccountServicePrincipalsService) AccountServicePrincipalsInterface {
-	return &AccountServicePrincipalsAPI{
-		AccountServicePrincipalsService: impl,
-	}
+	a.AccountServicePrincipalsService = impl
+	return a
 }
 
 // Impl returns low-level AccountServicePrincipals API implementation
@@ -726,9 +722,8 @@ type AccountUsersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountUsersInterface instead.
 func (a *AccountUsersAPI) WithImpl(impl AccountUsersService) AccountUsersInterface {
-	return &AccountUsersAPI{
-		AccountUsersService: impl,
-	}
+	a.AccountUsersService = impl
+	return a
 }
 
 // Impl returns low-level AccountUsers API implementation
@@ -894,9 +889,8 @@ type CurrentUserAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCurrentUserInterface instead.
 func (a *CurrentUserAPI) WithImpl(impl CurrentUserService) CurrentUserInterface {
-	return &CurrentUserAPI{
-		CurrentUserService: impl,
-	}
+	a.CurrentUserService = impl
+	return a
 }
 
 // Impl returns low-level CurrentUser API implementation
@@ -1009,9 +1003,8 @@ type GroupsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGroupsInterface instead.
 func (a *GroupsAPI) WithImpl(impl GroupsService) GroupsInterface {
-	return &GroupsAPI{
-		GroupsService: impl,
-	}
+	a.GroupsService = impl
+	return a
 }
 
 // Impl returns low-level Groups API implementation
@@ -1174,9 +1167,8 @@ type PermissionMigrationAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPermissionMigrationInterface instead.
 func (a *PermissionMigrationAPI) WithImpl(impl PermissionMigrationService) PermissionMigrationInterface {
-	return &PermissionMigrationAPI{
-		PermissionMigrationService: impl,
-	}
+	a.PermissionMigrationService = impl
+	return a
 }
 
 // Impl returns low-level PermissionMigration API implementation
@@ -1298,9 +1290,8 @@ type PermissionsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPermissionsInterface instead.
 func (a *PermissionsAPI) WithImpl(impl PermissionsService) PermissionsInterface {
-	return &PermissionsAPI{
-		PermissionsService: impl,
-	}
+	a.PermissionsService = impl
+	return a
 }
 
 // Impl returns low-level Permissions API implementation
@@ -1437,9 +1428,8 @@ type ServicePrincipalsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockServicePrincipalsInterface instead.
 func (a *ServicePrincipalsAPI) WithImpl(impl ServicePrincipalsService) ServicePrincipalsInterface {
-	return &ServicePrincipalsAPI{
-		ServicePrincipalsService: impl,
-	}
+	a.ServicePrincipalsService = impl
+	return a
 }
 
 // Impl returns low-level ServicePrincipals API implementation
@@ -1703,9 +1693,8 @@ type UsersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockUsersInterface instead.
 func (a *UsersAPI) WithImpl(impl UsersService) UsersInterface {
-	return &UsersAPI{
-		UsersService: impl,
-	}
+	a.UsersService = impl
+	return a
 }
 
 // Impl returns low-level Users API implementation
@@ -1918,9 +1907,8 @@ type WorkspaceAssignmentAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceAssignmentInterface instead.
 func (a *WorkspaceAssignmentAPI) WithImpl(impl WorkspaceAssignmentService) WorkspaceAssignmentInterface {
-	return &WorkspaceAssignmentAPI{
-		WorkspaceAssignmentService: impl,
-	}
+	a.WorkspaceAssignmentService = impl
+	return a
 }
 
 // Impl returns low-level WorkspaceAssignment API implementation

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -46,7 +46,7 @@ type AccountAccessControlInterface interface {
 
 func NewAccountAccessControl(client *client.DatabricksClient) *AccountAccessControlAPI {
 	return &AccountAccessControlAPI{
-		impl: &accountAccessControlImpl{
+		AccountAccessControlService: &accountAccessControlImpl{
 			client: client,
 		},
 	}
@@ -58,48 +58,22 @@ func NewAccountAccessControl(client *client.DatabricksClient) *AccountAccessCont
 type AccountAccessControlAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountAccessControlService)
-	impl AccountAccessControlService
+	AccountAccessControlService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountAccessControlInterface instead.
 func (a *AccountAccessControlAPI) WithImpl(impl AccountAccessControlService) AccountAccessControlInterface {
-	a.impl = impl
-	return a
+	return &AccountAccessControlAPI{
+		AccountAccessControlService: impl,
+	}
 }
 
 // Impl returns low-level AccountAccessControl API implementation
 // Deprecated: use MockAccountAccessControlInterface instead.
 func (a *AccountAccessControlAPI) Impl() AccountAccessControlService {
-	return a.impl
-}
-
-// Get assignable roles for a resource.
-//
-// Gets all the roles that can be granted on an account level resource. A role
-// is grantable if the rule set on the resource can contain an access rule of
-// the role.
-func (a *AccountAccessControlAPI) GetAssignableRolesForResource(ctx context.Context, request GetAssignableRolesForResourceRequest) (*GetAssignableRolesForResourceResponse, error) {
-	return a.impl.GetAssignableRolesForResource(ctx, request)
-}
-
-// Get a rule set.
-//
-// Get a rule set by its name. A rule set is always attached to a resource and
-// contains a list of access rules on the said resource. Currently only a
-// default rule set for each resource is supported.
-func (a *AccountAccessControlAPI) GetRuleSet(ctx context.Context, request GetRuleSetRequest) (*RuleSetResponse, error) {
-	return a.impl.GetRuleSet(ctx, request)
-}
-
-// Update a rule set.
-//
-// Replace the rules of a rule set. First, use get to read the current version
-// of the rule set before modifying it. This pattern helps prevent conflicts
-// between concurrent updates.
-func (a *AccountAccessControlAPI) UpdateRuleSet(ctx context.Context, request UpdateRuleSetRequest) (*RuleSetResponse, error) {
-	return a.impl.UpdateRuleSet(ctx, request)
+	return a.AccountAccessControlService
 }
 
 type AccountAccessControlProxyInterface interface {
@@ -136,7 +110,7 @@ type AccountAccessControlProxyInterface interface {
 
 func NewAccountAccessControlProxy(client *client.DatabricksClient) *AccountAccessControlProxyAPI {
 	return &AccountAccessControlProxyAPI{
-		impl: &accountAccessControlProxyImpl{
+		AccountAccessControlProxyService: &accountAccessControlProxyImpl{
 			client: client,
 		},
 	}
@@ -149,48 +123,22 @@ func NewAccountAccessControlProxy(client *client.DatabricksClient) *AccountAcces
 type AccountAccessControlProxyAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountAccessControlProxyService)
-	impl AccountAccessControlProxyService
+	AccountAccessControlProxyService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountAccessControlProxyInterface instead.
 func (a *AccountAccessControlProxyAPI) WithImpl(impl AccountAccessControlProxyService) AccountAccessControlProxyInterface {
-	a.impl = impl
-	return a
+	return &AccountAccessControlProxyAPI{
+		AccountAccessControlProxyService: impl,
+	}
 }
 
 // Impl returns low-level AccountAccessControlProxy API implementation
 // Deprecated: use MockAccountAccessControlProxyInterface instead.
 func (a *AccountAccessControlProxyAPI) Impl() AccountAccessControlProxyService {
-	return a.impl
-}
-
-// Get assignable roles for a resource.
-//
-// Gets all the roles that can be granted on an account-level resource. A role
-// is grantable if the rule set on the resource can contain an access rule of
-// the role.
-func (a *AccountAccessControlProxyAPI) GetAssignableRolesForResource(ctx context.Context, request GetAssignableRolesForResourceRequest) (*GetAssignableRolesForResourceResponse, error) {
-	return a.impl.GetAssignableRolesForResource(ctx, request)
-}
-
-// Get a rule set.
-//
-// Get a rule set by its name. A rule set is always attached to a resource and
-// contains a list of access rules on the said resource. Currently only a
-// default rule set for each resource is supported.
-func (a *AccountAccessControlProxyAPI) GetRuleSet(ctx context.Context, request GetRuleSetRequest) (*RuleSetResponse, error) {
-	return a.impl.GetRuleSet(ctx, request)
-}
-
-// Update a rule set.
-//
-// Replace the rules of a rule set. First, use a GET rule set request to read
-// the current version of the rule set before modifying it. This pattern helps
-// prevent conflicts between concurrent updates.
-func (a *AccountAccessControlProxyAPI) UpdateRuleSet(ctx context.Context, request UpdateRuleSetRequest) (*RuleSetResponse, error) {
-	return a.impl.UpdateRuleSet(ctx, request)
+	return a.AccountAccessControlProxyService
 }
 
 type AccountGroupsInterface interface {
@@ -274,7 +222,7 @@ type AccountGroupsInterface interface {
 
 func NewAccountGroups(client *client.DatabricksClient) *AccountGroupsAPI {
 	return &AccountGroupsAPI{
-		impl: &accountGroupsImpl{
+		AccountGroupsService: &accountGroupsImpl{
 			client: client,
 		},
 	}
@@ -290,43 +238,29 @@ func NewAccountGroups(client *client.DatabricksClient) *AccountGroupsAPI {
 type AccountGroupsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountGroupsService)
-	impl AccountGroupsService
+	AccountGroupsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountGroupsInterface instead.
 func (a *AccountGroupsAPI) WithImpl(impl AccountGroupsService) AccountGroupsInterface {
-	a.impl = impl
-	return a
+	return &AccountGroupsAPI{
+		AccountGroupsService: impl,
+	}
 }
 
 // Impl returns low-level AccountGroups API implementation
 // Deprecated: use MockAccountGroupsInterface instead.
 func (a *AccountGroupsAPI) Impl() AccountGroupsService {
-	return a.impl
-}
-
-// Create a new group.
-//
-// Creates a group in the Databricks account with a unique name, using the
-// supplied group details.
-func (a *AccountGroupsAPI) Create(ctx context.Context, request Group) (*Group, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a group.
-//
-// Deletes a group from the Databricks account.
-func (a *AccountGroupsAPI) Delete(ctx context.Context, request DeleteAccountGroupRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountGroupsService
 }
 
 // Delete a group.
 //
 // Deletes a group from the Databricks account.
 func (a *AccountGroupsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteAccountGroupRequest{
+	return a.AccountGroupsService.Delete(ctx, DeleteAccountGroupRequest{
 		Id: id,
 	})
 }
@@ -334,15 +268,8 @@ func (a *AccountGroupsAPI) DeleteById(ctx context.Context, id string) error {
 // Get group details.
 //
 // Gets the information for a specific group in the Databricks account.
-func (a *AccountGroupsAPI) Get(ctx context.Context, request GetAccountGroupRequest) (*Group, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get group details.
-//
-// Gets the information for a specific group in the Databricks account.
 func (a *AccountGroupsAPI) GetById(ctx context.Context, id string) (*Group, error) {
-	return a.impl.Get(ctx, GetAccountGroupRequest{
+	return a.AccountGroupsService.Get(ctx, GetAccountGroupRequest{
 		Id: id,
 	})
 }
@@ -360,7 +287,7 @@ func (a *AccountGroupsAPI) List(ctx context.Context, request ListAccountGroupsRe
 	}
 	getNextPage := func(ctx context.Context, req ListAccountGroupsRequest) (*ListGroupsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.AccountGroupsService.List(ctx, req)
 	}
 	getItems := func(resp *ListGroupsResponse) []Group {
 		return resp.Resources
@@ -449,20 +376,6 @@ func (a *AccountGroupsAPI) GetByDisplayName(ctx context.Context, name string) (*
 	return &alternatives[0], nil
 }
 
-// Update group details.
-//
-// Partially updates the details of a group.
-func (a *AccountGroupsAPI) Patch(ctx context.Context, request PartialUpdate) error {
-	return a.impl.Patch(ctx, request)
-}
-
-// Replace a group.
-//
-// Updates the details of a group by replacing the entire group entity.
-func (a *AccountGroupsAPI) Update(ctx context.Context, request Group) error {
-	return a.impl.Update(ctx, request)
-}
-
 type AccountServicePrincipalsInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -548,7 +461,7 @@ type AccountServicePrincipalsInterface interface {
 
 func NewAccountServicePrincipals(client *client.DatabricksClient) *AccountServicePrincipalsAPI {
 	return &AccountServicePrincipalsAPI{
-		impl: &accountServicePrincipalsImpl{
+		AccountServicePrincipalsService: &accountServicePrincipalsImpl{
 			client: client,
 		},
 	}
@@ -563,42 +476,29 @@ func NewAccountServicePrincipals(client *client.DatabricksClient) *AccountServic
 type AccountServicePrincipalsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountServicePrincipalsService)
-	impl AccountServicePrincipalsService
+	AccountServicePrincipalsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountServicePrincipalsInterface instead.
 func (a *AccountServicePrincipalsAPI) WithImpl(impl AccountServicePrincipalsService) AccountServicePrincipalsInterface {
-	a.impl = impl
-	return a
+	return &AccountServicePrincipalsAPI{
+		AccountServicePrincipalsService: impl,
+	}
 }
 
 // Impl returns low-level AccountServicePrincipals API implementation
 // Deprecated: use MockAccountServicePrincipalsInterface instead.
 func (a *AccountServicePrincipalsAPI) Impl() AccountServicePrincipalsService {
-	return a.impl
-}
-
-// Create a service principal.
-//
-// Creates a new service principal in the Databricks account.
-func (a *AccountServicePrincipalsAPI) Create(ctx context.Context, request ServicePrincipal) (*ServicePrincipal, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a service principal.
-//
-// Delete a single service principal in the Databricks account.
-func (a *AccountServicePrincipalsAPI) Delete(ctx context.Context, request DeleteAccountServicePrincipalRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountServicePrincipalsService
 }
 
 // Delete a service principal.
 //
 // Delete a single service principal in the Databricks account.
 func (a *AccountServicePrincipalsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteAccountServicePrincipalRequest{
+	return a.AccountServicePrincipalsService.Delete(ctx, DeleteAccountServicePrincipalRequest{
 		Id: id,
 	})
 }
@@ -607,16 +507,8 @@ func (a *AccountServicePrincipalsAPI) DeleteById(ctx context.Context, id string)
 //
 // Gets the details for a single service principal define in the Databricks
 // account.
-func (a *AccountServicePrincipalsAPI) Get(ctx context.Context, request GetAccountServicePrincipalRequest) (*ServicePrincipal, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get service principal details.
-//
-// Gets the details for a single service principal define in the Databricks
-// account.
 func (a *AccountServicePrincipalsAPI) GetById(ctx context.Context, id string) (*ServicePrincipal, error) {
-	return a.impl.Get(ctx, GetAccountServicePrincipalRequest{
+	return a.AccountServicePrincipalsService.Get(ctx, GetAccountServicePrincipalRequest{
 		Id: id,
 	})
 }
@@ -634,7 +526,7 @@ func (a *AccountServicePrincipalsAPI) List(ctx context.Context, request ListAcco
 	}
 	getNextPage := func(ctx context.Context, req ListAccountServicePrincipalsRequest) (*ListServicePrincipalResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.AccountServicePrincipalsService.List(ctx, req)
 	}
 	getItems := func(resp *ListServicePrincipalResponse) []ServicePrincipal {
 		return resp.Resources
@@ -723,23 +615,6 @@ func (a *AccountServicePrincipalsAPI) GetByDisplayName(ctx context.Context, name
 	return &alternatives[0], nil
 }
 
-// Update service principal details.
-//
-// Partially updates the details of a single service principal in the Databricks
-// account.
-func (a *AccountServicePrincipalsAPI) Patch(ctx context.Context, request PartialUpdate) error {
-	return a.impl.Patch(ctx, request)
-}
-
-// Replace service principal.
-//
-// Updates the details of a single service principal.
-//
-// This action replaces the existing service principal with the same name.
-func (a *AccountServicePrincipalsAPI) Update(ctx context.Context, request ServicePrincipal) error {
-	return a.impl.Update(ctx, request)
-}
-
 type AccountUsersInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -824,7 +699,7 @@ type AccountUsersInterface interface {
 
 func NewAccountUsers(client *client.DatabricksClient) *AccountUsersAPI {
 	return &AccountUsersAPI{
-		impl: &accountUsersImpl{
+		AccountUsersService: &accountUsersImpl{
 			client: client,
 		},
 	}
@@ -844,37 +719,22 @@ func NewAccountUsers(client *client.DatabricksClient) *AccountUsersAPI {
 type AccountUsersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountUsersService)
-	impl AccountUsersService
+	AccountUsersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountUsersInterface instead.
 func (a *AccountUsersAPI) WithImpl(impl AccountUsersService) AccountUsersInterface {
-	a.impl = impl
-	return a
+	return &AccountUsersAPI{
+		AccountUsersService: impl,
+	}
 }
 
 // Impl returns low-level AccountUsers API implementation
 // Deprecated: use MockAccountUsersInterface instead.
 func (a *AccountUsersAPI) Impl() AccountUsersService {
-	return a.impl
-}
-
-// Create a new user.
-//
-// Creates a new user in the Databricks account. This new user will also be
-// added to the Databricks account.
-func (a *AccountUsersAPI) Create(ctx context.Context, request User) (*User, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a user.
-//
-// Deletes a user. Deleting a user from a Databricks account also removes
-// objects associated with the user.
-func (a *AccountUsersAPI) Delete(ctx context.Context, request DeleteAccountUserRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountUsersService
 }
 
 // Delete a user.
@@ -882,7 +742,7 @@ func (a *AccountUsersAPI) Delete(ctx context.Context, request DeleteAccountUserR
 // Deletes a user. Deleting a user from a Databricks account also removes
 // objects associated with the user.
 func (a *AccountUsersAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteAccountUserRequest{
+	return a.AccountUsersService.Delete(ctx, DeleteAccountUserRequest{
 		Id: id,
 	})
 }
@@ -890,15 +750,8 @@ func (a *AccountUsersAPI) DeleteById(ctx context.Context, id string) error {
 // Get user details.
 //
 // Gets information for a specific user in Databricks account.
-func (a *AccountUsersAPI) Get(ctx context.Context, request GetAccountUserRequest) (*User, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get user details.
-//
-// Gets information for a specific user in Databricks account.
 func (a *AccountUsersAPI) GetById(ctx context.Context, id string) (*User, error) {
-	return a.impl.Get(ctx, GetAccountUserRequest{
+	return a.AccountUsersService.Get(ctx, GetAccountUserRequest{
 		Id: id,
 	})
 }
@@ -916,7 +769,7 @@ func (a *AccountUsersAPI) List(ctx context.Context, request ListAccountUsersRequ
 	}
 	getNextPage := func(ctx context.Context, req ListAccountUsersRequest) (*ListUsersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.AccountUsersService.List(ctx, req)
 	}
 	getItems := func(resp *ListUsersResponse) []User {
 		return resp.Resources
@@ -1005,21 +858,6 @@ func (a *AccountUsersAPI) GetByUserName(ctx context.Context, name string) (*User
 	return &alternatives[0], nil
 }
 
-// Update user details.
-//
-// Partially updates a user resource by applying the supplied operations on
-// specific user attributes.
-func (a *AccountUsersAPI) Patch(ctx context.Context, request PartialUpdate) error {
-	return a.impl.Patch(ctx, request)
-}
-
-// Replace a user.
-//
-// Replaces a user's information with the data supplied in request.
-func (a *AccountUsersAPI) Update(ctx context.Context, request User) error {
-	return a.impl.Update(ctx, request)
-}
-
 type CurrentUserInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -1038,7 +876,7 @@ type CurrentUserInterface interface {
 
 func NewCurrentUser(client *client.DatabricksClient) *CurrentUserAPI {
 	return &CurrentUserAPI{
-		impl: &currentUserImpl{
+		CurrentUserService: &currentUserImpl{
 			client: client,
 		},
 	}
@@ -1049,28 +887,22 @@ func NewCurrentUser(client *client.DatabricksClient) *CurrentUserAPI {
 type CurrentUserAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CurrentUserService)
-	impl CurrentUserService
+	CurrentUserService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCurrentUserInterface instead.
 func (a *CurrentUserAPI) WithImpl(impl CurrentUserService) CurrentUserInterface {
-	a.impl = impl
-	return a
+	return &CurrentUserAPI{
+		CurrentUserService: impl,
+	}
 }
 
 // Impl returns low-level CurrentUser API implementation
 // Deprecated: use MockCurrentUserInterface instead.
 func (a *CurrentUserAPI) Impl() CurrentUserService {
-	return a.impl
-}
-
-// Get current user info.
-//
-// Get details about the current method caller's identity.
-func (a *CurrentUserAPI) Me(ctx context.Context) (*User, error) {
-	return a.impl.Me(ctx)
+	return a.CurrentUserService
 }
 
 type GroupsInterface interface {
@@ -1154,7 +986,7 @@ type GroupsInterface interface {
 
 func NewGroups(client *client.DatabricksClient) *GroupsAPI {
 	return &GroupsAPI{
-		impl: &groupsImpl{
+		GroupsService: &groupsImpl{
 			client: client,
 		},
 	}
@@ -1170,43 +1002,29 @@ func NewGroups(client *client.DatabricksClient) *GroupsAPI {
 type GroupsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(GroupsService)
-	impl GroupsService
+	GroupsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGroupsInterface instead.
 func (a *GroupsAPI) WithImpl(impl GroupsService) GroupsInterface {
-	a.impl = impl
-	return a
+	return &GroupsAPI{
+		GroupsService: impl,
+	}
 }
 
 // Impl returns low-level Groups API implementation
 // Deprecated: use MockGroupsInterface instead.
 func (a *GroupsAPI) Impl() GroupsService {
-	return a.impl
-}
-
-// Create a new group.
-//
-// Creates a group in the Databricks workspace with a unique name, using the
-// supplied group details.
-func (a *GroupsAPI) Create(ctx context.Context, request Group) (*Group, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a group.
-//
-// Deletes a group from the Databricks workspace.
-func (a *GroupsAPI) Delete(ctx context.Context, request DeleteGroupRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.GroupsService
 }
 
 // Delete a group.
 //
 // Deletes a group from the Databricks workspace.
 func (a *GroupsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteGroupRequest{
+	return a.GroupsService.Delete(ctx, DeleteGroupRequest{
 		Id: id,
 	})
 }
@@ -1214,15 +1032,8 @@ func (a *GroupsAPI) DeleteById(ctx context.Context, id string) error {
 // Get group details.
 //
 // Gets the information for a specific group in the Databricks workspace.
-func (a *GroupsAPI) Get(ctx context.Context, request GetGroupRequest) (*Group, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get group details.
-//
-// Gets the information for a specific group in the Databricks workspace.
 func (a *GroupsAPI) GetById(ctx context.Context, id string) (*Group, error) {
-	return a.impl.Get(ctx, GetGroupRequest{
+	return a.GroupsService.Get(ctx, GetGroupRequest{
 		Id: id,
 	})
 }
@@ -1240,7 +1051,7 @@ func (a *GroupsAPI) List(ctx context.Context, request ListGroupsRequest) listing
 	}
 	getNextPage := func(ctx context.Context, req ListGroupsRequest) (*ListGroupsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.GroupsService.List(ctx, req)
 	}
 	getItems := func(resp *ListGroupsResponse) []Group {
 		return resp.Resources
@@ -1329,20 +1140,6 @@ func (a *GroupsAPI) GetByDisplayName(ctx context.Context, name string) (*Group, 
 	return &alternatives[0], nil
 }
 
-// Update group details.
-//
-// Partially updates the details of a group.
-func (a *GroupsAPI) Patch(ctx context.Context, request PartialUpdate) error {
-	return a.impl.Patch(ctx, request)
-}
-
-// Replace a group.
-//
-// Updates the details of a group by replacing the entire group entity.
-func (a *GroupsAPI) Update(ctx context.Context, request Group) error {
-	return a.impl.Update(ctx, request)
-}
-
 type PermissionMigrationInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -1359,7 +1156,7 @@ type PermissionMigrationInterface interface {
 
 func NewPermissionMigration(client *client.DatabricksClient) *PermissionMigrationAPI {
 	return &PermissionMigrationAPI{
-		impl: &permissionMigrationImpl{
+		PermissionMigrationService: &permissionMigrationImpl{
 			client: client,
 		},
 	}
@@ -1370,26 +1167,22 @@ func NewPermissionMigration(client *client.DatabricksClient) *PermissionMigratio
 type PermissionMigrationAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PermissionMigrationService)
-	impl PermissionMigrationService
+	PermissionMigrationService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPermissionMigrationInterface instead.
 func (a *PermissionMigrationAPI) WithImpl(impl PermissionMigrationService) PermissionMigrationInterface {
-	a.impl = impl
-	return a
+	return &PermissionMigrationAPI{
+		PermissionMigrationService: impl,
+	}
 }
 
 // Impl returns low-level PermissionMigration API implementation
 // Deprecated: use MockPermissionMigrationInterface instead.
 func (a *PermissionMigrationAPI) Impl() PermissionMigrationService {
-	return a.impl
-}
-
-// Migrate Permissions.
-func (a *PermissionMigrationAPI) MigratePermissions(ctx context.Context, request MigratePermissionsRequest) (*MigratePermissionsResponse, error) {
-	return a.impl.MigratePermissions(ctx, request)
+	return a.PermissionMigrationService
 }
 
 type PermissionsInterface interface {
@@ -1439,7 +1232,7 @@ type PermissionsInterface interface {
 
 func NewPermissions(client *client.DatabricksClient) *PermissionsAPI {
 	return &PermissionsAPI{
-		impl: &permissionsImpl{
+		PermissionsService: &permissionsImpl{
 			client: client,
 		},
 	}
@@ -1498,29 +1291,22 @@ func NewPermissions(client *client.DatabricksClient) *PermissionsAPI {
 type PermissionsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PermissionsService)
-	impl PermissionsService
+	PermissionsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPermissionsInterface instead.
 func (a *PermissionsAPI) WithImpl(impl PermissionsService) PermissionsInterface {
-	a.impl = impl
-	return a
+	return &PermissionsAPI{
+		PermissionsService: impl,
+	}
 }
 
 // Impl returns low-level Permissions API implementation
 // Deprecated: use MockPermissionsInterface instead.
 func (a *PermissionsAPI) Impl() PermissionsService {
-	return a.impl
-}
-
-// Get object permissions.
-//
-// Gets the permissions of an object. Objects can inherit permissions from their
-// parent objects or root object.
-func (a *PermissionsAPI) Get(ctx context.Context, request GetPermissionRequest) (*ObjectPermissions, error) {
-	return a.impl.Get(ctx, request)
+	return a.PermissionsService
 }
 
 // Get object permissions.
@@ -1528,43 +1314,20 @@ func (a *PermissionsAPI) Get(ctx context.Context, request GetPermissionRequest) 
 // Gets the permissions of an object. Objects can inherit permissions from their
 // parent objects or root object.
 func (a *PermissionsAPI) GetByRequestObjectTypeAndRequestObjectId(ctx context.Context, requestObjectType string, requestObjectId string) (*ObjectPermissions, error) {
-	return a.impl.Get(ctx, GetPermissionRequest{
+	return a.PermissionsService.Get(ctx, GetPermissionRequest{
 		RequestObjectType: requestObjectType,
 		RequestObjectId:   requestObjectId,
 	})
-}
-
-// Get object permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *PermissionsAPI) GetPermissionLevels(ctx context.Context, request GetPermissionLevelsRequest) (*GetPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
 }
 
 // Get object permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *PermissionsAPI) GetPermissionLevelsByRequestObjectTypeAndRequestObjectId(ctx context.Context, requestObjectType string, requestObjectId string) (*GetPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetPermissionLevelsRequest{
+	return a.PermissionsService.GetPermissionLevels(ctx, GetPermissionLevelsRequest{
 		RequestObjectType: requestObjectType,
 		RequestObjectId:   requestObjectId,
 	})
-}
-
-// Set object permissions.
-//
-// Sets permissions on an object. Objects can inherit permissions from their
-// parent objects or root object.
-func (a *PermissionsAPI) Set(ctx context.Context, request PermissionsRequest) (*ObjectPermissions, error) {
-	return a.impl.Set(ctx, request)
-}
-
-// Update object permissions.
-//
-// Updates the permissions on an object. Objects can inherit permissions from
-// their parent objects or root object.
-func (a *PermissionsAPI) Update(ctx context.Context, request PermissionsRequest) (*ObjectPermissions, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ServicePrincipalsInterface interface {
@@ -1652,7 +1415,7 @@ type ServicePrincipalsInterface interface {
 
 func NewServicePrincipals(client *client.DatabricksClient) *ServicePrincipalsAPI {
 	return &ServicePrincipalsAPI{
-		impl: &servicePrincipalsImpl{
+		ServicePrincipalsService: &servicePrincipalsImpl{
 			client: client,
 		},
 	}
@@ -1667,42 +1430,29 @@ func NewServicePrincipals(client *client.DatabricksClient) *ServicePrincipalsAPI
 type ServicePrincipalsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ServicePrincipalsService)
-	impl ServicePrincipalsService
+	ServicePrincipalsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockServicePrincipalsInterface instead.
 func (a *ServicePrincipalsAPI) WithImpl(impl ServicePrincipalsService) ServicePrincipalsInterface {
-	a.impl = impl
-	return a
+	return &ServicePrincipalsAPI{
+		ServicePrincipalsService: impl,
+	}
 }
 
 // Impl returns low-level ServicePrincipals API implementation
 // Deprecated: use MockServicePrincipalsInterface instead.
 func (a *ServicePrincipalsAPI) Impl() ServicePrincipalsService {
-	return a.impl
-}
-
-// Create a service principal.
-//
-// Creates a new service principal in the Databricks workspace.
-func (a *ServicePrincipalsAPI) Create(ctx context.Context, request ServicePrincipal) (*ServicePrincipal, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a service principal.
-//
-// Delete a single service principal in the Databricks workspace.
-func (a *ServicePrincipalsAPI) Delete(ctx context.Context, request DeleteServicePrincipalRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ServicePrincipalsService
 }
 
 // Delete a service principal.
 //
 // Delete a single service principal in the Databricks workspace.
 func (a *ServicePrincipalsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteServicePrincipalRequest{
+	return a.ServicePrincipalsService.Delete(ctx, DeleteServicePrincipalRequest{
 		Id: id,
 	})
 }
@@ -1711,16 +1461,8 @@ func (a *ServicePrincipalsAPI) DeleteById(ctx context.Context, id string) error 
 //
 // Gets the details for a single service principal define in the Databricks
 // workspace.
-func (a *ServicePrincipalsAPI) Get(ctx context.Context, request GetServicePrincipalRequest) (*ServicePrincipal, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get service principal details.
-//
-// Gets the details for a single service principal define in the Databricks
-// workspace.
 func (a *ServicePrincipalsAPI) GetById(ctx context.Context, id string) (*ServicePrincipal, error) {
-	return a.impl.Get(ctx, GetServicePrincipalRequest{
+	return a.ServicePrincipalsService.Get(ctx, GetServicePrincipalRequest{
 		Id: id,
 	})
 }
@@ -1738,7 +1480,7 @@ func (a *ServicePrincipalsAPI) List(ctx context.Context, request ListServicePrin
 	}
 	getNextPage := func(ctx context.Context, req ListServicePrincipalsRequest) (*ListServicePrincipalResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ServicePrincipalsService.List(ctx, req)
 	}
 	getItems := func(resp *ListServicePrincipalResponse) []ServicePrincipal {
 		return resp.Resources
@@ -1825,23 +1567,6 @@ func (a *ServicePrincipalsAPI) GetByDisplayName(ctx context.Context, name string
 		return nil, fmt.Errorf("there are %d instances of ServicePrincipal named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update service principal details.
-//
-// Partially updates the details of a single service principal in the Databricks
-// workspace.
-func (a *ServicePrincipalsAPI) Patch(ctx context.Context, request PartialUpdate) error {
-	return a.impl.Patch(ctx, request)
-}
-
-// Replace service principal.
-//
-// Updates the details of a single service principal.
-//
-// This action replaces the existing service principal with the same name.
-func (a *ServicePrincipalsAPI) Update(ctx context.Context, request ServicePrincipal) error {
-	return a.impl.Update(ctx, request)
 }
 
 type UsersInterface interface {
@@ -1951,7 +1676,7 @@ type UsersInterface interface {
 
 func NewUsers(client *client.DatabricksClient) *UsersAPI {
 	return &UsersAPI{
-		impl: &usersImpl{
+		UsersService: &usersImpl{
 			client: client,
 		},
 	}
@@ -1971,37 +1696,22 @@ func NewUsers(client *client.DatabricksClient) *UsersAPI {
 type UsersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(UsersService)
-	impl UsersService
+	UsersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockUsersInterface instead.
 func (a *UsersAPI) WithImpl(impl UsersService) UsersInterface {
-	a.impl = impl
-	return a
+	return &UsersAPI{
+		UsersService: impl,
+	}
 }
 
 // Impl returns low-level Users API implementation
 // Deprecated: use MockUsersInterface instead.
 func (a *UsersAPI) Impl() UsersService {
-	return a.impl
-}
-
-// Create a new user.
-//
-// Creates a new user in the Databricks workspace. This new user will also be
-// added to the Databricks account.
-func (a *UsersAPI) Create(ctx context.Context, request User) (*User, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a user.
-//
-// Deletes a user. Deleting a user from a Databricks workspace also removes
-// objects associated with the user.
-func (a *UsersAPI) Delete(ctx context.Context, request DeleteUserRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.UsersService
 }
 
 // Delete a user.
@@ -2009,40 +1719,18 @@ func (a *UsersAPI) Delete(ctx context.Context, request DeleteUserRequest) error 
 // Deletes a user. Deleting a user from a Databricks workspace also removes
 // objects associated with the user.
 func (a *UsersAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteUserRequest{
+	return a.UsersService.Delete(ctx, DeleteUserRequest{
 		Id: id,
 	})
-}
-
-// Get user details.
-//
-// Gets information for a specific user in Databricks workspace.
-func (a *UsersAPI) Get(ctx context.Context, request GetUserRequest) (*User, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get user details.
 //
 // Gets information for a specific user in Databricks workspace.
 func (a *UsersAPI) GetById(ctx context.Context, id string) (*User, error) {
-	return a.impl.Get(ctx, GetUserRequest{
+	return a.UsersService.Get(ctx, GetUserRequest{
 		Id: id,
 	})
-}
-
-// Get password permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *UsersAPI) GetPermissionLevels(ctx context.Context) (*GetPasswordPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx)
-}
-
-// Get password permissions.
-//
-// Gets the permissions of all passwords. Passwords can inherit permissions from
-// their root object.
-func (a *UsersAPI) GetPermissions(ctx context.Context) (*PasswordPermissions, error) {
-	return a.impl.GetPermissions(ctx)
 }
 
 // List users.
@@ -2058,7 +1746,7 @@ func (a *UsersAPI) List(ctx context.Context, request ListUsersRequest) listing.I
 	}
 	getNextPage := func(ctx context.Context, req ListUsersRequest) (*ListUsersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.UsersService.List(ctx, req)
 	}
 	getItems := func(resp *ListUsersResponse) []User {
 		return resp.Resources
@@ -2147,37 +1835,6 @@ func (a *UsersAPI) GetByUserName(ctx context.Context, name string) (*User, error
 	return &alternatives[0], nil
 }
 
-// Update user details.
-//
-// Partially updates a user resource by applying the supplied operations on
-// specific user attributes.
-func (a *UsersAPI) Patch(ctx context.Context, request PartialUpdate) error {
-	return a.impl.Patch(ctx, request)
-}
-
-// Set password permissions.
-//
-// Sets permissions on all passwords. Passwords can inherit permissions from
-// their root object.
-func (a *UsersAPI) SetPermissions(ctx context.Context, request PasswordPermissionsRequest) (*PasswordPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Replace a user.
-//
-// Replaces a user's information with the data supplied in request.
-func (a *UsersAPI) Update(ctx context.Context, request User) error {
-	return a.impl.Update(ctx, request)
-}
-
-// Update password permissions.
-//
-// Updates the permissions on all passwords. Passwords can inherit permissions
-// from their root object.
-func (a *UsersAPI) UpdatePermissions(ctx context.Context, request PasswordPermissionsRequest) (*PasswordPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
-}
-
 type WorkspaceAssignmentInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -2243,7 +1900,7 @@ type WorkspaceAssignmentInterface interface {
 
 func NewWorkspaceAssignment(client *client.DatabricksClient) *WorkspaceAssignmentAPI {
 	return &WorkspaceAssignmentAPI{
-		impl: &workspaceAssignmentImpl{
+		WorkspaceAssignmentService: &workspaceAssignmentImpl{
 			client: client,
 		},
 	}
@@ -2254,29 +1911,22 @@ func NewWorkspaceAssignment(client *client.DatabricksClient) *WorkspaceAssignmen
 type WorkspaceAssignmentAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(WorkspaceAssignmentService)
-	impl WorkspaceAssignmentService
+	WorkspaceAssignmentService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceAssignmentInterface instead.
 func (a *WorkspaceAssignmentAPI) WithImpl(impl WorkspaceAssignmentService) WorkspaceAssignmentInterface {
-	a.impl = impl
-	return a
+	return &WorkspaceAssignmentAPI{
+		WorkspaceAssignmentService: impl,
+	}
 }
 
 // Impl returns low-level WorkspaceAssignment API implementation
 // Deprecated: use MockWorkspaceAssignmentInterface instead.
 func (a *WorkspaceAssignmentAPI) Impl() WorkspaceAssignmentService {
-	return a.impl
-}
-
-// Delete permissions assignment.
-//
-// Deletes the workspace permissions assignment in a given account and workspace
-// for the specified principal.
-func (a *WorkspaceAssignmentAPI) Delete(ctx context.Context, request DeleteWorkspaceAssignmentRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.WorkspaceAssignmentService
 }
 
 // Delete permissions assignment.
@@ -2284,7 +1934,7 @@ func (a *WorkspaceAssignmentAPI) Delete(ctx context.Context, request DeleteWorks
 // Deletes the workspace permissions assignment in a given account and workspace
 // for the specified principal.
 func (a *WorkspaceAssignmentAPI) DeleteByWorkspaceIdAndPrincipalId(ctx context.Context, workspaceId int64, principalId int64) error {
-	return a.impl.Delete(ctx, DeleteWorkspaceAssignmentRequest{
+	return a.WorkspaceAssignmentService.Delete(ctx, DeleteWorkspaceAssignmentRequest{
 		WorkspaceId: workspaceId,
 		PrincipalId: principalId,
 	})
@@ -2294,16 +1944,8 @@ func (a *WorkspaceAssignmentAPI) DeleteByWorkspaceIdAndPrincipalId(ctx context.C
 //
 // Get an array of workspace permissions for the specified account and
 // workspace.
-func (a *WorkspaceAssignmentAPI) Get(ctx context.Context, request GetWorkspaceAssignmentRequest) (*WorkspacePermissions, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// List workspace permissions.
-//
-// Get an array of workspace permissions for the specified account and
-// workspace.
 func (a *WorkspaceAssignmentAPI) GetByWorkspaceId(ctx context.Context, workspaceId int64) (*WorkspacePermissions, error) {
-	return a.impl.Get(ctx, GetWorkspaceAssignmentRequest{
+	return a.WorkspaceAssignmentService.Get(ctx, GetWorkspaceAssignmentRequest{
 		WorkspaceId: workspaceId,
 	})
 }
@@ -2318,7 +1960,7 @@ func (a *WorkspaceAssignmentAPI) List(ctx context.Context, request ListWorkspace
 
 	getNextPage := func(ctx context.Context, req ListWorkspaceAssignmentRequest) (*PermissionAssignments, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.WorkspaceAssignmentService.List(ctx, req)
 	}
 	getItems := func(resp *PermissionAssignments) []PermissionAssignment {
 		return resp.PermissionAssignments
@@ -2348,15 +1990,7 @@ func (a *WorkspaceAssignmentAPI) ListAll(ctx context.Context, request ListWorksp
 // Get the permission assignments for the specified Databricks account and
 // Databricks workspace.
 func (a *WorkspaceAssignmentAPI) ListByWorkspaceId(ctx context.Context, workspaceId int64) (*PermissionAssignments, error) {
-	return a.impl.List(ctx, ListWorkspaceAssignmentRequest{
+	return a.WorkspaceAssignmentService.List(ctx, ListWorkspaceAssignmentRequest{
 		WorkspaceId: workspaceId,
 	})
-}
-
-// Create or update permissions assignment.
-//
-// Creates or updates the workspace permissions assignment in a given account
-// and workspace for the specified principal.
-func (a *WorkspaceAssignmentAPI) Update(ctx context.Context, request UpdateWorkspaceAssignments) (*PermissionAssignment, error) {
-	return a.impl.Update(ctx, request)
 }

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -329,7 +329,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" url:"-"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 	// Container for the group identifier. Workspace local versus account.
@@ -1233,7 +1233,7 @@ type ServicePrincipal struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks service principal ID.
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 	// Corresponds to AWS instance profile/arn role.
 	Roles []ComplexValue `json:"roles,omitempty"`
 	// The schema of the List response.

--- a/service/iam/model.go
+++ b/service/iam/model.go
@@ -329,7 +329,7 @@ type Group struct {
 
 	Groups []ComplexValue `json:"groups,omitempty"`
 	// Databricks group ID
-	Id string `json:"id,omitempty" url:"-"`
+	Id string `json:"id,omitempty"`
 
 	Members []ComplexValue `json:"members,omitempty"`
 	// Container for the group identifier. Workspace local versus account.

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -302,9 +302,8 @@ type JobsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockJobsInterface instead.
 func (a *JobsAPI) WithImpl(impl JobsService) JobsInterface {
-	return &JobsAPI{
-		JobsService: impl,
-	}
+	a.JobsService = impl
+	return a
 }
 
 // Impl returns low-level Jobs API implementation

--- a/service/jobs/api.go
+++ b/service/jobs/api.go
@@ -268,7 +268,7 @@ type JobsInterface interface {
 
 func NewJobs(client *client.DatabricksClient) *JobsAPI {
 	return &JobsAPI{
-		impl: &jobsImpl{
+		JobsService: &jobsImpl{
 			client: client,
 		},
 	}
@@ -295,21 +295,22 @@ func NewJobs(client *client.DatabricksClient) *JobsAPI {
 type JobsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(JobsService)
-	impl JobsService
+	JobsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockJobsInterface instead.
 func (a *JobsAPI) WithImpl(impl JobsService) JobsInterface {
-	a.impl = impl
-	return a
+	return &JobsAPI{
+		JobsService: impl,
+	}
 }
 
 // Impl returns low-level Jobs API implementation
 // Deprecated: use MockJobsInterface instead.
 func (a *JobsAPI) Impl() JobsService {
-	return a.impl
+	return a.JobsService
 }
 
 // WaitGetRunJobTerminatedOrSkipped repeatedly calls [JobsAPI.GetRun] and waits to reach TERMINATED or SKIPPED state
@@ -369,20 +370,12 @@ func (w *WaitGetRunJobTerminatedOrSkipped[R]) GetWithTimeout(timeout time.Durati
 	return w.Poll(timeout, w.callback)
 }
 
-// Cancel all runs of a job.
-//
-// Cancels all active runs of a job. The runs are canceled asynchronously, so it
-// doesn't prevent new runs from being started.
-func (a *JobsAPI) CancelAllRuns(ctx context.Context, request CancelAllRuns) error {
-	return a.impl.CancelAllRuns(ctx, request)
-}
-
 // Cancel a run.
 //
 // Cancels a job run or a task run. The run is canceled asynchronously, so it
 // may still be running when this request completes.
 func (a *JobsAPI) CancelRun(ctx context.Context, cancelRun CancelRun) (*WaitGetRunJobTerminatedOrSkipped[struct{}], error) {
-	err := a.impl.CancelRun(ctx, cancelRun)
+	err := a.JobsService.CancelRun(ctx, cancelRun)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +422,7 @@ func (a *JobsAPI) CancelRunAndWait(ctx context.Context, cancelRun CancelRun, opt
 // Cancels a job run or a task run. The run is canceled asynchronously, so it
 // may still be running when this request completes.
 func (a *JobsAPI) CancelRunByRunId(ctx context.Context, runId int64) error {
-	return a.impl.CancelRun(ctx, CancelRun{
+	return a.JobsService.CancelRun(ctx, CancelRun{
 		RunId: runId,
 	})
 }
@@ -440,90 +433,40 @@ func (a *JobsAPI) CancelRunByRunIdAndWait(ctx context.Context, runId int64, opti
 	}, options...)
 }
 
-// Create a new job.
-//
-// Create a new job.
-func (a *JobsAPI) Create(ctx context.Context, request CreateJob) (*CreateResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a job.
-//
-// Deletes a job.
-func (a *JobsAPI) Delete(ctx context.Context, request DeleteJob) error {
-	return a.impl.Delete(ctx, request)
-}
-
 // Delete a job.
 //
 // Deletes a job.
 func (a *JobsAPI) DeleteByJobId(ctx context.Context, jobId int64) error {
-	return a.impl.Delete(ctx, DeleteJob{
+	return a.JobsService.Delete(ctx, DeleteJob{
 		JobId: jobId,
 	})
-}
-
-// Delete a job run.
-//
-// Deletes a non-active run. Returns an error if the run is active.
-func (a *JobsAPI) DeleteRun(ctx context.Context, request DeleteRun) error {
-	return a.impl.DeleteRun(ctx, request)
 }
 
 // Delete a job run.
 //
 // Deletes a non-active run. Returns an error if the run is active.
 func (a *JobsAPI) DeleteRunByRunId(ctx context.Context, runId int64) error {
-	return a.impl.DeleteRun(ctx, DeleteRun{
+	return a.JobsService.DeleteRun(ctx, DeleteRun{
 		RunId: runId,
 	})
-}
-
-// Export and retrieve a job run.
-//
-// Export and retrieve the job run task.
-func (a *JobsAPI) ExportRun(ctx context.Context, request ExportRunRequest) (*ExportRunOutput, error) {
-	return a.impl.ExportRun(ctx, request)
-}
-
-// Get a single job.
-//
-// Retrieves the details for a single job.
-func (a *JobsAPI) Get(ctx context.Context, request GetJobRequest) (*Job, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a single job.
 //
 // Retrieves the details for a single job.
 func (a *JobsAPI) GetByJobId(ctx context.Context, jobId int64) (*Job, error) {
-	return a.impl.Get(ctx, GetJobRequest{
+	return a.JobsService.Get(ctx, GetJobRequest{
 		JobId: jobId,
 	})
-}
-
-// Get job permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *JobsAPI) GetPermissionLevels(ctx context.Context, request GetJobPermissionLevelsRequest) (*GetJobPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
 }
 
 // Get job permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *JobsAPI) GetPermissionLevelsByJobId(ctx context.Context, jobId string) (*GetJobPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetJobPermissionLevelsRequest{
+	return a.JobsService.GetPermissionLevels(ctx, GetJobPermissionLevelsRequest{
 		JobId: jobId,
 	})
-}
-
-// Get job permissions.
-//
-// Gets the permissions of a job. Jobs can inherit permissions from their root
-// object.
-func (a *JobsAPI) GetPermissions(ctx context.Context, request GetJobPermissionsRequest) (*JobPermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get job permissions.
@@ -531,32 +474,9 @@ func (a *JobsAPI) GetPermissions(ctx context.Context, request GetJobPermissionsR
 // Gets the permissions of a job. Jobs can inherit permissions from their root
 // object.
 func (a *JobsAPI) GetPermissionsByJobId(ctx context.Context, jobId string) (*JobPermissions, error) {
-	return a.impl.GetPermissions(ctx, GetJobPermissionsRequest{
+	return a.JobsService.GetPermissions(ctx, GetJobPermissionsRequest{
 		JobId: jobId,
 	})
-}
-
-// Get a single job run.
-//
-// Retrieve the metadata of a run.
-func (a *JobsAPI) GetRun(ctx context.Context, request GetRunRequest) (*Run, error) {
-	return a.impl.GetRun(ctx, request)
-}
-
-// Get the output for a single run.
-//
-// Retrieve the output and metadata of a single task run. When a notebook task
-// returns a value through the `dbutils.notebook.exit()` call, you can use this
-// endpoint to retrieve that value. Databricks restricts this API to returning
-// the first 5 MB of the output. To return a larger result, you can store job
-// results in a cloud storage service.
-//
-// This endpoint validates that the __run_id__ parameter is valid and returns an
-// HTTP status code 400 if the __run_id__ parameter is invalid. Runs are
-// automatically removed after 60 days. If you to want to reference them beyond
-// 60 days, you must save old run results before they expire.
-func (a *JobsAPI) GetRunOutput(ctx context.Context, request GetRunOutputRequest) (*RunOutput, error) {
-	return a.impl.GetRunOutput(ctx, request)
 }
 
 // Get the output for a single run.
@@ -572,7 +492,7 @@ func (a *JobsAPI) GetRunOutput(ctx context.Context, request GetRunOutputRequest)
 // automatically removed after 60 days. If you to want to reference them beyond
 // 60 days, you must save old run results before they expire.
 func (a *JobsAPI) GetRunOutputByRunId(ctx context.Context, runId int64) (*RunOutput, error) {
-	return a.impl.GetRunOutput(ctx, GetRunOutputRequest{
+	return a.JobsService.GetRunOutput(ctx, GetRunOutputRequest{
 		RunId: runId,
 	})
 }
@@ -586,7 +506,7 @@ func (a *JobsAPI) List(ctx context.Context, request ListJobsRequest) listing.Ite
 
 	getNextPage := func(ctx context.Context, req ListJobsRequest) (*ListJobsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.JobsService.List(ctx, req)
 	}
 	getItems := func(resp *ListJobsResponse) []BaseJob {
 		return resp.Jobs
@@ -678,7 +598,7 @@ func (a *JobsAPI) ListRuns(ctx context.Context, request ListRunsRequest) listing
 
 	getNextPage := func(ctx context.Context, req ListRunsRequest) (*ListRunsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListRuns(ctx, req)
+		return a.JobsService.ListRuns(ctx, req)
 	}
 	getItems := func(resp *ListRunsResponse) []BaseRun {
 		return resp.Runs
@@ -714,7 +634,7 @@ func (a *JobsAPI) ListRunsAll(ctx context.Context, request ListRunsRequest) ([]B
 // They use the current job and task settings, and can be viewed in the history
 // for the original job run.
 func (a *JobsAPI) RepairRun(ctx context.Context, repairRun RepairRun) (*WaitGetRunJobTerminatedOrSkipped[RepairRunResponse], error) {
-	repairRunResponse, err := a.impl.RepairRun(ctx, repairRun)
+	repairRunResponse, err := a.JobsService.RepairRun(ctx, repairRun)
 	if err != nil {
 		return nil, err
 	}
@@ -756,19 +676,11 @@ func (a *JobsAPI) RepairRunAndWait(ctx context.Context, repairRun RepairRun, opt
 	return wait.Get()
 }
 
-// Update all job settings (reset).
-//
-// Overwrite all settings for the given job. Use the [_Update_
-// endpoint](:method:jobs/update) to update job settings partially.
-func (a *JobsAPI) Reset(ctx context.Context, request ResetJob) error {
-	return a.impl.Reset(ctx, request)
-}
-
 // Trigger a new job run.
 //
 // Run a job and return the `run_id` of the triggered run.
 func (a *JobsAPI) RunNow(ctx context.Context, runNow RunNow) (*WaitGetRunJobTerminatedOrSkipped[RunNowResponse], error) {
-	runNowResponse, err := a.impl.RunNow(ctx, runNow)
+	runNowResponse, err := a.JobsService.RunNow(ctx, runNow)
 	if err != nil {
 		return nil, err
 	}
@@ -810,14 +722,6 @@ func (a *JobsAPI) RunNowAndWait(ctx context.Context, runNow RunNow, options ...r
 	return wait.Get()
 }
 
-// Set job permissions.
-//
-// Sets permissions on a job. Jobs can inherit permissions from their root
-// object.
-func (a *JobsAPI) SetPermissions(ctx context.Context, request JobPermissionsRequest) (*JobPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
 // Create and trigger a one-time run.
 //
 // Submit a one-time run. This endpoint allows you to submit a workload directly
@@ -825,7 +729,7 @@ func (a *JobsAPI) SetPermissions(ctx context.Context, request JobPermissionsRequ
 // the UI. Use the `jobs/runs/get` API to check the run state after the job is
 // submitted.
 func (a *JobsAPI) Submit(ctx context.Context, submitRun SubmitRun) (*WaitGetRunJobTerminatedOrSkipped[SubmitRunResponse], error) {
-	submitRunResponse, err := a.impl.Submit(ctx, submitRun)
+	submitRunResponse, err := a.JobsService.Submit(ctx, submitRun)
 	if err != nil {
 		return nil, err
 	}
@@ -865,20 +769,4 @@ func (a *JobsAPI) SubmitAndWait(ctx context.Context, submitRun SubmitRun, option
 		}
 	}
 	return wait.Get()
-}
-
-// Update job settings partially.
-//
-// Add, update, or remove specific settings of an existing job. Use the [_Reset_
-// endpoint](:method:jobs/reset) to overwrite all job settings.
-func (a *JobsAPI) Update(ctx context.Context, request UpdateJob) error {
-	return a.impl.Update(ctx, request)
-}
-
-// Update job permissions.
-//
-// Updates the permissions on a job. Jobs can inherit permissions from their
-// root object.
-func (a *JobsAPI) UpdatePermissions(ctx context.Context, request JobPermissionsRequest) (*JobPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }

--- a/service/marketplace/api.go
+++ b/service/marketplace/api.go
@@ -75,7 +75,7 @@ type ConsumerFulfillmentsInterface interface {
 
 func NewConsumerFulfillments(client *client.DatabricksClient) *ConsumerFulfillmentsAPI {
 	return &ConsumerFulfillmentsAPI{
-		impl: &consumerFulfillmentsImpl{
+		ConsumerFulfillmentsService: &consumerFulfillmentsImpl{
 			client: client,
 		},
 	}
@@ -85,21 +85,22 @@ func NewConsumerFulfillments(client *client.DatabricksClient) *ConsumerFulfillme
 type ConsumerFulfillmentsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ConsumerFulfillmentsService)
-	impl ConsumerFulfillmentsService
+	ConsumerFulfillmentsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerFulfillmentsInterface instead.
 func (a *ConsumerFulfillmentsAPI) WithImpl(impl ConsumerFulfillmentsService) ConsumerFulfillmentsInterface {
-	a.impl = impl
-	return a
+	return &ConsumerFulfillmentsAPI{
+		ConsumerFulfillmentsService: impl,
+	}
 }
 
 // Impl returns low-level ConsumerFulfillments API implementation
 // Deprecated: use MockConsumerFulfillmentsInterface instead.
 func (a *ConsumerFulfillmentsAPI) Impl() ConsumerFulfillmentsService {
-	return a.impl
+	return a.ConsumerFulfillmentsService
 }
 
 // Get listing content metadata.
@@ -111,7 +112,7 @@ func (a *ConsumerFulfillmentsAPI) Get(ctx context.Context, request GetListingCon
 
 	getNextPage := func(ctx context.Context, req GetListingContentMetadataRequest) (*GetListingContentMetadataResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.Get(ctx, req)
+		return a.ConsumerFulfillmentsService.Get(ctx, req)
 	}
 	getItems := func(resp *GetListingContentMetadataResponse) []SharedDataObject {
 		return resp.SharedDataObjects
@@ -145,7 +146,7 @@ func (a *ConsumerFulfillmentsAPI) GetAll(ctx context.Context, request GetListing
 //
 // Get a high level preview of the metadata of listing installable content.
 func (a *ConsumerFulfillmentsAPI) GetByListingId(ctx context.Context, listingId string) (*GetListingContentMetadataResponse, error) {
-	return a.impl.Get(ctx, GetListingContentMetadataRequest{
+	return a.ConsumerFulfillmentsService.Get(ctx, GetListingContentMetadataRequest{
 		ListingId: listingId,
 	})
 }
@@ -163,7 +164,7 @@ func (a *ConsumerFulfillmentsAPI) List(ctx context.Context, request ListFulfillm
 
 	getNextPage := func(ctx context.Context, req ListFulfillmentsRequest) (*ListFulfillmentsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ConsumerFulfillmentsService.List(ctx, req)
 	}
 	getItems := func(resp *ListFulfillmentsResponse) []ListingFulfillment {
 		return resp.Fulfillments
@@ -205,7 +206,7 @@ func (a *ConsumerFulfillmentsAPI) ListAll(ctx context.Context, request ListFulfi
 // Personalized installations contain metadata about the attached share or git
 // repo, as well as the Delta Sharing recipient type.
 func (a *ConsumerFulfillmentsAPI) ListByListingId(ctx context.Context, listingId string) (*ListFulfillmentsResponse, error) {
-	return a.impl.List(ctx, ListFulfillmentsRequest{
+	return a.ConsumerFulfillmentsService.List(ctx, ListFulfillmentsRequest{
 		ListingId: listingId,
 	})
 }
@@ -280,7 +281,7 @@ type ConsumerInstallationsInterface interface {
 
 func NewConsumerInstallations(client *client.DatabricksClient) *ConsumerInstallationsAPI {
 	return &ConsumerInstallationsAPI{
-		impl: &consumerInstallationsImpl{
+		ConsumerInstallationsService: &consumerInstallationsImpl{
 			client: client,
 		},
 	}
@@ -291,42 +292,29 @@ func NewConsumerInstallations(client *client.DatabricksClient) *ConsumerInstalla
 type ConsumerInstallationsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ConsumerInstallationsService)
-	impl ConsumerInstallationsService
+	ConsumerInstallationsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerInstallationsInterface instead.
 func (a *ConsumerInstallationsAPI) WithImpl(impl ConsumerInstallationsService) ConsumerInstallationsInterface {
-	a.impl = impl
-	return a
+	return &ConsumerInstallationsAPI{
+		ConsumerInstallationsService: impl,
+	}
 }
 
 // Impl returns low-level ConsumerInstallations API implementation
 // Deprecated: use MockConsumerInstallationsInterface instead.
 func (a *ConsumerInstallationsAPI) Impl() ConsumerInstallationsService {
-	return a.impl
-}
-
-// Install from a listing.
-//
-// Install payload associated with a Databricks Marketplace listing.
-func (a *ConsumerInstallationsAPI) Create(ctx context.Context, request CreateInstallationRequest) (*Installation, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Uninstall from a listing.
-//
-// Uninstall an installation associated with a Databricks Marketplace listing.
-func (a *ConsumerInstallationsAPI) Delete(ctx context.Context, request DeleteInstallationRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ConsumerInstallationsService
 }
 
 // Uninstall from a listing.
 //
 // Uninstall an installation associated with a Databricks Marketplace listing.
 func (a *ConsumerInstallationsAPI) DeleteByListingIdAndInstallationId(ctx context.Context, listingId string, installationId string) error {
-	return a.impl.Delete(ctx, DeleteInstallationRequest{
+	return a.ConsumerInstallationsService.Delete(ctx, DeleteInstallationRequest{
 		ListingId:      listingId,
 		InstallationId: installationId,
 	})
@@ -341,7 +329,7 @@ func (a *ConsumerInstallationsAPI) List(ctx context.Context, request ListAllInst
 
 	getNextPage := func(ctx context.Context, req ListAllInstallationsRequest) (*ListAllInstallationsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ConsumerInstallationsService.List(ctx, req)
 	}
 	getItems := func(resp *ListAllInstallationsResponse) []InstallationDetail {
 		return resp.Installations
@@ -380,7 +368,7 @@ func (a *ConsumerInstallationsAPI) ListListingInstallations(ctx context.Context,
 
 	getNextPage := func(ctx context.Context, req ListInstallationsRequest) (*ListInstallationsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListListingInstallations(ctx, req)
+		return a.ConsumerInstallationsService.ListListingInstallations(ctx, req)
 	}
 	getItems := func(resp *ListInstallationsResponse) []InstallationDetail {
 		return resp.Installations
@@ -414,20 +402,9 @@ func (a *ConsumerInstallationsAPI) ListListingInstallationsAll(ctx context.Conte
 //
 // List all installations for a particular listing.
 func (a *ConsumerInstallationsAPI) ListListingInstallationsByListingId(ctx context.Context, listingId string) (*ListInstallationsResponse, error) {
-	return a.impl.ListListingInstallations(ctx, ListInstallationsRequest{
+	return a.ConsumerInstallationsService.ListListingInstallations(ctx, ListInstallationsRequest{
 		ListingId: listingId,
 	})
-}
-
-// Update an installation.
-//
-// This is a update API that will update the part of the fields defined in the
-// installation table as well as interact with external services according to
-// the fields not included in the installation table 1. the token will be rotate
-// if the rotateToken flag is true 2. the token will be forcibly rotate if the
-// rotateToken flag is true and the tokenInfo field is empty
-func (a *ConsumerInstallationsAPI) Update(ctx context.Context, request UpdateInstallationRequest) (*UpdateInstallationResponse, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ConsumerListingsInterface interface {
@@ -513,7 +490,7 @@ type ConsumerListingsInterface interface {
 
 func NewConsumerListings(client *client.DatabricksClient) *ConsumerListingsAPI {
 	return &ConsumerListingsAPI{
-		impl: &consumerListingsImpl{
+		ConsumerListingsService: &consumerListingsImpl{
 			client: client,
 		},
 	}
@@ -524,37 +501,22 @@ func NewConsumerListings(client *client.DatabricksClient) *ConsumerListingsAPI {
 type ConsumerListingsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ConsumerListingsService)
-	impl ConsumerListingsService
+	ConsumerListingsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerListingsInterface instead.
 func (a *ConsumerListingsAPI) WithImpl(impl ConsumerListingsService) ConsumerListingsInterface {
-	a.impl = impl
-	return a
+	return &ConsumerListingsAPI{
+		ConsumerListingsService: impl,
+	}
 }
 
 // Impl returns low-level ConsumerListings API implementation
 // Deprecated: use MockConsumerListingsInterface instead.
 func (a *ConsumerListingsAPI) Impl() ConsumerListingsService {
-	return a.impl
-}
-
-// Get one batch of listings. One may specify up to 50 IDs per request.
-//
-// Batch get a published listing in the Databricks Marketplace that the consumer
-// has access to.
-func (a *ConsumerListingsAPI) BatchGet(ctx context.Context, request BatchGetListingsRequest) (*BatchGetListingsResponse, error) {
-	return a.impl.BatchGet(ctx, request)
-}
-
-// Get listing.
-//
-// Get a published listing in the Databricks Marketplace that the consumer has
-// access to.
-func (a *ConsumerListingsAPI) Get(ctx context.Context, request GetListingRequest) (*GetListingResponse, error) {
-	return a.impl.Get(ctx, request)
+	return a.ConsumerListingsService
 }
 
 // Get listing.
@@ -562,7 +524,7 @@ func (a *ConsumerListingsAPI) Get(ctx context.Context, request GetListingRequest
 // Get a published listing in the Databricks Marketplace that the consumer has
 // access to.
 func (a *ConsumerListingsAPI) GetById(ctx context.Context, id string) (*GetListingResponse, error) {
-	return a.impl.Get(ctx, GetListingRequest{
+	return a.ConsumerListingsService.Get(ctx, GetListingRequest{
 		Id: id,
 	})
 }
@@ -577,7 +539,7 @@ func (a *ConsumerListingsAPI) List(ctx context.Context, request ListListingsRequ
 
 	getNextPage := func(ctx context.Context, req ListListingsRequest) (*ListListingsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ConsumerListingsService.List(ctx, req)
 	}
 	getItems := func(resp *ListListingsResponse) []Listing {
 		return resp.Listings
@@ -672,7 +634,7 @@ func (a *ConsumerListingsAPI) Search(ctx context.Context, request SearchListings
 
 	getNextPage := func(ctx context.Context, req SearchListingsRequest) (*SearchListingsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.Search(ctx, req)
+		return a.ConsumerListingsService.Search(ctx, req)
 	}
 	getItems := func(resp *SearchListingsResponse) []Listing {
 		return resp.Listings
@@ -748,7 +710,7 @@ type ConsumerPersonalizationRequestsInterface interface {
 
 func NewConsumerPersonalizationRequests(client *client.DatabricksClient) *ConsumerPersonalizationRequestsAPI {
 	return &ConsumerPersonalizationRequestsAPI{
-		impl: &consumerPersonalizationRequestsImpl{
+		ConsumerPersonalizationRequestsService: &consumerPersonalizationRequestsImpl{
 			client: client,
 		},
 	}
@@ -759,36 +721,22 @@ func NewConsumerPersonalizationRequests(client *client.DatabricksClient) *Consum
 type ConsumerPersonalizationRequestsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ConsumerPersonalizationRequestsService)
-	impl ConsumerPersonalizationRequestsService
+	ConsumerPersonalizationRequestsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerPersonalizationRequestsInterface instead.
 func (a *ConsumerPersonalizationRequestsAPI) WithImpl(impl ConsumerPersonalizationRequestsService) ConsumerPersonalizationRequestsInterface {
-	a.impl = impl
-	return a
+	return &ConsumerPersonalizationRequestsAPI{
+		ConsumerPersonalizationRequestsService: impl,
+	}
 }
 
 // Impl returns low-level ConsumerPersonalizationRequests API implementation
 // Deprecated: use MockConsumerPersonalizationRequestsInterface instead.
 func (a *ConsumerPersonalizationRequestsAPI) Impl() ConsumerPersonalizationRequestsService {
-	return a.impl
-}
-
-// Create a personalization request.
-//
-// Create a personalization request for a listing.
-func (a *ConsumerPersonalizationRequestsAPI) Create(ctx context.Context, request CreatePersonalizationRequest) (*CreatePersonalizationRequestResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Get the personalization request for a listing.
-//
-// Get the personalization request for a listing. Each consumer can make at
-// *most* one personalization request for a listing.
-func (a *ConsumerPersonalizationRequestsAPI) Get(ctx context.Context, request GetPersonalizationRequestRequest) (*GetPersonalizationRequestResponse, error) {
-	return a.impl.Get(ctx, request)
+	return a.ConsumerPersonalizationRequestsService
 }
 
 // Get the personalization request for a listing.
@@ -796,7 +744,7 @@ func (a *ConsumerPersonalizationRequestsAPI) Get(ctx context.Context, request Ge
 // Get the personalization request for a listing. Each consumer can make at
 // *most* one personalization request for a listing.
 func (a *ConsumerPersonalizationRequestsAPI) GetByListingId(ctx context.Context, listingId string) (*GetPersonalizationRequestResponse, error) {
-	return a.impl.Get(ctx, GetPersonalizationRequestRequest{
+	return a.ConsumerPersonalizationRequestsService.Get(ctx, GetPersonalizationRequestRequest{
 		ListingId: listingId,
 	})
 }
@@ -810,7 +758,7 @@ func (a *ConsumerPersonalizationRequestsAPI) List(ctx context.Context, request L
 
 	getNextPage := func(ctx context.Context, req ListAllPersonalizationRequestsRequest) (*ListAllPersonalizationRequestsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ConsumerPersonalizationRequestsService.List(ctx, req)
 	}
 	getItems := func(resp *ListAllPersonalizationRequestsResponse) []PersonalizationRequest {
 		return resp.PersonalizationRequests
@@ -905,7 +853,7 @@ type ConsumerProvidersInterface interface {
 
 func NewConsumerProviders(client *client.DatabricksClient) *ConsumerProvidersAPI {
 	return &ConsumerProvidersAPI{
-		impl: &consumerProvidersImpl{
+		ConsumerProvidersService: &consumerProvidersImpl{
 			client: client,
 		},
 	}
@@ -915,37 +863,22 @@ func NewConsumerProviders(client *client.DatabricksClient) *ConsumerProvidersAPI
 type ConsumerProvidersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ConsumerProvidersService)
-	impl ConsumerProvidersService
+	ConsumerProvidersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerProvidersInterface instead.
 func (a *ConsumerProvidersAPI) WithImpl(impl ConsumerProvidersService) ConsumerProvidersInterface {
-	a.impl = impl
-	return a
+	return &ConsumerProvidersAPI{
+		ConsumerProvidersService: impl,
+	}
 }
 
 // Impl returns low-level ConsumerProviders API implementation
 // Deprecated: use MockConsumerProvidersInterface instead.
 func (a *ConsumerProvidersAPI) Impl() ConsumerProvidersService {
-	return a.impl
-}
-
-// Get one batch of providers. One may specify up to 50 IDs per request.
-//
-// Batch get a provider in the Databricks Marketplace with at least one visible
-// listing.
-func (a *ConsumerProvidersAPI) BatchGet(ctx context.Context, request BatchGetProvidersRequest) (*BatchGetProvidersResponse, error) {
-	return a.impl.BatchGet(ctx, request)
-}
-
-// Get a provider.
-//
-// Get a provider in the Databricks Marketplace with at least one visible
-// listing.
-func (a *ConsumerProvidersAPI) Get(ctx context.Context, request GetProviderRequest) (*GetProviderResponse, error) {
-	return a.impl.Get(ctx, request)
+	return a.ConsumerProvidersService
 }
 
 // Get a provider.
@@ -953,7 +886,7 @@ func (a *ConsumerProvidersAPI) Get(ctx context.Context, request GetProviderReque
 // Get a provider in the Databricks Marketplace with at least one visible
 // listing.
 func (a *ConsumerProvidersAPI) GetById(ctx context.Context, id string) (*GetProviderResponse, error) {
-	return a.impl.Get(ctx, GetProviderRequest{
+	return a.ConsumerProvidersService.Get(ctx, GetProviderRequest{
 		Id: id,
 	})
 }
@@ -968,7 +901,7 @@ func (a *ConsumerProvidersAPI) List(ctx context.Context, request ListProvidersRe
 
 	getNextPage := func(ctx context.Context, req ListProvidersRequest) (*ListProvidersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ConsumerProvidersService.List(ctx, req)
 	}
 	getItems := func(resp *ListProvidersResponse) []ProviderInfo {
 		return resp.Providers
@@ -1117,7 +1050,7 @@ type ProviderExchangeFiltersInterface interface {
 
 func NewProviderExchangeFilters(client *client.DatabricksClient) *ProviderExchangeFiltersAPI {
 	return &ProviderExchangeFiltersAPI{
-		impl: &providerExchangeFiltersImpl{
+		ProviderExchangeFiltersService: &providerExchangeFiltersImpl{
 			client: client,
 		},
 	}
@@ -1127,42 +1060,29 @@ func NewProviderExchangeFilters(client *client.DatabricksClient) *ProviderExchan
 type ProviderExchangeFiltersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderExchangeFiltersService)
-	impl ProviderExchangeFiltersService
+	ProviderExchangeFiltersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderExchangeFiltersInterface instead.
 func (a *ProviderExchangeFiltersAPI) WithImpl(impl ProviderExchangeFiltersService) ProviderExchangeFiltersInterface {
-	a.impl = impl
-	return a
+	return &ProviderExchangeFiltersAPI{
+		ProviderExchangeFiltersService: impl,
+	}
 }
 
 // Impl returns low-level ProviderExchangeFilters API implementation
 // Deprecated: use MockProviderExchangeFiltersInterface instead.
 func (a *ProviderExchangeFiltersAPI) Impl() ProviderExchangeFiltersService {
-	return a.impl
-}
-
-// Create a new exchange filter.
-//
-// Add an exchange filter.
-func (a *ProviderExchangeFiltersAPI) Create(ctx context.Context, request CreateExchangeFilterRequest) (*CreateExchangeFilterResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an exchange filter.
-//
-// Delete an exchange filter
-func (a *ProviderExchangeFiltersAPI) Delete(ctx context.Context, request DeleteExchangeFilterRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ProviderExchangeFiltersService
 }
 
 // Delete an exchange filter.
 //
 // Delete an exchange filter
 func (a *ProviderExchangeFiltersAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteExchangeFilterRequest{
+	return a.ProviderExchangeFiltersService.Delete(ctx, DeleteExchangeFilterRequest{
 		Id: id,
 	})
 }
@@ -1176,7 +1096,7 @@ func (a *ProviderExchangeFiltersAPI) List(ctx context.Context, request ListExcha
 
 	getNextPage := func(ctx context.Context, req ListExchangeFiltersRequest) (*ListExchangeFiltersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProviderExchangeFiltersService.List(ctx, req)
 	}
 	getItems := func(resp *ListExchangeFiltersResponse) []ExchangeFilter {
 		return resp.Filters
@@ -1257,13 +1177,6 @@ func (a *ProviderExchangeFiltersAPI) GetByName(ctx context.Context, name string)
 		return nil, fmt.Errorf("there are %d instances of ExchangeFilter named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update exchange filter.
-//
-// Update an exchange filter.
-func (a *ProviderExchangeFiltersAPI) Update(ctx context.Context, request UpdateExchangeFilterRequest) (*UpdateExchangeFilterResponse, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ProviderExchangesInterface interface {
@@ -1420,7 +1333,7 @@ type ProviderExchangesInterface interface {
 
 func NewProviderExchanges(client *client.DatabricksClient) *ProviderExchangesAPI {
 	return &ProviderExchangesAPI{
-		impl: &providerExchangesImpl{
+		ProviderExchangesService: &providerExchangesImpl{
 			client: client,
 		},
 	}
@@ -1431,65 +1344,38 @@ func NewProviderExchanges(client *client.DatabricksClient) *ProviderExchangesAPI
 type ProviderExchangesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderExchangesService)
-	impl ProviderExchangesService
+	ProviderExchangesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderExchangesInterface instead.
 func (a *ProviderExchangesAPI) WithImpl(impl ProviderExchangesService) ProviderExchangesInterface {
-	a.impl = impl
-	return a
+	return &ProviderExchangesAPI{
+		ProviderExchangesService: impl,
+	}
 }
 
 // Impl returns low-level ProviderExchanges API implementation
 // Deprecated: use MockProviderExchangesInterface instead.
 func (a *ProviderExchangesAPI) Impl() ProviderExchangesService {
-	return a.impl
-}
-
-// Add an exchange for listing.
-//
-// Associate an exchange with a listing
-func (a *ProviderExchangesAPI) AddListingToExchange(ctx context.Context, request AddExchangeForListingRequest) (*AddExchangeForListingResponse, error) {
-	return a.impl.AddListingToExchange(ctx, request)
-}
-
-// Create an exchange.
-//
-// Create an exchange
-func (a *ProviderExchangesAPI) Create(ctx context.Context, request CreateExchangeRequest) (*CreateExchangeResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an exchange.
-//
-// This removes a listing from marketplace.
-func (a *ProviderExchangesAPI) Delete(ctx context.Context, request DeleteExchangeRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ProviderExchangesService
 }
 
 // Delete an exchange.
 //
 // This removes a listing from marketplace.
 func (a *ProviderExchangesAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteExchangeRequest{
+	return a.ProviderExchangesService.Delete(ctx, DeleteExchangeRequest{
 		Id: id,
 	})
-}
-
-// Remove an exchange for listing.
-//
-// Disassociate an exchange with a listing
-func (a *ProviderExchangesAPI) DeleteListingFromExchange(ctx context.Context, request RemoveExchangeForListingRequest) error {
-	return a.impl.DeleteListingFromExchange(ctx, request)
 }
 
 // Remove an exchange for listing.
 //
 // Disassociate an exchange with a listing
 func (a *ProviderExchangesAPI) DeleteListingFromExchangeById(ctx context.Context, id string) error {
-	return a.impl.DeleteListingFromExchange(ctx, RemoveExchangeForListingRequest{
+	return a.ProviderExchangesService.DeleteListingFromExchange(ctx, RemoveExchangeForListingRequest{
 		Id: id,
 	})
 }
@@ -1497,15 +1383,8 @@ func (a *ProviderExchangesAPI) DeleteListingFromExchangeById(ctx context.Context
 // Get an exchange.
 //
 // Get an exchange.
-func (a *ProviderExchangesAPI) Get(ctx context.Context, request GetExchangeRequest) (*GetExchangeResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get an exchange.
-//
-// Get an exchange.
 func (a *ProviderExchangesAPI) GetById(ctx context.Context, id string) (*GetExchangeResponse, error) {
-	return a.impl.Get(ctx, GetExchangeRequest{
+	return a.ProviderExchangesService.Get(ctx, GetExchangeRequest{
 		Id: id,
 	})
 }
@@ -1519,7 +1398,7 @@ func (a *ProviderExchangesAPI) List(ctx context.Context, request ListExchangesRe
 
 	getNextPage := func(ctx context.Context, req ListExchangesRequest) (*ListExchangesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProviderExchangesService.List(ctx, req)
 	}
 	getItems := func(resp *ListExchangesResponse) []Exchange {
 		return resp.Exchanges
@@ -1611,7 +1490,7 @@ func (a *ProviderExchangesAPI) ListExchangesForListing(ctx context.Context, requ
 
 	getNextPage := func(ctx context.Context, req ListExchangesForListingRequest) (*ListExchangesForListingResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListExchangesForListing(ctx, req)
+		return a.ProviderExchangesService.ListExchangesForListing(ctx, req)
 	}
 	getItems := func(resp *ListExchangesForListingResponse) []ExchangeListing {
 		return resp.ExchangeListing
@@ -1703,7 +1582,7 @@ func (a *ProviderExchangesAPI) ListListingsForExchange(ctx context.Context, requ
 
 	getNextPage := func(ctx context.Context, req ListListingsForExchangeRequest) (*ListListingsForExchangeResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListListingsForExchange(ctx, req)
+		return a.ProviderExchangesService.ListListingsForExchange(ctx, req)
 	}
 	getItems := func(resp *ListListingsForExchangeResponse) []ExchangeListing {
 		return resp.ExchangeListings
@@ -1786,13 +1665,6 @@ func (a *ProviderExchangesAPI) GetByListingName(ctx context.Context, name string
 	return &alternatives[0], nil
 }
 
-// Update exchange.
-//
-// Update an exchange
-func (a *ProviderExchangesAPI) Update(ctx context.Context, request UpdateExchangeRequest) (*UpdateExchangeResponse, error) {
-	return a.impl.Update(ctx, request)
-}
-
 type ProviderFilesInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -1864,7 +1736,7 @@ type ProviderFilesInterface interface {
 
 func NewProviderFiles(client *client.DatabricksClient) *ProviderFilesAPI {
 	return &ProviderFilesAPI{
-		impl: &providerFilesImpl{
+		ProviderFilesService: &providerFilesImpl{
 			client: client,
 		},
 	}
@@ -1875,43 +1747,29 @@ func NewProviderFiles(client *client.DatabricksClient) *ProviderFilesAPI {
 type ProviderFilesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderFilesService)
-	impl ProviderFilesService
+	ProviderFilesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderFilesInterface instead.
 func (a *ProviderFilesAPI) WithImpl(impl ProviderFilesService) ProviderFilesInterface {
-	a.impl = impl
-	return a
+	return &ProviderFilesAPI{
+		ProviderFilesService: impl,
+	}
 }
 
 // Impl returns low-level ProviderFiles API implementation
 // Deprecated: use MockProviderFilesInterface instead.
 func (a *ProviderFilesAPI) Impl() ProviderFilesService {
-	return a.impl
-}
-
-// Create a file.
-//
-// Create a file. Currently, only provider icons and attached notebooks are
-// supported.
-func (a *ProviderFilesAPI) Create(ctx context.Context, request CreateFileRequest) (*CreateFileResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a file.
-//
-// Delete a file
-func (a *ProviderFilesAPI) Delete(ctx context.Context, request DeleteFileRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ProviderFilesService
 }
 
 // Delete a file.
 //
 // Delete a file
 func (a *ProviderFilesAPI) DeleteByFileId(ctx context.Context, fileId string) error {
-	return a.impl.Delete(ctx, DeleteFileRequest{
+	return a.ProviderFilesService.Delete(ctx, DeleteFileRequest{
 		FileId: fileId,
 	})
 }
@@ -1919,15 +1777,8 @@ func (a *ProviderFilesAPI) DeleteByFileId(ctx context.Context, fileId string) er
 // Get a file.
 //
 // Get a file
-func (a *ProviderFilesAPI) Get(ctx context.Context, request GetFileRequest) (*GetFileResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a file.
-//
-// Get a file
 func (a *ProviderFilesAPI) GetByFileId(ctx context.Context, fileId string) (*GetFileResponse, error) {
-	return a.impl.Get(ctx, GetFileRequest{
+	return a.ProviderFilesService.Get(ctx, GetFileRequest{
 		FileId: fileId,
 	})
 }
@@ -1941,7 +1792,7 @@ func (a *ProviderFilesAPI) List(ctx context.Context, request ListFilesRequest) l
 
 	getNextPage := func(ctx context.Context, req ListFilesRequest) (*ListFilesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProviderFilesService.List(ctx, req)
 	}
 	getItems := func(resp *ListFilesResponse) []FileInfo {
 		return resp.FileInfos
@@ -2099,7 +1950,7 @@ type ProviderListingsInterface interface {
 
 func NewProviderListings(client *client.DatabricksClient) *ProviderListingsAPI {
 	return &ProviderListingsAPI{
-		impl: &providerListingsImpl{
+		ProviderListingsService: &providerListingsImpl{
 			client: client,
 		},
 	}
@@ -2110,42 +1961,29 @@ func NewProviderListings(client *client.DatabricksClient) *ProviderListingsAPI {
 type ProviderListingsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderListingsService)
-	impl ProviderListingsService
+	ProviderListingsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderListingsInterface instead.
 func (a *ProviderListingsAPI) WithImpl(impl ProviderListingsService) ProviderListingsInterface {
-	a.impl = impl
-	return a
+	return &ProviderListingsAPI{
+		ProviderListingsService: impl,
+	}
 }
 
 // Impl returns low-level ProviderListings API implementation
 // Deprecated: use MockProviderListingsInterface instead.
 func (a *ProviderListingsAPI) Impl() ProviderListingsService {
-	return a.impl
-}
-
-// Create a listing.
-//
-// Create a new listing
-func (a *ProviderListingsAPI) Create(ctx context.Context, request CreateListingRequest) (*CreateListingResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a listing.
-//
-// Delete a listing
-func (a *ProviderListingsAPI) Delete(ctx context.Context, request DeleteListingRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ProviderListingsService
 }
 
 // Delete a listing.
 //
 // Delete a listing
 func (a *ProviderListingsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteListingRequest{
+	return a.ProviderListingsService.Delete(ctx, DeleteListingRequest{
 		Id: id,
 	})
 }
@@ -2153,15 +1991,8 @@ func (a *ProviderListingsAPI) DeleteById(ctx context.Context, id string) error {
 // Get a listing.
 //
 // Get a listing
-func (a *ProviderListingsAPI) Get(ctx context.Context, request GetListingRequest) (*GetListingResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a listing.
-//
-// Get a listing
 func (a *ProviderListingsAPI) GetById(ctx context.Context, id string) (*GetListingResponse, error) {
-	return a.impl.Get(ctx, GetListingRequest{
+	return a.ProviderListingsService.Get(ctx, GetListingRequest{
 		Id: id,
 	})
 }
@@ -2175,7 +2006,7 @@ func (a *ProviderListingsAPI) List(ctx context.Context, request GetListingsReque
 
 	getNextPage := func(ctx context.Context, req GetListingsRequest) (*GetListingsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProviderListingsService.List(ctx, req)
 	}
 	getItems := func(resp *GetListingsResponse) []Listing {
 		return resp.Listings
@@ -2258,13 +2089,6 @@ func (a *ProviderListingsAPI) GetBySummaryName(ctx context.Context, name string)
 	return &alternatives[0], nil
 }
 
-// Update listing.
-//
-// Update a listing
-func (a *ProviderListingsAPI) Update(ctx context.Context, request UpdateListingRequest) (*UpdateListingResponse, error) {
-	return a.impl.Update(ctx, request)
-}
-
 type ProviderPersonalizationRequestsInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -2300,7 +2124,7 @@ type ProviderPersonalizationRequestsInterface interface {
 
 func NewProviderPersonalizationRequests(client *client.DatabricksClient) *ProviderPersonalizationRequestsAPI {
 	return &ProviderPersonalizationRequestsAPI{
-		impl: &providerPersonalizationRequestsImpl{
+		ProviderPersonalizationRequestsService: &providerPersonalizationRequestsImpl{
 			client: client,
 		},
 	}
@@ -2311,21 +2135,22 @@ func NewProviderPersonalizationRequests(client *client.DatabricksClient) *Provid
 type ProviderPersonalizationRequestsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderPersonalizationRequestsService)
-	impl ProviderPersonalizationRequestsService
+	ProviderPersonalizationRequestsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderPersonalizationRequestsInterface instead.
 func (a *ProviderPersonalizationRequestsAPI) WithImpl(impl ProviderPersonalizationRequestsService) ProviderPersonalizationRequestsInterface {
-	a.impl = impl
-	return a
+	return &ProviderPersonalizationRequestsAPI{
+		ProviderPersonalizationRequestsService: impl,
+	}
 }
 
 // Impl returns low-level ProviderPersonalizationRequests API implementation
 // Deprecated: use MockProviderPersonalizationRequestsInterface instead.
 func (a *ProviderPersonalizationRequestsAPI) Impl() ProviderPersonalizationRequestsService {
-	return a.impl
+	return a.ProviderPersonalizationRequestsService
 }
 
 // All personalization requests across all listings.
@@ -2338,7 +2163,7 @@ func (a *ProviderPersonalizationRequestsAPI) List(ctx context.Context, request L
 
 	getNextPage := func(ctx context.Context, req ListAllPersonalizationRequestsRequest) (*ListAllPersonalizationRequestsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProviderPersonalizationRequestsService.List(ctx, req)
 	}
 	getItems := func(resp *ListAllPersonalizationRequestsResponse) []PersonalizationRequest {
 		return resp.PersonalizationRequests
@@ -2367,14 +2192,6 @@ func (a *ProviderPersonalizationRequestsAPI) List(ctx context.Context, request L
 func (a *ProviderPersonalizationRequestsAPI) ListAll(ctx context.Context, request ListAllPersonalizationRequestsRequest) ([]PersonalizationRequest, error) {
 	iterator := a.List(ctx, request)
 	return listing.ToSlice[PersonalizationRequest](ctx, iterator)
-}
-
-// Update personalization request status.
-//
-// Update personalization request. This method only permits updating the status
-// of the request.
-func (a *ProviderPersonalizationRequestsAPI) Update(ctx context.Context, request UpdatePersonalizationRequestRequest) (*UpdatePersonalizationRequestResponse, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ProviderProviderAnalyticsDashboardsInterface interface {
@@ -2411,7 +2228,7 @@ type ProviderProviderAnalyticsDashboardsInterface interface {
 
 func NewProviderProviderAnalyticsDashboards(client *client.DatabricksClient) *ProviderProviderAnalyticsDashboardsAPI {
 	return &ProviderProviderAnalyticsDashboardsAPI{
-		impl: &providerProviderAnalyticsDashboardsImpl{
+		ProviderProviderAnalyticsDashboardsService: &providerProviderAnalyticsDashboardsImpl{
 			client: client,
 		},
 	}
@@ -2421,50 +2238,22 @@ func NewProviderProviderAnalyticsDashboards(client *client.DatabricksClient) *Pr
 type ProviderProviderAnalyticsDashboardsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderProviderAnalyticsDashboardsService)
-	impl ProviderProviderAnalyticsDashboardsService
+	ProviderProviderAnalyticsDashboardsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderProviderAnalyticsDashboardsInterface instead.
 func (a *ProviderProviderAnalyticsDashboardsAPI) WithImpl(impl ProviderProviderAnalyticsDashboardsService) ProviderProviderAnalyticsDashboardsInterface {
-	a.impl = impl
-	return a
+	return &ProviderProviderAnalyticsDashboardsAPI{
+		ProviderProviderAnalyticsDashboardsService: impl,
+	}
 }
 
 // Impl returns low-level ProviderProviderAnalyticsDashboards API implementation
 // Deprecated: use MockProviderProviderAnalyticsDashboardsInterface instead.
 func (a *ProviderProviderAnalyticsDashboardsAPI) Impl() ProviderProviderAnalyticsDashboardsService {
-	return a.impl
-}
-
-// Create provider analytics dashboard.
-//
-// Create provider analytics dashboard. Returns Marketplace specific `id`. Not
-// to be confused with the Lakeview dashboard id.
-func (a *ProviderProviderAnalyticsDashboardsAPI) Create(ctx context.Context) (*ProviderAnalyticsDashboard, error) {
-	return a.impl.Create(ctx)
-}
-
-// Get provider analytics dashboard.
-//
-// Get provider analytics dashboard.
-func (a *ProviderProviderAnalyticsDashboardsAPI) Get(ctx context.Context) (*ListProviderAnalyticsDashboardResponse, error) {
-	return a.impl.Get(ctx)
-}
-
-// Get latest version of provider analytics dashboard.
-//
-// Get latest version of provider analytics dashboard.
-func (a *ProviderProviderAnalyticsDashboardsAPI) GetLatestVersion(ctx context.Context) (*GetLatestVersionProviderAnalyticsDashboardResponse, error) {
-	return a.impl.GetLatestVersion(ctx)
-}
-
-// Update provider analytics dashboard.
-//
-// Update provider analytics dashboard.
-func (a *ProviderProviderAnalyticsDashboardsAPI) Update(ctx context.Context, request UpdateProviderAnalyticsDashboardRequest) (*UpdateProviderAnalyticsDashboardResponse, error) {
-	return a.impl.Update(ctx, request)
+	return a.ProviderProviderAnalyticsDashboardsService
 }
 
 type ProviderProvidersInterface interface {
@@ -2542,7 +2331,7 @@ type ProviderProvidersInterface interface {
 
 func NewProviderProviders(client *client.DatabricksClient) *ProviderProvidersAPI {
 	return &ProviderProvidersAPI{
-		impl: &providerProvidersImpl{
+		ProviderProvidersService: &providerProvidersImpl{
 			client: client,
 		},
 	}
@@ -2552,42 +2341,29 @@ func NewProviderProviders(client *client.DatabricksClient) *ProviderProvidersAPI
 type ProviderProvidersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProviderProvidersService)
-	impl ProviderProvidersService
+	ProviderProvidersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderProvidersInterface instead.
 func (a *ProviderProvidersAPI) WithImpl(impl ProviderProvidersService) ProviderProvidersInterface {
-	a.impl = impl
-	return a
+	return &ProviderProvidersAPI{
+		ProviderProvidersService: impl,
+	}
 }
 
 // Impl returns low-level ProviderProviders API implementation
 // Deprecated: use MockProviderProvidersInterface instead.
 func (a *ProviderProvidersAPI) Impl() ProviderProvidersService {
-	return a.impl
-}
-
-// Create a provider.
-//
-// Create a provider
-func (a *ProviderProvidersAPI) Create(ctx context.Context, request CreateProviderRequest) (*CreateProviderResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete provider.
-//
-// Delete provider
-func (a *ProviderProvidersAPI) Delete(ctx context.Context, request DeleteProviderRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ProviderProvidersService
 }
 
 // Delete provider.
 //
 // Delete provider
 func (a *ProviderProvidersAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteProviderRequest{
+	return a.ProviderProvidersService.Delete(ctx, DeleteProviderRequest{
 		Id: id,
 	})
 }
@@ -2595,15 +2371,8 @@ func (a *ProviderProvidersAPI) DeleteById(ctx context.Context, id string) error 
 // Get provider.
 //
 // Get provider profile
-func (a *ProviderProvidersAPI) Get(ctx context.Context, request GetProviderRequest) (*GetProviderResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get provider.
-//
-// Get provider profile
 func (a *ProviderProvidersAPI) GetById(ctx context.Context, id string) (*GetProviderResponse, error) {
-	return a.impl.Get(ctx, GetProviderRequest{
+	return a.ProviderProvidersService.Get(ctx, GetProviderRequest{
 		Id: id,
 	})
 }
@@ -2617,7 +2386,7 @@ func (a *ProviderProvidersAPI) List(ctx context.Context, request ListProvidersRe
 
 	getNextPage := func(ctx context.Context, req ListProvidersRequest) (*ListProvidersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProviderProvidersService.List(ctx, req)
 	}
 	getItems := func(resp *ListProvidersResponse) []ProviderInfo {
 		return resp.Providers
@@ -2698,11 +2467,4 @@ func (a *ProviderProvidersAPI) GetByName(ctx context.Context, name string) (*Pro
 		return nil, fmt.Errorf("there are %d instances of ProviderInfo named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update provider.
-//
-// Update provider profile
-func (a *ProviderProvidersAPI) Update(ctx context.Context, request UpdateProviderRequest) (*UpdateProviderResponse, error) {
-	return a.impl.Update(ctx, request)
 }

--- a/service/marketplace/api.go
+++ b/service/marketplace/api.go
@@ -92,9 +92,8 @@ type ConsumerFulfillmentsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerFulfillmentsInterface instead.
 func (a *ConsumerFulfillmentsAPI) WithImpl(impl ConsumerFulfillmentsService) ConsumerFulfillmentsInterface {
-	return &ConsumerFulfillmentsAPI{
-		ConsumerFulfillmentsService: impl,
-	}
+	a.ConsumerFulfillmentsService = impl
+	return a
 }
 
 // Impl returns low-level ConsumerFulfillments API implementation
@@ -299,9 +298,8 @@ type ConsumerInstallationsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerInstallationsInterface instead.
 func (a *ConsumerInstallationsAPI) WithImpl(impl ConsumerInstallationsService) ConsumerInstallationsInterface {
-	return &ConsumerInstallationsAPI{
-		ConsumerInstallationsService: impl,
-	}
+	a.ConsumerInstallationsService = impl
+	return a
 }
 
 // Impl returns low-level ConsumerInstallations API implementation
@@ -508,9 +506,8 @@ type ConsumerListingsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerListingsInterface instead.
 func (a *ConsumerListingsAPI) WithImpl(impl ConsumerListingsService) ConsumerListingsInterface {
-	return &ConsumerListingsAPI{
-		ConsumerListingsService: impl,
-	}
+	a.ConsumerListingsService = impl
+	return a
 }
 
 // Impl returns low-level ConsumerListings API implementation
@@ -728,9 +725,8 @@ type ConsumerPersonalizationRequestsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerPersonalizationRequestsInterface instead.
 func (a *ConsumerPersonalizationRequestsAPI) WithImpl(impl ConsumerPersonalizationRequestsService) ConsumerPersonalizationRequestsInterface {
-	return &ConsumerPersonalizationRequestsAPI{
-		ConsumerPersonalizationRequestsService: impl,
-	}
+	a.ConsumerPersonalizationRequestsService = impl
+	return a
 }
 
 // Impl returns low-level ConsumerPersonalizationRequests API implementation
@@ -870,9 +866,8 @@ type ConsumerProvidersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockConsumerProvidersInterface instead.
 func (a *ConsumerProvidersAPI) WithImpl(impl ConsumerProvidersService) ConsumerProvidersInterface {
-	return &ConsumerProvidersAPI{
-		ConsumerProvidersService: impl,
-	}
+	a.ConsumerProvidersService = impl
+	return a
 }
 
 // Impl returns low-level ConsumerProviders API implementation
@@ -1067,9 +1062,8 @@ type ProviderExchangeFiltersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderExchangeFiltersInterface instead.
 func (a *ProviderExchangeFiltersAPI) WithImpl(impl ProviderExchangeFiltersService) ProviderExchangeFiltersInterface {
-	return &ProviderExchangeFiltersAPI{
-		ProviderExchangeFiltersService: impl,
-	}
+	a.ProviderExchangeFiltersService = impl
+	return a
 }
 
 // Impl returns low-level ProviderExchangeFilters API implementation
@@ -1351,9 +1345,8 @@ type ProviderExchangesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderExchangesInterface instead.
 func (a *ProviderExchangesAPI) WithImpl(impl ProviderExchangesService) ProviderExchangesInterface {
-	return &ProviderExchangesAPI{
-		ProviderExchangesService: impl,
-	}
+	a.ProviderExchangesService = impl
+	return a
 }
 
 // Impl returns low-level ProviderExchanges API implementation
@@ -1754,9 +1747,8 @@ type ProviderFilesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderFilesInterface instead.
 func (a *ProviderFilesAPI) WithImpl(impl ProviderFilesService) ProviderFilesInterface {
-	return &ProviderFilesAPI{
-		ProviderFilesService: impl,
-	}
+	a.ProviderFilesService = impl
+	return a
 }
 
 // Impl returns low-level ProviderFiles API implementation
@@ -1968,9 +1960,8 @@ type ProviderListingsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderListingsInterface instead.
 func (a *ProviderListingsAPI) WithImpl(impl ProviderListingsService) ProviderListingsInterface {
-	return &ProviderListingsAPI{
-		ProviderListingsService: impl,
-	}
+	a.ProviderListingsService = impl
+	return a
 }
 
 // Impl returns low-level ProviderListings API implementation
@@ -2142,9 +2133,8 @@ type ProviderPersonalizationRequestsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderPersonalizationRequestsInterface instead.
 func (a *ProviderPersonalizationRequestsAPI) WithImpl(impl ProviderPersonalizationRequestsService) ProviderPersonalizationRequestsInterface {
-	return &ProviderPersonalizationRequestsAPI{
-		ProviderPersonalizationRequestsService: impl,
-	}
+	a.ProviderPersonalizationRequestsService = impl
+	return a
 }
 
 // Impl returns low-level ProviderPersonalizationRequests API implementation
@@ -2245,9 +2235,8 @@ type ProviderProviderAnalyticsDashboardsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderProviderAnalyticsDashboardsInterface instead.
 func (a *ProviderProviderAnalyticsDashboardsAPI) WithImpl(impl ProviderProviderAnalyticsDashboardsService) ProviderProviderAnalyticsDashboardsInterface {
-	return &ProviderProviderAnalyticsDashboardsAPI{
-		ProviderProviderAnalyticsDashboardsService: impl,
-	}
+	a.ProviderProviderAnalyticsDashboardsService = impl
+	return a
 }
 
 // Impl returns low-level ProviderProviderAnalyticsDashboards API implementation
@@ -2348,9 +2337,8 @@ type ProviderProvidersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProviderProvidersInterface instead.
 func (a *ProviderProvidersAPI) WithImpl(impl ProviderProvidersService) ProviderProvidersInterface {
-	return &ProviderProvidersAPI{
-		ProviderProvidersService: impl,
-	}
+	a.ProviderProvidersService = impl
+	return a
 }
 
 // Impl returns low-level ProviderProviders API implementation

--- a/service/ml/api.go
+++ b/service/ml/api.go
@@ -344,9 +344,8 @@ type ExperimentsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockExperimentsInterface instead.
 func (a *ExperimentsAPI) WithImpl(impl ExperimentsService) ExperimentsInterface {
-	return &ExperimentsAPI{
-		ExperimentsService: impl,
-	}
+	a.ExperimentsService = impl
+	return a
 }
 
 // Impl returns low-level Experiments API implementation
@@ -889,9 +888,8 @@ type ModelRegistryAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockModelRegistryInterface instead.
 func (a *ModelRegistryAPI) WithImpl(impl ModelRegistryService) ModelRegistryInterface {
-	return &ModelRegistryAPI{
-		ModelRegistryService: impl,
-	}
+	a.ModelRegistryService = impl
+	return a
 }
 
 // Impl returns low-level ModelRegistry API implementation

--- a/service/oauth2/api.go
+++ b/service/oauth2/api.go
@@ -76,7 +76,7 @@ type CustomAppIntegrationInterface interface {
 
 func NewCustomAppIntegration(client *client.DatabricksClient) *CustomAppIntegrationAPI {
 	return &CustomAppIntegrationAPI{
-		impl: &customAppIntegrationImpl{
+		CustomAppIntegrationService: &customAppIntegrationImpl{
 			client: client,
 		},
 	}
@@ -88,39 +88,22 @@ func NewCustomAppIntegration(client *client.DatabricksClient) *CustomAppIntegrat
 type CustomAppIntegrationAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CustomAppIntegrationService)
-	impl CustomAppIntegrationService
+	CustomAppIntegrationService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCustomAppIntegrationInterface instead.
 func (a *CustomAppIntegrationAPI) WithImpl(impl CustomAppIntegrationService) CustomAppIntegrationInterface {
-	a.impl = impl
-	return a
+	return &CustomAppIntegrationAPI{
+		CustomAppIntegrationService: impl,
+	}
 }
 
 // Impl returns low-level CustomAppIntegration API implementation
 // Deprecated: use MockCustomAppIntegrationInterface instead.
 func (a *CustomAppIntegrationAPI) Impl() CustomAppIntegrationService {
-	return a.impl
-}
-
-// Create Custom OAuth App Integration.
-//
-// Create Custom OAuth App Integration.
-//
-// You can retrieve the custom OAuth app integration via
-// :method:CustomAppIntegration/get.
-func (a *CustomAppIntegrationAPI) Create(ctx context.Context, request CreateCustomAppIntegration) (*CreateCustomAppIntegrationOutput, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete Custom OAuth App Integration.
-//
-// Delete an existing Custom OAuth App Integration. You can retrieve the custom
-// OAuth app integration via :method:CustomAppIntegration/get.
-func (a *CustomAppIntegrationAPI) Delete(ctx context.Context, request DeleteCustomAppIntegrationRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.CustomAppIntegrationService
 }
 
 // Delete Custom OAuth App Integration.
@@ -128,7 +111,7 @@ func (a *CustomAppIntegrationAPI) Delete(ctx context.Context, request DeleteCust
 // Delete an existing Custom OAuth App Integration. You can retrieve the custom
 // OAuth app integration via :method:CustomAppIntegration/get.
 func (a *CustomAppIntegrationAPI) DeleteByIntegrationId(ctx context.Context, integrationId string) error {
-	return a.impl.Delete(ctx, DeleteCustomAppIntegrationRequest{
+	return a.CustomAppIntegrationService.Delete(ctx, DeleteCustomAppIntegrationRequest{
 		IntegrationId: integrationId,
 	})
 }
@@ -136,15 +119,8 @@ func (a *CustomAppIntegrationAPI) DeleteByIntegrationId(ctx context.Context, int
 // Get OAuth Custom App Integration.
 //
 // Gets the Custom OAuth App Integration for the given integration id.
-func (a *CustomAppIntegrationAPI) Get(ctx context.Context, request GetCustomAppIntegrationRequest) (*GetCustomAppIntegrationOutput, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get OAuth Custom App Integration.
-//
-// Gets the Custom OAuth App Integration for the given integration id.
 func (a *CustomAppIntegrationAPI) GetByIntegrationId(ctx context.Context, integrationId string) (*GetCustomAppIntegrationOutput, error) {
-	return a.impl.Get(ctx, GetCustomAppIntegrationRequest{
+	return a.CustomAppIntegrationService.Get(ctx, GetCustomAppIntegrationRequest{
 		IntegrationId: integrationId,
 	})
 }
@@ -159,7 +135,7 @@ func (a *CustomAppIntegrationAPI) List(ctx context.Context, request ListCustomAp
 
 	getNextPage := func(ctx context.Context, req ListCustomAppIntegrationsRequest) (*GetCustomAppIntegrationsOutput, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.CustomAppIntegrationService.List(ctx, req)
 	}
 	getItems := func(resp *GetCustomAppIntegrationsOutput) []GetCustomAppIntegrationOutput {
 		return resp.Apps
@@ -190,14 +166,6 @@ func (a *CustomAppIntegrationAPI) ListAll(ctx context.Context, request ListCusto
 	return listing.ToSlice[GetCustomAppIntegrationOutput](ctx, iterator)
 }
 
-// Updates Custom OAuth App Integration.
-//
-// Updates an existing custom OAuth App Integration. You can retrieve the custom
-// OAuth app integration via :method:CustomAppIntegration/get.
-func (a *CustomAppIntegrationAPI) Update(ctx context.Context, request UpdateCustomAppIntegration) error {
-	return a.impl.Update(ctx, request)
-}
-
 type OAuthPublishedAppsInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -225,7 +193,7 @@ type OAuthPublishedAppsInterface interface {
 
 func NewOAuthPublishedApps(client *client.DatabricksClient) *OAuthPublishedAppsAPI {
 	return &OAuthPublishedAppsAPI{
-		impl: &oAuthPublishedAppsImpl{
+		OAuthPublishedAppsService: &oAuthPublishedAppsImpl{
 			client: client,
 		},
 	}
@@ -238,21 +206,22 @@ func NewOAuthPublishedApps(client *client.DatabricksClient) *OAuthPublishedAppsA
 type OAuthPublishedAppsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(OAuthPublishedAppsService)
-	impl OAuthPublishedAppsService
+	OAuthPublishedAppsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockOAuthPublishedAppsInterface instead.
 func (a *OAuthPublishedAppsAPI) WithImpl(impl OAuthPublishedAppsService) OAuthPublishedAppsInterface {
-	a.impl = impl
-	return a
+	return &OAuthPublishedAppsAPI{
+		OAuthPublishedAppsService: impl,
+	}
 }
 
 // Impl returns low-level OAuthPublishedApps API implementation
 // Deprecated: use MockOAuthPublishedAppsInterface instead.
 func (a *OAuthPublishedAppsAPI) Impl() OAuthPublishedAppsService {
-	return a.impl
+	return a.OAuthPublishedAppsService
 }
 
 // Get all the published OAuth apps.
@@ -264,7 +233,7 @@ func (a *OAuthPublishedAppsAPI) List(ctx context.Context, request ListOAuthPubli
 
 	getNextPage := func(ctx context.Context, req ListOAuthPublishedAppsRequest) (*GetPublishedAppsOutput, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.OAuthPublishedAppsService.List(ctx, req)
 	}
 	getItems := func(resp *GetPublishedAppsOutput) []PublishedAppOutput {
 		return resp.Apps
@@ -359,7 +328,7 @@ type PublishedAppIntegrationInterface interface {
 
 func NewPublishedAppIntegration(client *client.DatabricksClient) *PublishedAppIntegrationAPI {
 	return &PublishedAppIntegrationAPI{
-		impl: &publishedAppIntegrationImpl{
+		PublishedAppIntegrationService: &publishedAppIntegrationImpl{
 			client: client,
 		},
 	}
@@ -371,39 +340,22 @@ func NewPublishedAppIntegration(client *client.DatabricksClient) *PublishedAppIn
 type PublishedAppIntegrationAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PublishedAppIntegrationService)
-	impl PublishedAppIntegrationService
+	PublishedAppIntegrationService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPublishedAppIntegrationInterface instead.
 func (a *PublishedAppIntegrationAPI) WithImpl(impl PublishedAppIntegrationService) PublishedAppIntegrationInterface {
-	a.impl = impl
-	return a
+	return &PublishedAppIntegrationAPI{
+		PublishedAppIntegrationService: impl,
+	}
 }
 
 // Impl returns low-level PublishedAppIntegration API implementation
 // Deprecated: use MockPublishedAppIntegrationInterface instead.
 func (a *PublishedAppIntegrationAPI) Impl() PublishedAppIntegrationService {
-	return a.impl
-}
-
-// Create Published OAuth App Integration.
-//
-// Create Published OAuth App Integration.
-//
-// You can retrieve the published OAuth app integration via
-// :method:PublishedAppIntegration/get.
-func (a *PublishedAppIntegrationAPI) Create(ctx context.Context, request CreatePublishedAppIntegration) (*CreatePublishedAppIntegrationOutput, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete Published OAuth App Integration.
-//
-// Delete an existing Published OAuth App Integration. You can retrieve the
-// published OAuth app integration via :method:PublishedAppIntegration/get.
-func (a *PublishedAppIntegrationAPI) Delete(ctx context.Context, request DeletePublishedAppIntegrationRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.PublishedAppIntegrationService
 }
 
 // Delete Published OAuth App Integration.
@@ -411,7 +363,7 @@ func (a *PublishedAppIntegrationAPI) Delete(ctx context.Context, request DeleteP
 // Delete an existing Published OAuth App Integration. You can retrieve the
 // published OAuth app integration via :method:PublishedAppIntegration/get.
 func (a *PublishedAppIntegrationAPI) DeleteByIntegrationId(ctx context.Context, integrationId string) error {
-	return a.impl.Delete(ctx, DeletePublishedAppIntegrationRequest{
+	return a.PublishedAppIntegrationService.Delete(ctx, DeletePublishedAppIntegrationRequest{
 		IntegrationId: integrationId,
 	})
 }
@@ -419,15 +371,8 @@ func (a *PublishedAppIntegrationAPI) DeleteByIntegrationId(ctx context.Context, 
 // Get OAuth Published App Integration.
 //
 // Gets the Published OAuth App Integration for the given integration id.
-func (a *PublishedAppIntegrationAPI) Get(ctx context.Context, request GetPublishedAppIntegrationRequest) (*GetPublishedAppIntegrationOutput, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get OAuth Published App Integration.
-//
-// Gets the Published OAuth App Integration for the given integration id.
 func (a *PublishedAppIntegrationAPI) GetByIntegrationId(ctx context.Context, integrationId string) (*GetPublishedAppIntegrationOutput, error) {
-	return a.impl.Get(ctx, GetPublishedAppIntegrationRequest{
+	return a.PublishedAppIntegrationService.Get(ctx, GetPublishedAppIntegrationRequest{
 		IntegrationId: integrationId,
 	})
 }
@@ -442,7 +387,7 @@ func (a *PublishedAppIntegrationAPI) List(ctx context.Context, request ListPubli
 
 	getNextPage := func(ctx context.Context, req ListPublishedAppIntegrationsRequest) (*GetPublishedAppIntegrationsOutput, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.PublishedAppIntegrationService.List(ctx, req)
 	}
 	getItems := func(resp *GetPublishedAppIntegrationsOutput) []GetPublishedAppIntegrationOutput {
 		return resp.Apps
@@ -471,14 +416,6 @@ func (a *PublishedAppIntegrationAPI) List(ctx context.Context, request ListPubli
 func (a *PublishedAppIntegrationAPI) ListAll(ctx context.Context, request ListPublishedAppIntegrationsRequest) ([]GetPublishedAppIntegrationOutput, error) {
 	iterator := a.List(ctx, request)
 	return listing.ToSlice[GetPublishedAppIntegrationOutput](ctx, iterator)
-}
-
-// Updates Published OAuth App Integration.
-//
-// Updates an existing published OAuth App Integration. You can retrieve the
-// published OAuth app integration via :method:PublishedAppIntegration/get.
-func (a *PublishedAppIntegrationAPI) Update(ctx context.Context, request UpdatePublishedAppIntegration) error {
-	return a.impl.Update(ctx, request)
 }
 
 type ServicePrincipalSecretsInterface interface {
@@ -534,7 +471,7 @@ type ServicePrincipalSecretsInterface interface {
 
 func NewServicePrincipalSecrets(client *client.DatabricksClient) *ServicePrincipalSecretsAPI {
 	return &ServicePrincipalSecretsAPI{
-		impl: &servicePrincipalSecretsImpl{
+		ServicePrincipalSecretsService: &servicePrincipalSecretsImpl{
 			client: client,
 		},
 	}
@@ -556,42 +493,29 @@ func NewServicePrincipalSecrets(client *client.DatabricksClient) *ServicePrincip
 type ServicePrincipalSecretsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ServicePrincipalSecretsService)
-	impl ServicePrincipalSecretsService
+	ServicePrincipalSecretsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockServicePrincipalSecretsInterface instead.
 func (a *ServicePrincipalSecretsAPI) WithImpl(impl ServicePrincipalSecretsService) ServicePrincipalSecretsInterface {
-	a.impl = impl
-	return a
+	return &ServicePrincipalSecretsAPI{
+		ServicePrincipalSecretsService: impl,
+	}
 }
 
 // Impl returns low-level ServicePrincipalSecrets API implementation
 // Deprecated: use MockServicePrincipalSecretsInterface instead.
 func (a *ServicePrincipalSecretsAPI) Impl() ServicePrincipalSecretsService {
-	return a.impl
-}
-
-// Create service principal secret.
-//
-// Create a secret for the given service principal.
-func (a *ServicePrincipalSecretsAPI) Create(ctx context.Context, request CreateServicePrincipalSecretRequest) (*CreateServicePrincipalSecretResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete service principal secret.
-//
-// Delete a secret from the given service principal.
-func (a *ServicePrincipalSecretsAPI) Delete(ctx context.Context, request DeleteServicePrincipalSecretRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ServicePrincipalSecretsService
 }
 
 // Delete service principal secret.
 //
 // Delete a secret from the given service principal.
 func (a *ServicePrincipalSecretsAPI) DeleteByServicePrincipalIdAndSecretId(ctx context.Context, servicePrincipalId int64, secretId string) error {
-	return a.impl.Delete(ctx, DeleteServicePrincipalSecretRequest{
+	return a.ServicePrincipalSecretsService.Delete(ctx, DeleteServicePrincipalSecretRequest{
 		ServicePrincipalId: servicePrincipalId,
 		SecretId:           secretId,
 	})
@@ -608,7 +532,7 @@ func (a *ServicePrincipalSecretsAPI) List(ctx context.Context, request ListServi
 
 	getNextPage := func(ctx context.Context, req ListServicePrincipalSecretsRequest) (*ListServicePrincipalSecretsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ServicePrincipalSecretsService.List(ctx, req)
 	}
 	getItems := func(resp *ListServicePrincipalSecretsResponse) []SecretInfo {
 		return resp.Secrets
@@ -640,7 +564,7 @@ func (a *ServicePrincipalSecretsAPI) ListAll(ctx context.Context, request ListSe
 // only returns information about the secrets themselves and does not include
 // the secret values.
 func (a *ServicePrincipalSecretsAPI) ListByServicePrincipalId(ctx context.Context, servicePrincipalId int64) (*ListServicePrincipalSecretsResponse, error) {
-	return a.impl.List(ctx, ListServicePrincipalSecretsRequest{
+	return a.ServicePrincipalSecretsService.List(ctx, ListServicePrincipalSecretsRequest{
 		ServicePrincipalId: servicePrincipalId,
 	})
 }

--- a/service/oauth2/api.go
+++ b/service/oauth2/api.go
@@ -95,9 +95,8 @@ type CustomAppIntegrationAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCustomAppIntegrationInterface instead.
 func (a *CustomAppIntegrationAPI) WithImpl(impl CustomAppIntegrationService) CustomAppIntegrationInterface {
-	return &CustomAppIntegrationAPI{
-		CustomAppIntegrationService: impl,
-	}
+	a.CustomAppIntegrationService = impl
+	return a
 }
 
 // Impl returns low-level CustomAppIntegration API implementation
@@ -213,9 +212,8 @@ type OAuthPublishedAppsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockOAuthPublishedAppsInterface instead.
 func (a *OAuthPublishedAppsAPI) WithImpl(impl OAuthPublishedAppsService) OAuthPublishedAppsInterface {
-	return &OAuthPublishedAppsAPI{
-		OAuthPublishedAppsService: impl,
-	}
+	a.OAuthPublishedAppsService = impl
+	return a
 }
 
 // Impl returns low-level OAuthPublishedApps API implementation
@@ -347,9 +345,8 @@ type PublishedAppIntegrationAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPublishedAppIntegrationInterface instead.
 func (a *PublishedAppIntegrationAPI) WithImpl(impl PublishedAppIntegrationService) PublishedAppIntegrationInterface {
-	return &PublishedAppIntegrationAPI{
-		PublishedAppIntegrationService: impl,
-	}
+	a.PublishedAppIntegrationService = impl
+	return a
 }
 
 // Impl returns low-level PublishedAppIntegration API implementation
@@ -500,9 +497,8 @@ type ServicePrincipalSecretsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockServicePrincipalSecretsInterface instead.
 func (a *ServicePrincipalSecretsAPI) WithImpl(impl ServicePrincipalSecretsService) ServicePrincipalSecretsInterface {
-	return &ServicePrincipalSecretsAPI{
-		ServicePrincipalSecretsService: impl,
-	}
+	a.ServicePrincipalSecretsService = impl
+	return a
 }
 
 // Impl returns low-level ServicePrincipalSecrets API implementation

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -218,9 +218,8 @@ type PipelinesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPipelinesInterface instead.
 func (a *PipelinesAPI) WithImpl(impl PipelinesService) PipelinesInterface {
-	return &PipelinesAPI{
-		PipelinesService: impl,
-	}
+	a.PipelinesService = impl
+	return a
 }
 
 // Impl returns low-level Pipelines API implementation

--- a/service/pipelines/api.go
+++ b/service/pipelines/api.go
@@ -188,7 +188,7 @@ type PipelinesInterface interface {
 
 func NewPipelines(client *client.DatabricksClient) *PipelinesAPI {
 	return &PipelinesAPI{
-		impl: &pipelinesImpl{
+		PipelinesService: &pipelinesImpl{
 			client: client,
 		},
 	}
@@ -211,21 +211,22 @@ func NewPipelines(client *client.DatabricksClient) *PipelinesAPI {
 type PipelinesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PipelinesService)
-	impl PipelinesService
+	PipelinesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPipelinesInterface instead.
 func (a *PipelinesAPI) WithImpl(impl PipelinesService) PipelinesInterface {
-	a.impl = impl
-	return a
+	return &PipelinesAPI{
+		PipelinesService: impl,
+	}
 }
 
 // Impl returns low-level Pipelines API implementation
 // Deprecated: use MockPipelinesInterface instead.
 func (a *PipelinesAPI) Impl() PipelinesService {
-	return a.impl
+	return a.PipelinesService
 }
 
 // WaitGetPipelineIdle repeatedly calls [PipelinesAPI.Get] and waits to reach IDLE state
@@ -336,64 +337,29 @@ func (w *WaitGetPipelineRunning[R]) GetWithTimeout(timeout time.Duration) (*GetP
 	return w.Poll(timeout, w.callback)
 }
 
-// Create a pipeline.
-//
-// Creates a new data processing pipeline based on the requested configuration.
-// If successful, this method returns the ID of the new pipeline.
-func (a *PipelinesAPI) Create(ctx context.Context, request CreatePipeline) (*CreatePipelineResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a pipeline.
-//
-// Deletes a pipeline.
-func (a *PipelinesAPI) Delete(ctx context.Context, request DeletePipelineRequest) error {
-	return a.impl.Delete(ctx, request)
-}
-
 // Delete a pipeline.
 //
 // Deletes a pipeline.
 func (a *PipelinesAPI) DeleteByPipelineId(ctx context.Context, pipelineId string) error {
-	return a.impl.Delete(ctx, DeletePipelineRequest{
+	return a.PipelinesService.Delete(ctx, DeletePipelineRequest{
 		PipelineId: pipelineId,
 	})
-}
-
-// Get a pipeline.
-func (a *PipelinesAPI) Get(ctx context.Context, request GetPipelineRequest) (*GetPipelineResponse, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a pipeline.
 func (a *PipelinesAPI) GetByPipelineId(ctx context.Context, pipelineId string) (*GetPipelineResponse, error) {
-	return a.impl.Get(ctx, GetPipelineRequest{
+	return a.PipelinesService.Get(ctx, GetPipelineRequest{
 		PipelineId: pipelineId,
 	})
-}
-
-// Get pipeline permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *PipelinesAPI) GetPermissionLevels(ctx context.Context, request GetPipelinePermissionLevelsRequest) (*GetPipelinePermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
 }
 
 // Get pipeline permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *PipelinesAPI) GetPermissionLevelsByPipelineId(ctx context.Context, pipelineId string) (*GetPipelinePermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetPipelinePermissionLevelsRequest{
+	return a.PipelinesService.GetPermissionLevels(ctx, GetPipelinePermissionLevelsRequest{
 		PipelineId: pipelineId,
 	})
-}
-
-// Get pipeline permissions.
-//
-// Gets the permissions of a pipeline. Pipelines can inherit permissions from
-// their root object.
-func (a *PipelinesAPI) GetPermissions(ctx context.Context, request GetPipelinePermissionsRequest) (*PipelinePermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get pipeline permissions.
@@ -401,7 +367,7 @@ func (a *PipelinesAPI) GetPermissions(ctx context.Context, request GetPipelinePe
 // Gets the permissions of a pipeline. Pipelines can inherit permissions from
 // their root object.
 func (a *PipelinesAPI) GetPermissionsByPipelineId(ctx context.Context, pipelineId string) (*PipelinePermissions, error) {
-	return a.impl.GetPermissions(ctx, GetPipelinePermissionsRequest{
+	return a.PipelinesService.GetPermissions(ctx, GetPipelinePermissionsRequest{
 		PipelineId: pipelineId,
 	})
 }
@@ -409,15 +375,8 @@ func (a *PipelinesAPI) GetPermissionsByPipelineId(ctx context.Context, pipelineI
 // Get a pipeline update.
 //
 // Gets an update from an active pipeline.
-func (a *PipelinesAPI) GetUpdate(ctx context.Context, request GetUpdateRequest) (*GetUpdateResponse, error) {
-	return a.impl.GetUpdate(ctx, request)
-}
-
-// Get a pipeline update.
-//
-// Gets an update from an active pipeline.
 func (a *PipelinesAPI) GetUpdateByPipelineIdAndUpdateId(ctx context.Context, pipelineId string, updateId string) (*GetUpdateResponse, error) {
-	return a.impl.GetUpdate(ctx, GetUpdateRequest{
+	return a.PipelinesService.GetUpdate(ctx, GetUpdateRequest{
 		PipelineId: pipelineId,
 		UpdateId:   updateId,
 	})
@@ -432,7 +391,7 @@ func (a *PipelinesAPI) ListPipelineEvents(ctx context.Context, request ListPipel
 
 	getNextPage := func(ctx context.Context, req ListPipelineEventsRequest) (*ListPipelineEventsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListPipelineEvents(ctx, req)
+		return a.PipelinesService.ListPipelineEvents(ctx, req)
 	}
 	getItems := func(resp *ListPipelineEventsResponse) []PipelineEvent {
 		return resp.Events
@@ -467,7 +426,7 @@ func (a *PipelinesAPI) ListPipelineEventsAll(ctx context.Context, request ListPi
 //
 // Retrieves events for a pipeline.
 func (a *PipelinesAPI) ListPipelineEventsByPipelineId(ctx context.Context, pipelineId string) (*ListPipelineEventsResponse, error) {
-	return a.impl.ListPipelineEvents(ctx, ListPipelineEventsRequest{
+	return a.PipelinesService.ListPipelineEvents(ctx, ListPipelineEventsRequest{
 		PipelineId: pipelineId,
 	})
 }
@@ -481,7 +440,7 @@ func (a *PipelinesAPI) ListPipelines(ctx context.Context, request ListPipelinesR
 
 	getNextPage := func(ctx context.Context, req ListPipelinesRequest) (*ListPipelinesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListPipelines(ctx, req)
+		return a.PipelinesService.ListPipelines(ctx, req)
 	}
 	getItems := func(resp *ListPipelinesResponse) []PipelineStateInfo {
 		return resp.Statuses
@@ -568,34 +527,10 @@ func (a *PipelinesAPI) GetByName(ctx context.Context, name string) (*PipelineSta
 // List pipeline updates.
 //
 // List updates for an active pipeline.
-func (a *PipelinesAPI) ListUpdates(ctx context.Context, request ListUpdatesRequest) (*ListUpdatesResponse, error) {
-	return a.impl.ListUpdates(ctx, request)
-}
-
-// List pipeline updates.
-//
-// List updates for an active pipeline.
 func (a *PipelinesAPI) ListUpdatesByPipelineId(ctx context.Context, pipelineId string) (*ListUpdatesResponse, error) {
-	return a.impl.ListUpdates(ctx, ListUpdatesRequest{
+	return a.PipelinesService.ListUpdates(ctx, ListUpdatesRequest{
 		PipelineId: pipelineId,
 	})
-}
-
-// Set pipeline permissions.
-//
-// Sets permissions on a pipeline. Pipelines can inherit permissions from their
-// root object.
-func (a *PipelinesAPI) SetPermissions(ctx context.Context, request PipelinePermissionsRequest) (*PipelinePermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Start a pipeline.
-//
-// Starts a new update for the pipeline. If there is already an active update
-// for the pipeline, the request will fail and the active update will remain
-// running.
-func (a *PipelinesAPI) StartUpdate(ctx context.Context, request StartUpdate) (*StartUpdateResponse, error) {
-	return a.impl.StartUpdate(ctx, request)
 }
 
 // Stop a pipeline.
@@ -603,7 +538,7 @@ func (a *PipelinesAPI) StartUpdate(ctx context.Context, request StartUpdate) (*S
 // Stops the pipeline by canceling the active update. If there is no active
 // update for the pipeline, this request is a no-op.
 func (a *PipelinesAPI) Stop(ctx context.Context, stopRequest StopRequest) (*WaitGetPipelineIdle[struct{}], error) {
-	err := a.impl.Stop(ctx, stopRequest)
+	err := a.PipelinesService.Stop(ctx, stopRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -643,19 +578,4 @@ func (a *PipelinesAPI) StopAndWait(ctx context.Context, stopRequest StopRequest,
 		}
 	}
 	return wait.Get()
-}
-
-// Edit a pipeline.
-//
-// Updates a pipeline with the supplied configuration.
-func (a *PipelinesAPI) Update(ctx context.Context, request EditPipeline) error {
-	return a.impl.Update(ctx, request)
-}
-
-// Update pipeline permissions.
-//
-// Updates the permissions on a pipeline. Pipelines can inherit permissions from
-// their root object.
-func (a *PipelinesAPI) UpdatePermissions(ctx context.Context, request PipelinePermissionsRequest) (*PipelinePermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }

--- a/service/provisioning/api.go
+++ b/service/provisioning/api.go
@@ -94,7 +94,7 @@ type CredentialsInterface interface {
 
 func NewCredentials(client *client.DatabricksClient) *CredentialsAPI {
 	return &CredentialsAPI{
-		impl: &credentialsImpl{
+		CredentialsService: &credentialsImpl{
 			client: client,
 		},
 	}
@@ -108,50 +108,22 @@ func NewCredentials(client *client.DatabricksClient) *CredentialsAPI {
 type CredentialsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CredentialsService)
-	impl CredentialsService
+	CredentialsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCredentialsInterface instead.
 func (a *CredentialsAPI) WithImpl(impl CredentialsService) CredentialsInterface {
-	a.impl = impl
-	return a
+	return &CredentialsAPI{
+		CredentialsService: impl,
+	}
 }
 
 // Impl returns low-level Credentials API implementation
 // Deprecated: use MockCredentialsInterface instead.
 func (a *CredentialsAPI) Impl() CredentialsService {
-	return a.impl
-}
-
-// Create credential configuration.
-//
-// Creates a Databricks credential configuration that represents cloud
-// cross-account credentials for a specified account. Databricks uses this to
-// set up network infrastructure properly to host Databricks clusters. For your
-// AWS IAM role, you need to trust the External ID (the Databricks Account API
-// account ID) in the returned credential object, and configure the required
-// access policy.
-//
-// Save the response's `credentials_id` field, which is the ID for your new
-// credential configuration object.
-//
-// For information about how to create a new workspace with this API, see
-// [Create a new workspace using the Account API]
-//
-// [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
-func (a *CredentialsAPI) Create(ctx context.Context, request CreateCredentialRequest) (*Credential, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete credential configuration.
-//
-// Deletes a Databricks credential configuration object for an account, both
-// specified by ID. You cannot delete a credential that is associated with any
-// workspace.
-func (a *CredentialsAPI) Delete(ctx context.Context, request DeleteCredentialRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.CredentialsService
 }
 
 // Delete credential configuration.
@@ -160,17 +132,9 @@ func (a *CredentialsAPI) Delete(ctx context.Context, request DeleteCredentialReq
 // specified by ID. You cannot delete a credential that is associated with any
 // workspace.
 func (a *CredentialsAPI) DeleteByCredentialsId(ctx context.Context, credentialsId string) error {
-	return a.impl.Delete(ctx, DeleteCredentialRequest{
+	return a.CredentialsService.Delete(ctx, DeleteCredentialRequest{
 		CredentialsId: credentialsId,
 	})
-}
-
-// Get credential configuration.
-//
-// Gets a Databricks credential configuration object for an account, both
-// specified by ID.
-func (a *CredentialsAPI) Get(ctx context.Context, request GetCredentialRequest) (*Credential, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get credential configuration.
@@ -178,17 +142,9 @@ func (a *CredentialsAPI) Get(ctx context.Context, request GetCredentialRequest) 
 // Gets a Databricks credential configuration object for an account, both
 // specified by ID.
 func (a *CredentialsAPI) GetByCredentialsId(ctx context.Context, credentialsId string) (*Credential, error) {
-	return a.impl.Get(ctx, GetCredentialRequest{
+	return a.CredentialsService.Get(ctx, GetCredentialRequest{
 		CredentialsId: credentialsId,
 	})
-}
-
-// Get all credential configurations.
-//
-// Gets all Databricks credential configurations associated with an account
-// specified by ID.
-func (a *CredentialsAPI) List(ctx context.Context) ([]Credential, error) {
-	return a.impl.List(ctx)
 }
 
 // CredentialCredentialsNameToCredentialsIdMap calls [CredentialsAPI.List] and creates a map of results with [Credential].CredentialsName as key and [Credential].CredentialsId as value.
@@ -345,7 +301,7 @@ type EncryptionKeysInterface interface {
 
 func NewEncryptionKeys(client *client.DatabricksClient) *EncryptionKeysAPI {
 	return &EncryptionKeysAPI{
-		impl: &encryptionKeysImpl{
+		EncryptionKeysService: &encryptionKeysImpl{
 			client: client,
 		},
 	}
@@ -370,52 +326,22 @@ func NewEncryptionKeys(client *client.DatabricksClient) *EncryptionKeysAPI {
 type EncryptionKeysAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(EncryptionKeysService)
-	impl EncryptionKeysService
+	EncryptionKeysService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockEncryptionKeysInterface instead.
 func (a *EncryptionKeysAPI) WithImpl(impl EncryptionKeysService) EncryptionKeysInterface {
-	a.impl = impl
-	return a
+	return &EncryptionKeysAPI{
+		EncryptionKeysService: impl,
+	}
 }
 
 // Impl returns low-level EncryptionKeys API implementation
 // Deprecated: use MockEncryptionKeysInterface instead.
 func (a *EncryptionKeysAPI) Impl() EncryptionKeysService {
-	return a.impl
-}
-
-// Create encryption key configuration.
-//
-// Creates a customer-managed key configuration object for an account, specified
-// by ID. This operation uploads a reference to a customer-managed key to
-// Databricks. If the key is assigned as a workspace's customer-managed key for
-// managed services, Databricks uses the key to encrypt the workspaces notebooks
-// and secrets in the control plane, in addition to Databricks SQL queries and
-// query history. If it is specified as a workspace's customer-managed key for
-// workspace storage, the key encrypts the workspace's root S3 bucket (which
-// contains the workspace's root DBFS and system data) and, optionally, cluster
-// EBS volume data.
-//
-// **Important**: Customer-managed keys are supported only for some deployment
-// types, subscription types, and AWS regions that currently support creation of
-// Databricks workspaces.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform or on a select custom plan that allows multiple workspaces per
-// account.
-func (a *EncryptionKeysAPI) Create(ctx context.Context, request CreateCustomerManagedKeyRequest) (*CustomerManagedKey, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete encryption key configuration.
-//
-// Deletes a customer-managed key configuration object for an account. You
-// cannot delete a configuration that is associated with a running workspace.
-func (a *EncryptionKeysAPI) Delete(ctx context.Context, request DeleteEncryptionKeyRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.EncryptionKeysService
 }
 
 // Delete encryption key configuration.
@@ -423,30 +349,9 @@ func (a *EncryptionKeysAPI) Delete(ctx context.Context, request DeleteEncryption
 // Deletes a customer-managed key configuration object for an account. You
 // cannot delete a configuration that is associated with a running workspace.
 func (a *EncryptionKeysAPI) DeleteByCustomerManagedKeyId(ctx context.Context, customerManagedKeyId string) error {
-	return a.impl.Delete(ctx, DeleteEncryptionKeyRequest{
+	return a.EncryptionKeysService.Delete(ctx, DeleteEncryptionKeyRequest{
 		CustomerManagedKeyId: customerManagedKeyId,
 	})
-}
-
-// Get encryption key configuration.
-//
-// Gets a customer-managed key configuration object for an account, specified by
-// ID. This operation uploads a reference to a customer-managed key to
-// Databricks. If assigned as a workspace's customer-managed key for managed
-// services, Databricks uses the key to encrypt the workspaces notebooks and
-// secrets in the control plane, in addition to Databricks SQL queries and query
-// history. If it is specified as a workspace's customer-managed key for
-// storage, the key encrypts the workspace's root S3 bucket (which contains the
-// workspace's root DBFS and system data) and, optionally, cluster EBS volume
-// data.
-//
-// **Important**: Customer-managed keys are supported only for some deployment
-// types, subscription types, and AWS regions.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform.",
-func (a *EncryptionKeysAPI) Get(ctx context.Context, request GetEncryptionKeyRequest) (*CustomerManagedKey, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get encryption key configuration.
@@ -467,28 +372,9 @@ func (a *EncryptionKeysAPI) Get(ctx context.Context, request GetEncryptionKeyReq
 // This operation is available only if your account is on the E2 version of the
 // platform.",
 func (a *EncryptionKeysAPI) GetByCustomerManagedKeyId(ctx context.Context, customerManagedKeyId string) (*CustomerManagedKey, error) {
-	return a.impl.Get(ctx, GetEncryptionKeyRequest{
+	return a.EncryptionKeysService.Get(ctx, GetEncryptionKeyRequest{
 		CustomerManagedKeyId: customerManagedKeyId,
 	})
-}
-
-// Get all encryption key configurations.
-//
-// Gets all customer-managed key configuration objects for an account. If the
-// key is specified as a workspace's managed services customer-managed key,
-// Databricks uses the key to encrypt the workspace's notebooks and secrets in
-// the control plane, in addition to Databricks SQL queries and query history.
-// If the key is specified as a workspace's storage customer-managed key, the
-// key is used to encrypt the workspace's root S3 bucket and optionally can
-// encrypt cluster EBS volumes data in the data plane.
-//
-// **Important**: Customer-managed keys are supported only for some deployment
-// types, subscription types, and AWS regions.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform.
-func (a *EncryptionKeysAPI) List(ctx context.Context) ([]CustomerManagedKey, error) {
-	return a.impl.List(ctx)
 }
 
 type NetworksInterface interface {
@@ -570,7 +456,7 @@ type NetworksInterface interface {
 
 func NewNetworks(client *client.DatabricksClient) *NetworksAPI {
 	return &NetworksAPI{
-		impl: &networksImpl{
+		NetworksService: &networksImpl{
 			client: client,
 		},
 	}
@@ -582,42 +468,22 @@ func NewNetworks(client *client.DatabricksClient) *NetworksAPI {
 type NetworksAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(NetworksService)
-	impl NetworksService
+	NetworksService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockNetworksInterface instead.
 func (a *NetworksAPI) WithImpl(impl NetworksService) NetworksInterface {
-	a.impl = impl
-	return a
+	return &NetworksAPI{
+		NetworksService: impl,
+	}
 }
 
 // Impl returns low-level Networks API implementation
 // Deprecated: use MockNetworksInterface instead.
 func (a *NetworksAPI) Impl() NetworksService {
-	return a.impl
-}
-
-// Create network configuration.
-//
-// Creates a Databricks network configuration that represents an VPC and its
-// resources. The VPC will be used for new Databricks clusters. This requires a
-// pre-existing VPC and subnets.
-func (a *NetworksAPI) Create(ctx context.Context, request CreateNetworkRequest) (*Network, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a network configuration.
-//
-// Deletes a Databricks network configuration, which represents a cloud VPC and
-// its resources. You cannot delete a network that is associated with a
-// workspace.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform.
-func (a *NetworksAPI) Delete(ctx context.Context, request DeleteNetworkRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.NetworksService
 }
 
 // Delete a network configuration.
@@ -629,17 +495,9 @@ func (a *NetworksAPI) Delete(ctx context.Context, request DeleteNetworkRequest) 
 // This operation is available only if your account is on the E2 version of the
 // platform.
 func (a *NetworksAPI) DeleteByNetworkId(ctx context.Context, networkId string) error {
-	return a.impl.Delete(ctx, DeleteNetworkRequest{
+	return a.NetworksService.Delete(ctx, DeleteNetworkRequest{
 		NetworkId: networkId,
 	})
-}
-
-// Get a network configuration.
-//
-// Gets a Databricks network configuration, which represents a cloud VPC and its
-// resources.
-func (a *NetworksAPI) Get(ctx context.Context, request GetNetworkRequest) (*Network, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a network configuration.
@@ -647,20 +505,9 @@ func (a *NetworksAPI) Get(ctx context.Context, request GetNetworkRequest) (*Netw
 // Gets a Databricks network configuration, which represents a cloud VPC and its
 // resources.
 func (a *NetworksAPI) GetByNetworkId(ctx context.Context, networkId string) (*Network, error) {
-	return a.impl.Get(ctx, GetNetworkRequest{
+	return a.NetworksService.Get(ctx, GetNetworkRequest{
 		NetworkId: networkId,
 	})
-}
-
-// Get all network configurations.
-//
-// Gets a list of all Databricks network configurations for an account,
-// specified by ID.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform.
-func (a *NetworksAPI) List(ctx context.Context) ([]Network, error) {
-	return a.impl.List(ctx)
 }
 
 // NetworkNetworkNameToNetworkIdMap calls [NetworksAPI.List] and creates a map of results with [Network].NetworkName as key and [Network].NetworkId as value.
@@ -845,7 +692,7 @@ type PrivateAccessInterface interface {
 
 func NewPrivateAccess(client *client.DatabricksClient) *PrivateAccessAPI {
 	return &PrivateAccessAPI{
-		impl: &privateAccessImpl{
+		PrivateAccessService: &privateAccessImpl{
 			client: client,
 		},
 	}
@@ -855,56 +702,22 @@ func NewPrivateAccess(client *client.DatabricksClient) *PrivateAccessAPI {
 type PrivateAccessAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PrivateAccessService)
-	impl PrivateAccessService
+	PrivateAccessService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPrivateAccessInterface instead.
 func (a *PrivateAccessAPI) WithImpl(impl PrivateAccessService) PrivateAccessInterface {
-	a.impl = impl
-	return a
+	return &PrivateAccessAPI{
+		PrivateAccessService: impl,
+	}
 }
 
 // Impl returns low-level PrivateAccess API implementation
 // Deprecated: use MockPrivateAccessInterface instead.
 func (a *PrivateAccessAPI) Impl() PrivateAccessService {
-	return a.impl
-}
-
-// Create private access settings.
-//
-// Creates a private access settings object, which specifies how your workspace
-// is accessed over [AWS PrivateLink]. To use AWS PrivateLink, a workspace must
-// have a private access settings object referenced by ID in the workspace's
-// `private_access_settings_id` property.
-//
-// You can share one private access settings with multiple workspaces in a
-// single account. However, private access settings are specific to AWS regions,
-// so only workspaces in the same AWS region can use a given private access
-// settings object.
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-func (a *PrivateAccessAPI) Create(ctx context.Context, request UpsertPrivateAccessSettingsRequest) (*PrivateAccessSettings, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a private access settings object.
-//
-// Deletes a private access settings object, which determines how your workspace
-// is accessed over [AWS PrivateLink].
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].",
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-func (a *PrivateAccessAPI) Delete(ctx context.Context, request DeletePrivateAccesRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.PrivateAccessService
 }
 
 // Delete a private access settings object.
@@ -918,23 +731,9 @@ func (a *PrivateAccessAPI) Delete(ctx context.Context, request DeletePrivateAcce
 // [AWS PrivateLink]: https://aws.amazon.com/privatelink
 // [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
 func (a *PrivateAccessAPI) DeleteByPrivateAccessSettingsId(ctx context.Context, privateAccessSettingsId string) error {
-	return a.impl.Delete(ctx, DeletePrivateAccesRequest{
+	return a.PrivateAccessService.Delete(ctx, DeletePrivateAccesRequest{
 		PrivateAccessSettingsId: privateAccessSettingsId,
 	})
-}
-
-// Get a private access settings object.
-//
-// Gets a private access settings object, which specifies how your workspace is
-// accessed over [AWS PrivateLink].
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].",
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-func (a *PrivateAccessAPI) Get(ctx context.Context, request GetPrivateAccesRequest) (*PrivateAccessSettings, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a private access settings object.
@@ -948,17 +747,9 @@ func (a *PrivateAccessAPI) Get(ctx context.Context, request GetPrivateAccesReque
 // [AWS PrivateLink]: https://aws.amazon.com/privatelink
 // [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
 func (a *PrivateAccessAPI) GetByPrivateAccessSettingsId(ctx context.Context, privateAccessSettingsId string) (*PrivateAccessSettings, error) {
-	return a.impl.Get(ctx, GetPrivateAccesRequest{
+	return a.PrivateAccessService.Get(ctx, GetPrivateAccesRequest{
 		PrivateAccessSettingsId: privateAccessSettingsId,
 	})
-}
-
-// Get all private access settings objects.
-//
-// Gets a list of all private access settings objects for an account, specified
-// by ID.
-func (a *PrivateAccessAPI) List(ctx context.Context) ([]PrivateAccessSettings, error) {
-	return a.impl.List(ctx)
 }
 
 // PrivateAccessSettingsPrivateAccessSettingsNameToPrivateAccessSettingsIdMap calls [PrivateAccessAPI.List] and creates a map of results with [PrivateAccessSettings].PrivateAccessSettingsName as key and [PrivateAccessSettings].PrivateAccessSettingsId as value.
@@ -1012,33 +803,6 @@ func (a *PrivateAccessAPI) GetByPrivateAccessSettingsName(ctx context.Context, n
 		return nil, fmt.Errorf("there are %d instances of PrivateAccessSettings named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Replace private access settings.
-//
-// Updates an existing private access settings object, which specifies how your
-// workspace is accessed over [AWS PrivateLink]. To use AWS PrivateLink, a
-// workspace must have a private access settings object referenced by ID in the
-// workspace's `private_access_settings_id` property.
-//
-// This operation completely overwrites your existing private access settings
-// object attached to your workspaces. All workspaces attached to the private
-// access settings are affected by any change. If `public_access_enabled`,
-// `private_access_level`, or `allowed_vpc_endpoint_ids` are updated, effects of
-// these changes might take several minutes to propagate to the workspace API.
-//
-// You can share one private access settings object with multiple workspaces in
-// a single account. However, private access settings are specific to AWS
-// regions, so only workspaces in the same AWS region can use a given private
-// access settings object.
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-func (a *PrivateAccessAPI) Replace(ctx context.Context, request UpsertPrivateAccessSettingsRequest) error {
-	return a.impl.Replace(ctx, request)
 }
 
 type StorageInterface interface {
@@ -1114,7 +878,7 @@ type StorageInterface interface {
 
 func NewStorage(client *client.DatabricksClient) *StorageAPI {
 	return &StorageAPI{
-		impl: &storageImpl{
+		StorageService: &storageImpl{
 			client: client,
 		},
 	}
@@ -1129,45 +893,22 @@ func NewStorage(client *client.DatabricksClient) *StorageAPI {
 type StorageAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(StorageService)
-	impl StorageService
+	StorageService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockStorageInterface instead.
 func (a *StorageAPI) WithImpl(impl StorageService) StorageInterface {
-	a.impl = impl
-	return a
+	return &StorageAPI{
+		StorageService: impl,
+	}
 }
 
 // Impl returns low-level Storage API implementation
 // Deprecated: use MockStorageInterface instead.
 func (a *StorageAPI) Impl() StorageService {
-	return a.impl
-}
-
-// Create new storage configuration.
-//
-// Creates new storage configuration for an account, specified by ID. Uploads a
-// storage configuration object that represents the root AWS S3 bucket in your
-// account. Databricks stores related workspace assets including DBFS, cluster
-// logs, and job results. For the AWS S3 bucket, you need to configure the
-// required bucket policy.
-//
-// For information about how to create a new workspace with this API, see
-// [Create a new workspace using the Account API]
-//
-// [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
-func (a *StorageAPI) Create(ctx context.Context, request CreateStorageConfigurationRequest) (*StorageConfiguration, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete storage configuration.
-//
-// Deletes a Databricks storage configuration. You cannot delete a storage
-// configuration that is associated with any workspace.
-func (a *StorageAPI) Delete(ctx context.Context, request DeleteStorageRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.StorageService
 }
 
 // Delete storage configuration.
@@ -1175,33 +916,18 @@ func (a *StorageAPI) Delete(ctx context.Context, request DeleteStorageRequest) e
 // Deletes a Databricks storage configuration. You cannot delete a storage
 // configuration that is associated with any workspace.
 func (a *StorageAPI) DeleteByStorageConfigurationId(ctx context.Context, storageConfigurationId string) error {
-	return a.impl.Delete(ctx, DeleteStorageRequest{
+	return a.StorageService.Delete(ctx, DeleteStorageRequest{
 		StorageConfigurationId: storageConfigurationId,
 	})
-}
-
-// Get storage configuration.
-//
-// Gets a Databricks storage configuration for an account, both specified by ID.
-func (a *StorageAPI) Get(ctx context.Context, request GetStorageRequest) (*StorageConfiguration, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get storage configuration.
 //
 // Gets a Databricks storage configuration for an account, both specified by ID.
 func (a *StorageAPI) GetByStorageConfigurationId(ctx context.Context, storageConfigurationId string) (*StorageConfiguration, error) {
-	return a.impl.Get(ctx, GetStorageRequest{
+	return a.StorageService.Get(ctx, GetStorageRequest{
 		StorageConfigurationId: storageConfigurationId,
 	})
-}
-
-// Get all storage configurations.
-//
-// Gets a list of all Databricks storage configurations for your account,
-// specified by ID.
-func (a *StorageAPI) List(ctx context.Context) ([]StorageConfiguration, error) {
-	return a.impl.List(ctx)
 }
 
 // StorageConfigurationStorageConfigurationNameToStorageConfigurationIdMap calls [StorageAPI.List] and creates a map of results with [StorageConfiguration].StorageConfigurationName as key and [StorageConfiguration].StorageConfigurationId as value.
@@ -1360,7 +1086,7 @@ type VpcEndpointsInterface interface {
 
 func NewVpcEndpoints(client *client.DatabricksClient) *VpcEndpointsAPI {
 	return &VpcEndpointsAPI{
-		impl: &vpcEndpointsImpl{
+		VpcEndpointsService: &vpcEndpointsImpl{
 			client: client,
 		},
 	}
@@ -1370,56 +1096,22 @@ func NewVpcEndpoints(client *client.DatabricksClient) *VpcEndpointsAPI {
 type VpcEndpointsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(VpcEndpointsService)
-	impl VpcEndpointsService
+	VpcEndpointsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVpcEndpointsInterface instead.
 func (a *VpcEndpointsAPI) WithImpl(impl VpcEndpointsService) VpcEndpointsInterface {
-	a.impl = impl
-	return a
+	return &VpcEndpointsAPI{
+		VpcEndpointsService: impl,
+	}
 }
 
 // Impl returns low-level VpcEndpoints API implementation
 // Deprecated: use MockVpcEndpointsInterface instead.
 func (a *VpcEndpointsAPI) Impl() VpcEndpointsService {
-	return a.impl
-}
-
-// Create VPC endpoint configuration.
-//
-// Creates a VPC endpoint configuration, which represents a [VPC endpoint]
-// object in AWS used to communicate privately with Databricks over [AWS
-// PrivateLink].
-//
-// After you create the VPC endpoint configuration, the Databricks [endpoint
-// service] automatically accepts the VPC endpoint.
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-// [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html
-// [endpoint service]: https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html
-func (a *VpcEndpointsAPI) Create(ctx context.Context, request CreateVpcEndpointRequest) (*VpcEndpoint, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete VPC endpoint configuration.
-//
-// Deletes a VPC endpoint configuration, which represents an [AWS VPC endpoint]
-// that can communicate privately with Databricks over [AWS PrivateLink].
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [AWS VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-func (a *VpcEndpointsAPI) Delete(ctx context.Context, request DeleteVpcEndpointRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.VpcEndpointsService
 }
 
 // Delete VPC endpoint configuration.
@@ -1434,20 +1126,9 @@ func (a *VpcEndpointsAPI) Delete(ctx context.Context, request DeleteVpcEndpointR
 // [AWS VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
 // [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
 func (a *VpcEndpointsAPI) DeleteByVpcEndpointId(ctx context.Context, vpcEndpointId string) error {
-	return a.impl.Delete(ctx, DeleteVpcEndpointRequest{
+	return a.VpcEndpointsService.Delete(ctx, DeleteVpcEndpointRequest{
 		VpcEndpointId: vpcEndpointId,
 	})
-}
-
-// Get a VPC endpoint configuration.
-//
-// Gets a VPC endpoint configuration, which represents a [VPC endpoint] object
-// in AWS used to communicate privately with Databricks over [AWS PrivateLink].
-//
-// [AWS PrivateLink]: https://aws.amazon.com/privatelink
-// [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
-func (a *VpcEndpointsAPI) Get(ctx context.Context, request GetVpcEndpointRequest) (*VpcEndpoint, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a VPC endpoint configuration.
@@ -1458,21 +1139,9 @@ func (a *VpcEndpointsAPI) Get(ctx context.Context, request GetVpcEndpointRequest
 // [AWS PrivateLink]: https://aws.amazon.com/privatelink
 // [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
 func (a *VpcEndpointsAPI) GetByVpcEndpointId(ctx context.Context, vpcEndpointId string) (*VpcEndpoint, error) {
-	return a.impl.Get(ctx, GetVpcEndpointRequest{
+	return a.VpcEndpointsService.Get(ctx, GetVpcEndpointRequest{
 		VpcEndpointId: vpcEndpointId,
 	})
-}
-
-// Get all VPC endpoint configurations.
-//
-// Gets a list of all VPC endpoints for an account, specified by ID.
-//
-// Before configuring PrivateLink, read the [Databricks article about
-// PrivateLink].
-//
-// [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
-func (a *VpcEndpointsAPI) List(ctx context.Context) ([]VpcEndpoint, error) {
-	return a.impl.List(ctx)
 }
 
 // VpcEndpointVpcEndpointNameToVpcEndpointIdMap calls [VpcEndpointsAPI.List] and creates a map of results with [VpcEndpoint].VpcEndpointName as key and [VpcEndpoint].VpcEndpointId as value.
@@ -1785,7 +1454,7 @@ type WorkspacesInterface interface {
 
 func NewWorkspaces(client *client.DatabricksClient) *WorkspacesAPI {
 	return &WorkspacesAPI{
-		impl: &workspacesImpl{
+		WorkspacesService: &workspacesImpl{
 			client: client,
 		},
 	}
@@ -1803,21 +1472,22 @@ func NewWorkspaces(client *client.DatabricksClient) *WorkspacesAPI {
 type WorkspacesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(WorkspacesService)
-	impl WorkspacesService
+	WorkspacesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspacesInterface instead.
 func (a *WorkspacesAPI) WithImpl(impl WorkspacesService) WorkspacesInterface {
-	a.impl = impl
-	return a
+	return &WorkspacesAPI{
+		WorkspacesService: impl,
+	}
 }
 
 // Impl returns low-level Workspaces API implementation
 // Deprecated: use MockWorkspacesInterface instead.
 func (a *WorkspacesAPI) Impl() WorkspacesService {
-	return a.impl
+	return a.WorkspacesService
 }
 
 // WaitGetWorkspaceRunning repeatedly calls [WorkspacesAPI.Get] and waits to reach RUNNING state
@@ -1886,7 +1556,7 @@ func (w *WaitGetWorkspaceRunning[R]) GetWithTimeout(timeout time.Duration) (*Wor
 // repeated `GET` requests with the workspace ID and check its status. The
 // workspace becomes available when the status changes to `RUNNING`.
 func (a *WorkspacesAPI) Create(ctx context.Context, createWorkspaceRequest CreateWorkspaceRequest) (*WaitGetWorkspaceRunning[Workspace], error) {
-	workspace, err := a.impl.Create(ctx, createWorkspaceRequest)
+	workspace, err := a.WorkspacesService.Create(ctx, createWorkspaceRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -1938,44 +1608,10 @@ func (a *WorkspacesAPI) CreateAndWait(ctx context.Context, createWorkspaceReques
 // This operation is available only if your account is on the E2 version of the
 // platform or on a select custom plan that allows multiple workspaces per
 // account.
-func (a *WorkspacesAPI) Delete(ctx context.Context, request DeleteWorkspaceRequest) error {
-	return a.impl.Delete(ctx, request)
-}
-
-// Delete a workspace.
-//
-// Terminates and deletes a Databricks workspace. From an API perspective,
-// deletion is immediate. However, it might take a few minutes for all
-// workspaces resources to be deleted, depending on the size and number of
-// workspace resources.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform or on a select custom plan that allows multiple workspaces per
-// account.
 func (a *WorkspacesAPI) DeleteByWorkspaceId(ctx context.Context, workspaceId int64) error {
-	return a.impl.Delete(ctx, DeleteWorkspaceRequest{
+	return a.WorkspacesService.Delete(ctx, DeleteWorkspaceRequest{
 		WorkspaceId: workspaceId,
 	})
-}
-
-// Get a workspace.
-//
-// Gets information including status for a Databricks workspace, specified by
-// ID. In the response, the `workspace_status` field indicates the current
-// status. After initial workspace creation (which is asynchronous), make
-// repeated `GET` requests with the workspace ID and check its status. The
-// workspace becomes available when the status changes to `RUNNING`.
-//
-// For information about how to create a new workspace with this API **including
-// error handling**, see [Create a new workspace using the Account API].
-//
-// This operation is available only if your account is on the E2 version of the
-// platform or on a select custom plan that allows multiple workspaces per
-// account.
-//
-// [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
-func (a *WorkspacesAPI) Get(ctx context.Context, request GetWorkspaceRequest) (*Workspace, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a workspace.
@@ -1995,20 +1631,9 @@ func (a *WorkspacesAPI) Get(ctx context.Context, request GetWorkspaceRequest) (*
 //
 // [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
 func (a *WorkspacesAPI) GetByWorkspaceId(ctx context.Context, workspaceId int64) (*Workspace, error) {
-	return a.impl.Get(ctx, GetWorkspaceRequest{
+	return a.WorkspacesService.Get(ctx, GetWorkspaceRequest{
 		WorkspaceId: workspaceId,
 	})
-}
-
-// Get all workspaces.
-//
-// Gets a list of all workspaces associated with an account, specified by ID.
-//
-// This operation is available only if your account is on the E2 version of the
-// platform or on a select custom plan that allows multiple workspaces per
-// account.
-func (a *WorkspacesAPI) List(ctx context.Context) ([]Workspace, error) {
-	return a.impl.List(ctx)
 }
 
 // WorkspaceWorkspaceNameToWorkspaceIdMap calls [WorkspacesAPI.List] and creates a map of results with [Workspace].WorkspaceName as key and [Workspace].WorkspaceId as value.
@@ -2187,7 +1812,7 @@ func (a *WorkspacesAPI) GetByWorkspaceName(ctx context.Context, name string) (*W
 // [Account Console]: https://docs.databricks.com/administration-guide/account-settings-e2/account-console-e2.html
 // [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
 func (a *WorkspacesAPI) Update(ctx context.Context, updateWorkspaceRequest UpdateWorkspaceRequest) (*WaitGetWorkspaceRunning[struct{}], error) {
-	err := a.impl.Update(ctx, updateWorkspaceRequest)
+	err := a.WorkspacesService.Update(ctx, updateWorkspaceRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/service/provisioning/api.go
+++ b/service/provisioning/api.go
@@ -115,9 +115,8 @@ type CredentialsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCredentialsInterface instead.
 func (a *CredentialsAPI) WithImpl(impl CredentialsService) CredentialsInterface {
-	return &CredentialsAPI{
-		CredentialsService: impl,
-	}
+	a.CredentialsService = impl
+	return a
 }
 
 // Impl returns low-level Credentials API implementation
@@ -333,9 +332,8 @@ type EncryptionKeysAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockEncryptionKeysInterface instead.
 func (a *EncryptionKeysAPI) WithImpl(impl EncryptionKeysService) EncryptionKeysInterface {
-	return &EncryptionKeysAPI{
-		EncryptionKeysService: impl,
-	}
+	a.EncryptionKeysService = impl
+	return a
 }
 
 // Impl returns low-level EncryptionKeys API implementation
@@ -475,9 +473,8 @@ type NetworksAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockNetworksInterface instead.
 func (a *NetworksAPI) WithImpl(impl NetworksService) NetworksInterface {
-	return &NetworksAPI{
-		NetworksService: impl,
-	}
+	a.NetworksService = impl
+	return a
 }
 
 // Impl returns low-level Networks API implementation
@@ -709,9 +706,8 @@ type PrivateAccessAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPrivateAccessInterface instead.
 func (a *PrivateAccessAPI) WithImpl(impl PrivateAccessService) PrivateAccessInterface {
-	return &PrivateAccessAPI{
-		PrivateAccessService: impl,
-	}
+	a.PrivateAccessService = impl
+	return a
 }
 
 // Impl returns low-level PrivateAccess API implementation
@@ -900,9 +896,8 @@ type StorageAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockStorageInterface instead.
 func (a *StorageAPI) WithImpl(impl StorageService) StorageInterface {
-	return &StorageAPI{
-		StorageService: impl,
-	}
+	a.StorageService = impl
+	return a
 }
 
 // Impl returns low-level Storage API implementation
@@ -1103,9 +1098,8 @@ type VpcEndpointsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVpcEndpointsInterface instead.
 func (a *VpcEndpointsAPI) WithImpl(impl VpcEndpointsService) VpcEndpointsInterface {
-	return &VpcEndpointsAPI{
-		VpcEndpointsService: impl,
-	}
+	a.VpcEndpointsService = impl
+	return a
 }
 
 // Impl returns low-level VpcEndpoints API implementation
@@ -1479,9 +1473,8 @@ type WorkspacesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspacesInterface instead.
 func (a *WorkspacesAPI) WithImpl(impl WorkspacesService) WorkspacesInterface {
-	return &WorkspacesAPI{
-		WorkspacesService: impl,
-	}
+	a.WorkspacesService = impl
+	return a
 }
 
 // Impl returns low-level Workspaces API implementation

--- a/service/serving/api.go
+++ b/service/serving/api.go
@@ -171,9 +171,8 @@ type AppsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAppsInterface instead.
 func (a *AppsAPI) WithImpl(impl AppsService) AppsInterface {
-	return &AppsAPI{
-		AppsService: impl,
-	}
+	a.AppsService = impl
+	return a
 }
 
 // Impl returns low-level Apps API implementation
@@ -710,9 +709,8 @@ type ServingEndpointsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockServingEndpointsInterface instead.
 func (a *ServingEndpointsAPI) WithImpl(impl ServingEndpointsService) ServingEndpointsInterface {
-	return &ServingEndpointsAPI{
-		ServingEndpointsService: impl,
-	}
+	a.ServingEndpointsService = impl
+	return a
 }
 
 // Impl returns low-level ServingEndpoints API implementation
@@ -1012,9 +1010,8 @@ type ServingEndpointsDataPlaneAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockServingEndpointsDataPlaneInterface instead.
 func (a *ServingEndpointsDataPlaneAPI) WithImpl(impl ServingEndpointsDataPlaneService) ServingEndpointsDataPlaneInterface {
-	return &ServingEndpointsDataPlaneAPI{
-		ServingEndpointsDataPlaneService: impl,
-	}
+	a.ServingEndpointsDataPlaneService = impl
+	return a
 }
 
 // Impl returns low-level ServingEndpointsDataPlane API implementation

--- a/service/settings/api.go
+++ b/service/settings/api.go
@@ -128,7 +128,7 @@ type AccountIpAccessListsInterface interface {
 
 func NewAccountIpAccessLists(client *client.DatabricksClient) *AccountIpAccessListsAPI {
 	return &AccountIpAccessListsAPI{
-		impl: &accountIpAccessListsImpl{
+		AccountIpAccessListsService: &accountIpAccessListsImpl{
 			client: client,
 		},
 	}
@@ -159,55 +159,29 @@ func NewAccountIpAccessLists(client *client.DatabricksClient) *AccountIpAccessLi
 type AccountIpAccessListsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountIpAccessListsService)
-	impl AccountIpAccessListsService
+	AccountIpAccessListsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountIpAccessListsInterface instead.
 func (a *AccountIpAccessListsAPI) WithImpl(impl AccountIpAccessListsService) AccountIpAccessListsInterface {
-	a.impl = impl
-	return a
+	return &AccountIpAccessListsAPI{
+		AccountIpAccessListsService: impl,
+	}
 }
 
 // Impl returns low-level AccountIpAccessLists API implementation
 // Deprecated: use MockAccountIpAccessListsInterface instead.
 func (a *AccountIpAccessListsAPI) Impl() AccountIpAccessListsService {
-	return a.impl
-}
-
-// Create access list.
-//
-// Creates an IP access list for the account.
-//
-// A list can be an allow list or a block list. See the top of this file for a
-// description of how the server treats allow lists and block lists at runtime.
-//
-// When creating or updating an IP access list:
-//
-// * For all allow lists and block lists combined, the API supports a maximum of
-// 1000 IP/CIDR values, where one CIDR counts as a single value. Attempts to
-// exceed that number return error 400 with `error_code` value `QUOTA_EXCEEDED`.
-// * If the new list would block the calling user's current IP, error 400 is
-// returned with `error_code` value `INVALID_STATE`.
-//
-// It can take a few minutes for the changes to take effect.
-func (a *AccountIpAccessListsAPI) Create(ctx context.Context, request CreateIpAccessList) (*CreateIpAccessListResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete access list.
-//
-// Deletes an IP access list, specified by its list ID.
-func (a *AccountIpAccessListsAPI) Delete(ctx context.Context, request DeleteAccountIpAccessListRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AccountIpAccessListsService
 }
 
 // Delete access list.
 //
 // Deletes an IP access list, specified by its list ID.
 func (a *AccountIpAccessListsAPI) DeleteByIpAccessListId(ctx context.Context, ipAccessListId string) error {
-	return a.impl.Delete(ctx, DeleteAccountIpAccessListRequest{
+	return a.AccountIpAccessListsService.Delete(ctx, DeleteAccountIpAccessListRequest{
 		IpAccessListId: ipAccessListId,
 	})
 }
@@ -215,15 +189,8 @@ func (a *AccountIpAccessListsAPI) DeleteByIpAccessListId(ctx context.Context, ip
 // Get IP access list.
 //
 // Gets an IP access list, specified by its list ID.
-func (a *AccountIpAccessListsAPI) Get(ctx context.Context, request GetAccountIpAccessListRequest) (*GetIpAccessListResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get IP access list.
-//
-// Gets an IP access list, specified by its list ID.
 func (a *AccountIpAccessListsAPI) GetByIpAccessListId(ctx context.Context, ipAccessListId string) (*GetIpAccessListResponse, error) {
-	return a.impl.Get(ctx, GetAccountIpAccessListRequest{
+	return a.AccountIpAccessListsService.Get(ctx, GetAccountIpAccessListRequest{
 		IpAccessListId: ipAccessListId,
 	})
 }
@@ -238,7 +205,7 @@ func (a *AccountIpAccessListsAPI) List(ctx context.Context) listing.Iterator[IpA
 
 	getNextPage := func(ctx context.Context, req struct{}) (*GetIpAccessListsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.AccountIpAccessListsService.List(ctx)
 	}
 	getItems := func(resp *GetIpAccessListsResponse) []IpAccessListInfo {
 		return resp.IpAccessLists
@@ -315,43 +282,6 @@ func (a *AccountIpAccessListsAPI) GetByLabel(ctx context.Context, name string) (
 	return &alternatives[0], nil
 }
 
-// Replace access list.
-//
-// Replaces an IP access list, specified by its ID.
-//
-// A list can include allow lists and block lists. See the top of this file for
-// a description of how the server treats allow lists and block lists at run
-// time. When replacing an IP access list: * For all allow lists and block lists
-// combined, the API supports a maximum of 1000 IP/CIDR values, where one CIDR
-// counts as a single value. Attempts to exceed that number return error 400
-// with `error_code` value `QUOTA_EXCEEDED`. * If the resulting list would block
-// the calling user's current IP, error 400 is returned with `error_code` value
-// `INVALID_STATE`. It can take a few minutes for the changes to take effect.
-func (a *AccountIpAccessListsAPI) Replace(ctx context.Context, request ReplaceIpAccessList) error {
-	return a.impl.Replace(ctx, request)
-}
-
-// Update access list.
-//
-// Updates an existing IP access list, specified by its ID.
-//
-// A list can include allow lists and block lists. See the top of this file for
-// a description of how the server treats allow lists and block lists at run
-// time.
-//
-// When updating an IP access list:
-//
-// * For all allow lists and block lists combined, the API supports a maximum of
-// 1000 IP/CIDR values, where one CIDR counts as a single value. Attempts to
-// exceed that number return error 400 with `error_code` value `QUOTA_EXCEEDED`.
-// * If the updated list would block the calling user's current IP, error 400 is
-// returned with `error_code` value `INVALID_STATE`.
-//
-// It can take a few minutes for the changes to take effect.
-func (a *AccountIpAccessListsAPI) Update(ctx context.Context, request UpdateIpAccessList) error {
-	return a.impl.Update(ctx, request)
-}
-
 type AccountSettingsInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -394,7 +324,7 @@ type AccountSettingsInterface interface {
 
 func NewAccountSettings(client *client.DatabricksClient) *AccountSettingsAPI {
 	return &AccountSettingsAPI{
-		impl: &accountSettingsImpl{
+		AccountSettingsService: &accountSettingsImpl{
 			client: client,
 		},
 
@@ -410,7 +340,7 @@ func NewAccountSettings(client *client.DatabricksClient) *AccountSettingsAPI {
 type AccountSettingsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AccountSettingsService)
-	impl AccountSettingsService
+	AccountSettingsService
 
 	// The compliance security profile settings at the account level control
 	// whether to enable it for new workspaces. By default, this account-level
@@ -458,14 +388,18 @@ func (a *AccountSettingsAPI) PersonalCompute() PersonalComputeInterface {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountSettingsInterface instead.
 func (a *AccountSettingsAPI) WithImpl(impl AccountSettingsService) AccountSettingsInterface {
-	a.impl = impl
-	return a
+	return &AccountSettingsAPI{
+		AccountSettingsService: impl,
+		cspEnablementAccount:   a.cspEnablementAccount,
+		esmEnablementAccount:   a.esmEnablementAccount,
+		personalCompute:        a.personalCompute,
+	}
 }
 
 // Impl returns low-level AccountSettings API implementation
 // Deprecated: use MockAccountSettingsInterface instead.
 func (a *AccountSettingsAPI) Impl() AccountSettingsService {
-	return a.impl
+	return a.AccountSettingsService
 }
 
 type AutomaticClusterUpdateInterface interface {
@@ -495,7 +429,7 @@ type AutomaticClusterUpdateInterface interface {
 
 func NewAutomaticClusterUpdate(client *client.DatabricksClient) *AutomaticClusterUpdateAPI {
 	return &AutomaticClusterUpdateAPI{
-		impl: &automaticClusterUpdateImpl{
+		AutomaticClusterUpdateService: &automaticClusterUpdateImpl{
 			client: client,
 		},
 	}
@@ -506,39 +440,22 @@ func NewAutomaticClusterUpdate(client *client.DatabricksClient) *AutomaticCluste
 type AutomaticClusterUpdateAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AutomaticClusterUpdateService)
-	impl AutomaticClusterUpdateService
+	AutomaticClusterUpdateService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAutomaticClusterUpdateInterface instead.
 func (a *AutomaticClusterUpdateAPI) WithImpl(impl AutomaticClusterUpdateService) AutomaticClusterUpdateInterface {
-	a.impl = impl
-	return a
+	return &AutomaticClusterUpdateAPI{
+		AutomaticClusterUpdateService: impl,
+	}
 }
 
 // Impl returns low-level AutomaticClusterUpdate API implementation
 // Deprecated: use MockAutomaticClusterUpdateInterface instead.
 func (a *AutomaticClusterUpdateAPI) Impl() AutomaticClusterUpdateService {
-	return a.impl
-}
-
-// Get the automatic cluster update setting.
-//
-// Gets the automatic cluster update setting.
-func (a *AutomaticClusterUpdateAPI) Get(ctx context.Context, request GetAutomaticClusterUpdateSettingRequest) (*AutomaticClusterUpdateSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the automatic cluster update setting.
-//
-// Updates the automatic cluster update setting for the workspace. A fresh etag
-// needs to be provided in `PATCH` requests (as part of the setting field). The
-// etag can be retrieved by making a `GET` request before the `PATCH` request.
-// If the setting is updated concurrently, `PATCH` fails with 409 and the
-// request must be retried by using the fresh etag in the 409 response.
-func (a *AutomaticClusterUpdateAPI) Update(ctx context.Context, request UpdateAutomaticClusterUpdateSettingRequest) (*AutomaticClusterUpdateSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.AutomaticClusterUpdateService
 }
 
 type ComplianceSecurityProfileInterface interface {
@@ -568,7 +485,7 @@ type ComplianceSecurityProfileInterface interface {
 
 func NewComplianceSecurityProfile(client *client.DatabricksClient) *ComplianceSecurityProfileAPI {
 	return &ComplianceSecurityProfileAPI{
-		impl: &complianceSecurityProfileImpl{
+		ComplianceSecurityProfileService: &complianceSecurityProfileImpl{
 			client: client,
 		},
 	}
@@ -582,39 +499,22 @@ func NewComplianceSecurityProfile(client *client.DatabricksClient) *ComplianceSe
 type ComplianceSecurityProfileAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ComplianceSecurityProfileService)
-	impl ComplianceSecurityProfileService
+	ComplianceSecurityProfileService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockComplianceSecurityProfileInterface instead.
 func (a *ComplianceSecurityProfileAPI) WithImpl(impl ComplianceSecurityProfileService) ComplianceSecurityProfileInterface {
-	a.impl = impl
-	return a
+	return &ComplianceSecurityProfileAPI{
+		ComplianceSecurityProfileService: impl,
+	}
 }
 
 // Impl returns low-level ComplianceSecurityProfile API implementation
 // Deprecated: use MockComplianceSecurityProfileInterface instead.
 func (a *ComplianceSecurityProfileAPI) Impl() ComplianceSecurityProfileService {
-	return a.impl
-}
-
-// Get the compliance security profile setting.
-//
-// Gets the compliance security profile setting.
-func (a *ComplianceSecurityProfileAPI) Get(ctx context.Context, request GetComplianceSecurityProfileSettingRequest) (*ComplianceSecurityProfileSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the compliance security profile setting.
-//
-// Updates the compliance security profile setting for the workspace. A fresh
-// etag needs to be provided in `PATCH` requests (as part of the setting field).
-// The etag can be retrieved by making a `GET` request before the `PATCH`
-// request. If the setting is updated concurrently, `PATCH` fails with 409 and
-// the request must be retried by using the fresh etag in the 409 response.
-func (a *ComplianceSecurityProfileAPI) Update(ctx context.Context, request UpdateComplianceSecurityProfileSettingRequest) (*ComplianceSecurityProfileSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.ComplianceSecurityProfileService
 }
 
 type CredentialsManagerInterface interface {
@@ -636,7 +536,7 @@ type CredentialsManagerInterface interface {
 
 func NewCredentialsManager(client *client.DatabricksClient) *CredentialsManagerAPI {
 	return &CredentialsManagerAPI{
-		impl: &credentialsManagerImpl{
+		CredentialsManagerService: &credentialsManagerImpl{
 			client: client,
 		},
 	}
@@ -647,29 +547,22 @@ func NewCredentialsManager(client *client.DatabricksClient) *CredentialsManagerA
 type CredentialsManagerAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CredentialsManagerService)
-	impl CredentialsManagerService
+	CredentialsManagerService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCredentialsManagerInterface instead.
 func (a *CredentialsManagerAPI) WithImpl(impl CredentialsManagerService) CredentialsManagerInterface {
-	a.impl = impl
-	return a
+	return &CredentialsManagerAPI{
+		CredentialsManagerService: impl,
+	}
 }
 
 // Impl returns low-level CredentialsManager API implementation
 // Deprecated: use MockCredentialsManagerInterface instead.
 func (a *CredentialsManagerAPI) Impl() CredentialsManagerService {
-	return a.impl
-}
-
-// Exchange token.
-//
-// Exchange tokens with an Identity Provider to get a new access token. It
-// allows specifying scopes to determine token permissions.
-func (a *CredentialsManagerAPI) ExchangeToken(ctx context.Context, request ExchangeTokenRequest) (*ExchangeTokenResponse, error) {
-	return a.impl.ExchangeToken(ctx, request)
+	return a.CredentialsManagerService
 }
 
 type CspEnablementAccountInterface interface {
@@ -696,7 +589,7 @@ type CspEnablementAccountInterface interface {
 
 func NewCspEnablementAccount(client *client.DatabricksClient) *CspEnablementAccountAPI {
 	return &CspEnablementAccountAPI{
-		impl: &cspEnablementAccountImpl{
+		CspEnablementAccountService: &cspEnablementAccountImpl{
 			client: client,
 		},
 	}
@@ -712,36 +605,22 @@ func NewCspEnablementAccount(client *client.DatabricksClient) *CspEnablementAcco
 type CspEnablementAccountAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CspEnablementAccountService)
-	impl CspEnablementAccountService
+	CspEnablementAccountService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCspEnablementAccountInterface instead.
 func (a *CspEnablementAccountAPI) WithImpl(impl CspEnablementAccountService) CspEnablementAccountInterface {
-	a.impl = impl
-	return a
+	return &CspEnablementAccountAPI{
+		CspEnablementAccountService: impl,
+	}
 }
 
 // Impl returns low-level CspEnablementAccount API implementation
 // Deprecated: use MockCspEnablementAccountInterface instead.
 func (a *CspEnablementAccountAPI) Impl() CspEnablementAccountService {
-	return a.impl
-}
-
-// Get the compliance security profile setting for new workspaces.
-//
-// Gets the compliance security profile setting for new workspaces.
-func (a *CspEnablementAccountAPI) Get(ctx context.Context, request GetCspEnablementAccountSettingRequest) (*CspEnablementAccountSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the compliance security profile setting for new workspaces.
-//
-// Updates the value of the compliance security profile setting for new
-// workspaces.
-func (a *CspEnablementAccountAPI) Update(ctx context.Context, request UpdateCspEnablementAccountSettingRequest) (*CspEnablementAccountSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.CspEnablementAccountService
 }
 
 type DefaultNamespaceInterface interface {
@@ -782,7 +661,7 @@ type DefaultNamespaceInterface interface {
 
 func NewDefaultNamespace(client *client.DatabricksClient) *DefaultNamespaceAPI {
 	return &DefaultNamespaceAPI{
-		impl: &defaultNamespaceImpl{
+		DefaultNamespaceService: &defaultNamespaceImpl{
 			client: client,
 		},
 	}
@@ -803,52 +682,22 @@ func NewDefaultNamespace(client *client.DatabricksClient) *DefaultNamespaceAPI {
 type DefaultNamespaceAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(DefaultNamespaceService)
-	impl DefaultNamespaceService
+	DefaultNamespaceService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDefaultNamespaceInterface instead.
 func (a *DefaultNamespaceAPI) WithImpl(impl DefaultNamespaceService) DefaultNamespaceInterface {
-	a.impl = impl
-	return a
+	return &DefaultNamespaceAPI{
+		DefaultNamespaceService: impl,
+	}
 }
 
 // Impl returns low-level DefaultNamespace API implementation
 // Deprecated: use MockDefaultNamespaceInterface instead.
 func (a *DefaultNamespaceAPI) Impl() DefaultNamespaceService {
-	return a.impl
-}
-
-// Delete the default namespace setting.
-//
-// Deletes the default namespace setting for the workspace. A fresh etag needs
-// to be provided in `DELETE` requests (as a query parameter). The etag can be
-// retrieved by making a `GET` request before the `DELETE` request. If the
-// setting is updated/deleted concurrently, `DELETE` fails with 409 and the
-// request must be retried by using the fresh etag in the 409 response.
-func (a *DefaultNamespaceAPI) Delete(ctx context.Context, request DeleteDefaultNamespaceSettingRequest) (*DeleteDefaultNamespaceSettingResponse, error) {
-	return a.impl.Delete(ctx, request)
-}
-
-// Get the default namespace setting.
-//
-// Gets the default namespace setting.
-func (a *DefaultNamespaceAPI) Get(ctx context.Context, request GetDefaultNamespaceSettingRequest) (*DefaultNamespaceSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the default namespace setting.
-//
-// Updates the default namespace setting for the workspace. A fresh etag needs
-// to be provided in `PATCH` requests (as part of the setting field). The etag
-// can be retrieved by making a `GET` request before the `PATCH` request. Note
-// that if the setting does not exist, `GET` returns a NOT_FOUND error and the
-// etag is present in the error response, which should be set in the `PATCH`
-// request. If the setting is updated concurrently, `PATCH` fails with 409 and
-// the request must be retried by using the fresh etag in the 409 response.
-func (a *DefaultNamespaceAPI) Update(ctx context.Context, request UpdateDefaultNamespaceSettingRequest) (*DefaultNamespaceSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.DefaultNamespaceService
 }
 
 type EnhancedSecurityMonitoringInterface interface {
@@ -878,7 +727,7 @@ type EnhancedSecurityMonitoringInterface interface {
 
 func NewEnhancedSecurityMonitoring(client *client.DatabricksClient) *EnhancedSecurityMonitoringAPI {
 	return &EnhancedSecurityMonitoringAPI{
-		impl: &enhancedSecurityMonitoringImpl{
+		EnhancedSecurityMonitoringService: &enhancedSecurityMonitoringImpl{
 			client: client,
 		},
 	}
@@ -894,39 +743,22 @@ func NewEnhancedSecurityMonitoring(client *client.DatabricksClient) *EnhancedSec
 type EnhancedSecurityMonitoringAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(EnhancedSecurityMonitoringService)
-	impl EnhancedSecurityMonitoringService
+	EnhancedSecurityMonitoringService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockEnhancedSecurityMonitoringInterface instead.
 func (a *EnhancedSecurityMonitoringAPI) WithImpl(impl EnhancedSecurityMonitoringService) EnhancedSecurityMonitoringInterface {
-	a.impl = impl
-	return a
+	return &EnhancedSecurityMonitoringAPI{
+		EnhancedSecurityMonitoringService: impl,
+	}
 }
 
 // Impl returns low-level EnhancedSecurityMonitoring API implementation
 // Deprecated: use MockEnhancedSecurityMonitoringInterface instead.
 func (a *EnhancedSecurityMonitoringAPI) Impl() EnhancedSecurityMonitoringService {
-	return a.impl
-}
-
-// Get the enhanced security monitoring setting.
-//
-// Gets the enhanced security monitoring setting.
-func (a *EnhancedSecurityMonitoringAPI) Get(ctx context.Context, request GetEnhancedSecurityMonitoringSettingRequest) (*EnhancedSecurityMonitoringSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the enhanced security monitoring setting.
-//
-// Updates the enhanced security monitoring setting for the workspace. A fresh
-// etag needs to be provided in `PATCH` requests (as part of the setting field).
-// The etag can be retrieved by making a `GET` request before the `PATCH`
-// request. If the setting is updated concurrently, `PATCH` fails with 409 and
-// the request must be retried by using the fresh etag in the 409 response.
-func (a *EnhancedSecurityMonitoringAPI) Update(ctx context.Context, request UpdateEnhancedSecurityMonitoringSettingRequest) (*EnhancedSecurityMonitoringSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.EnhancedSecurityMonitoringService
 }
 
 type EsmEnablementAccountInterface interface {
@@ -953,7 +785,7 @@ type EsmEnablementAccountInterface interface {
 
 func NewEsmEnablementAccount(client *client.DatabricksClient) *EsmEnablementAccountAPI {
 	return &EsmEnablementAccountAPI{
-		impl: &esmEnablementAccountImpl{
+		EsmEnablementAccountService: &esmEnablementAccountImpl{
 			client: client,
 		},
 	}
@@ -967,36 +799,22 @@ func NewEsmEnablementAccount(client *client.DatabricksClient) *EsmEnablementAcco
 type EsmEnablementAccountAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(EsmEnablementAccountService)
-	impl EsmEnablementAccountService
+	EsmEnablementAccountService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockEsmEnablementAccountInterface instead.
 func (a *EsmEnablementAccountAPI) WithImpl(impl EsmEnablementAccountService) EsmEnablementAccountInterface {
-	a.impl = impl
-	return a
+	return &EsmEnablementAccountAPI{
+		EsmEnablementAccountService: impl,
+	}
 }
 
 // Impl returns low-level EsmEnablementAccount API implementation
 // Deprecated: use MockEsmEnablementAccountInterface instead.
 func (a *EsmEnablementAccountAPI) Impl() EsmEnablementAccountService {
-	return a.impl
-}
-
-// Get the enhanced security monitoring setting for new workspaces.
-//
-// Gets the enhanced security monitoring setting for new workspaces.
-func (a *EsmEnablementAccountAPI) Get(ctx context.Context, request GetEsmEnablementAccountSettingRequest) (*EsmEnablementAccountSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the enhanced security monitoring setting for new workspaces.
-//
-// Updates the value of the enhanced security monitoring setting for new
-// workspaces.
-func (a *EsmEnablementAccountAPI) Update(ctx context.Context, request UpdateEsmEnablementAccountSettingRequest) (*EsmEnablementAccountSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.EsmEnablementAccountService
 }
 
 type IpAccessListsInterface interface {
@@ -1121,7 +939,7 @@ type IpAccessListsInterface interface {
 
 func NewIpAccessLists(client *client.DatabricksClient) *IpAccessListsAPI {
 	return &IpAccessListsAPI{
-		impl: &ipAccessListsImpl{
+		IpAccessListsService: &ipAccessListsImpl{
 			client: client,
 		},
 	}
@@ -1151,57 +969,29 @@ func NewIpAccessLists(client *client.DatabricksClient) *IpAccessListsAPI {
 type IpAccessListsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(IpAccessListsService)
-	impl IpAccessListsService
+	IpAccessListsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockIpAccessListsInterface instead.
 func (a *IpAccessListsAPI) WithImpl(impl IpAccessListsService) IpAccessListsInterface {
-	a.impl = impl
-	return a
+	return &IpAccessListsAPI{
+		IpAccessListsService: impl,
+	}
 }
 
 // Impl returns low-level IpAccessLists API implementation
 // Deprecated: use MockIpAccessListsInterface instead.
 func (a *IpAccessListsAPI) Impl() IpAccessListsService {
-	return a.impl
-}
-
-// Create access list.
-//
-// Creates an IP access list for this workspace.
-//
-// A list can be an allow list or a block list. See the top of this file for a
-// description of how the server treats allow lists and block lists at runtime.
-//
-// When creating or updating an IP access list:
-//
-// * For all allow lists and block lists combined, the API supports a maximum of
-// 1000 IP/CIDR values, where one CIDR counts as a single value. Attempts to
-// exceed that number return error 400 with `error_code` value `QUOTA_EXCEEDED`.
-// * If the new list would block the calling user's current IP, error 400 is
-// returned with `error_code` value `INVALID_STATE`.
-//
-// It can take a few minutes for the changes to take effect. **Note**: Your new
-// IP access list has no effect until you enable the feature. See
-// :method:workspaceconf/setStatus
-func (a *IpAccessListsAPI) Create(ctx context.Context, request CreateIpAccessList) (*CreateIpAccessListResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete access list.
-//
-// Deletes an IP access list, specified by its list ID.
-func (a *IpAccessListsAPI) Delete(ctx context.Context, request DeleteIpAccessListRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.IpAccessListsService
 }
 
 // Delete access list.
 //
 // Deletes an IP access list, specified by its list ID.
 func (a *IpAccessListsAPI) DeleteByIpAccessListId(ctx context.Context, ipAccessListId string) error {
-	return a.impl.Delete(ctx, DeleteIpAccessListRequest{
+	return a.IpAccessListsService.Delete(ctx, DeleteIpAccessListRequest{
 		IpAccessListId: ipAccessListId,
 	})
 }
@@ -1209,15 +999,8 @@ func (a *IpAccessListsAPI) DeleteByIpAccessListId(ctx context.Context, ipAccessL
 // Get access list.
 //
 // Gets an IP access list, specified by its list ID.
-func (a *IpAccessListsAPI) Get(ctx context.Context, request GetIpAccessListRequest) (*FetchIpAccessListResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get access list.
-//
-// Gets an IP access list, specified by its list ID.
 func (a *IpAccessListsAPI) GetByIpAccessListId(ctx context.Context, ipAccessListId string) (*FetchIpAccessListResponse, error) {
-	return a.impl.Get(ctx, GetIpAccessListRequest{
+	return a.IpAccessListsService.Get(ctx, GetIpAccessListRequest{
 		IpAccessListId: ipAccessListId,
 	})
 }
@@ -1232,7 +1015,7 @@ func (a *IpAccessListsAPI) List(ctx context.Context) listing.Iterator[IpAccessLi
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListIpAccessListResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.IpAccessListsService.List(ctx)
 	}
 	getItems := func(resp *ListIpAccessListResponse) []IpAccessListInfo {
 		return resp.IpAccessLists
@@ -1307,47 +1090,6 @@ func (a *IpAccessListsAPI) GetByLabel(ctx context.Context, name string) (*IpAcce
 		return nil, fmt.Errorf("there are %d instances of IpAccessListInfo named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Replace access list.
-//
-// Replaces an IP access list, specified by its ID.
-//
-// A list can include allow lists and block lists. See the top of this file for
-// a description of how the server treats allow lists and block lists at run
-// time. When replacing an IP access list: * For all allow lists and block lists
-// combined, the API supports a maximum of 1000 IP/CIDR values, where one CIDR
-// counts as a single value. Attempts to exceed that number return error 400
-// with `error_code` value `QUOTA_EXCEEDED`. * If the resulting list would block
-// the calling user's current IP, error 400 is returned with `error_code` value
-// `INVALID_STATE`. It can take a few minutes for the changes to take effect.
-// Note that your resulting IP access list has no effect until you enable the
-// feature. See :method:workspaceconf/setStatus.
-func (a *IpAccessListsAPI) Replace(ctx context.Context, request ReplaceIpAccessList) error {
-	return a.impl.Replace(ctx, request)
-}
-
-// Update access list.
-//
-// Updates an existing IP access list, specified by its ID.
-//
-// A list can include allow lists and block lists. See the top of this file for
-// a description of how the server treats allow lists and block lists at run
-// time.
-//
-// When updating an IP access list:
-//
-// * For all allow lists and block lists combined, the API supports a maximum of
-// 1000 IP/CIDR values, where one CIDR counts as a single value. Attempts to
-// exceed that number return error 400 with `error_code` value `QUOTA_EXCEEDED`.
-// * If the updated list would block the calling user's current IP, error 400 is
-// returned with `error_code` value `INVALID_STATE`.
-//
-// It can take a few minutes for the changes to take effect. Note that your
-// resulting IP access list has no effect until you enable the feature. See
-// :method:workspaceconf/setStatus.
-func (a *IpAccessListsAPI) Update(ctx context.Context, request UpdateIpAccessList) error {
-	return a.impl.Update(ctx, request)
 }
 
 type NetworkConnectivityInterface interface {
@@ -1463,7 +1205,7 @@ type NetworkConnectivityInterface interface {
 
 func NewNetworkConnectivity(client *client.DatabricksClient) *NetworkConnectivityAPI {
 	return &NetworkConnectivityAPI{
-		impl: &networkConnectivityImpl{
+		NetworkConnectivityService: &networkConnectivityImpl{
 			client: client,
 		},
 	}
@@ -1474,70 +1216,31 @@ func NewNetworkConnectivity(client *client.DatabricksClient) *NetworkConnectivit
 type NetworkConnectivityAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(NetworkConnectivityService)
-	impl NetworkConnectivityService
+	NetworkConnectivityService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockNetworkConnectivityInterface instead.
 func (a *NetworkConnectivityAPI) WithImpl(impl NetworkConnectivityService) NetworkConnectivityInterface {
-	a.impl = impl
-	return a
+	return &NetworkConnectivityAPI{
+		NetworkConnectivityService: impl,
+	}
 }
 
 // Impl returns low-level NetworkConnectivity API implementation
 // Deprecated: use MockNetworkConnectivityInterface instead.
 func (a *NetworkConnectivityAPI) Impl() NetworkConnectivityService {
-	return a.impl
-}
-
-// Create a network connectivity configuration.
-func (a *NetworkConnectivityAPI) CreateNetworkConnectivityConfiguration(ctx context.Context, request CreateNetworkConnectivityConfigRequest) (*NetworkConnectivityConfiguration, error) {
-	return a.impl.CreateNetworkConnectivityConfiguration(ctx, request)
-}
-
-// Create a private endpoint rule.
-//
-// Create a private endpoint rule for the specified network connectivity config
-// object. Once the object is created, Databricks asynchronously provisions a
-// new Azure private endpoint to your specified Azure resource.
-//
-// **IMPORTANT**: You must use Azure portal or other Azure tools to approve the
-// private endpoint to complete the connection. To get the information of the
-// private endpoint created, make a `GET` request on the new private endpoint
-// rule. See [serverless private link].
-//
-// [serverless private link]: https://learn.microsoft.com/azure/databricks/security/network/serverless-network-security/serverless-private-link
-func (a *NetworkConnectivityAPI) CreatePrivateEndpointRule(ctx context.Context, request CreatePrivateEndpointRuleRequest) (*NccAzurePrivateEndpointRule, error) {
-	return a.impl.CreatePrivateEndpointRule(ctx, request)
-}
-
-// Delete a network connectivity configuration.
-//
-// Deletes a network connectivity configuration.
-func (a *NetworkConnectivityAPI) DeleteNetworkConnectivityConfiguration(ctx context.Context, request DeleteNetworkConnectivityConfigurationRequest) error {
-	return a.impl.DeleteNetworkConnectivityConfiguration(ctx, request)
+	return a.NetworkConnectivityService
 }
 
 // Delete a network connectivity configuration.
 //
 // Deletes a network connectivity configuration.
 func (a *NetworkConnectivityAPI) DeleteNetworkConnectivityConfigurationByNetworkConnectivityConfigId(ctx context.Context, networkConnectivityConfigId string) error {
-	return a.impl.DeleteNetworkConnectivityConfiguration(ctx, DeleteNetworkConnectivityConfigurationRequest{
+	return a.NetworkConnectivityService.DeleteNetworkConnectivityConfiguration(ctx, DeleteNetworkConnectivityConfigurationRequest{
 		NetworkConnectivityConfigId: networkConnectivityConfigId,
 	})
-}
-
-// Delete a private endpoint rule.
-//
-// Initiates deleting a private endpoint rule. If the connection state is
-// PENDING or EXPIRED, the private endpoint is immediately deleted. Otherwise,
-// the private endpoint is deactivated and will be deleted after seven days of
-// deactivation. When a private endpoint is deactivated, the `deactivated` field
-// is set to `true` and the private endpoint is not available to your serverless
-// compute resources.
-func (a *NetworkConnectivityAPI) DeletePrivateEndpointRule(ctx context.Context, request DeletePrivateEndpointRuleRequest) (*NccAzurePrivateEndpointRule, error) {
-	return a.impl.DeletePrivateEndpointRule(ctx, request)
 }
 
 // Delete a private endpoint rule.
@@ -1549,7 +1252,7 @@ func (a *NetworkConnectivityAPI) DeletePrivateEndpointRule(ctx context.Context, 
 // is set to `true` and the private endpoint is not available to your serverless
 // compute resources.
 func (a *NetworkConnectivityAPI) DeletePrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(ctx context.Context, networkConnectivityConfigId string, privateEndpointRuleId string) (*NccAzurePrivateEndpointRule, error) {
-	return a.impl.DeletePrivateEndpointRule(ctx, DeletePrivateEndpointRuleRequest{
+	return a.NetworkConnectivityService.DeletePrivateEndpointRule(ctx, DeletePrivateEndpointRuleRequest{
 		NetworkConnectivityConfigId: networkConnectivityConfigId,
 		PrivateEndpointRuleId:       privateEndpointRuleId,
 	})
@@ -1558,15 +1261,8 @@ func (a *NetworkConnectivityAPI) DeletePrivateEndpointRuleByNetworkConnectivityC
 // Get a network connectivity configuration.
 //
 // Gets a network connectivity configuration.
-func (a *NetworkConnectivityAPI) GetNetworkConnectivityConfiguration(ctx context.Context, request GetNetworkConnectivityConfigurationRequest) (*NetworkConnectivityConfiguration, error) {
-	return a.impl.GetNetworkConnectivityConfiguration(ctx, request)
-}
-
-// Get a network connectivity configuration.
-//
-// Gets a network connectivity configuration.
 func (a *NetworkConnectivityAPI) GetNetworkConnectivityConfigurationByNetworkConnectivityConfigId(ctx context.Context, networkConnectivityConfigId string) (*NetworkConnectivityConfiguration, error) {
-	return a.impl.GetNetworkConnectivityConfiguration(ctx, GetNetworkConnectivityConfigurationRequest{
+	return a.NetworkConnectivityService.GetNetworkConnectivityConfiguration(ctx, GetNetworkConnectivityConfigurationRequest{
 		NetworkConnectivityConfigId: networkConnectivityConfigId,
 	})
 }
@@ -1574,15 +1270,8 @@ func (a *NetworkConnectivityAPI) GetNetworkConnectivityConfigurationByNetworkCon
 // Get a private endpoint rule.
 //
 // Gets the private endpoint rule.
-func (a *NetworkConnectivityAPI) GetPrivateEndpointRule(ctx context.Context, request GetPrivateEndpointRuleRequest) (*NccAzurePrivateEndpointRule, error) {
-	return a.impl.GetPrivateEndpointRule(ctx, request)
-}
-
-// Get a private endpoint rule.
-//
-// Gets the private endpoint rule.
 func (a *NetworkConnectivityAPI) GetPrivateEndpointRuleByNetworkConnectivityConfigIdAndPrivateEndpointRuleId(ctx context.Context, networkConnectivityConfigId string, privateEndpointRuleId string) (*NccAzurePrivateEndpointRule, error) {
-	return a.impl.GetPrivateEndpointRule(ctx, GetPrivateEndpointRuleRequest{
+	return a.NetworkConnectivityService.GetPrivateEndpointRule(ctx, GetPrivateEndpointRuleRequest{
 		NetworkConnectivityConfigId: networkConnectivityConfigId,
 		PrivateEndpointRuleId:       privateEndpointRuleId,
 	})
@@ -1597,7 +1286,7 @@ func (a *NetworkConnectivityAPI) ListNetworkConnectivityConfigurations(ctx conte
 
 	getNextPage := func(ctx context.Context, req ListNetworkConnectivityConfigurationsRequest) (*ListNetworkConnectivityConfigurationsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListNetworkConnectivityConfigurations(ctx, req)
+		return a.NetworkConnectivityService.ListNetworkConnectivityConfigurations(ctx, req)
 	}
 	getItems := func(resp *ListNetworkConnectivityConfigurationsResponse) []NetworkConnectivityConfiguration {
 		return resp.Items
@@ -1636,7 +1325,7 @@ func (a *NetworkConnectivityAPI) ListPrivateEndpointRules(ctx context.Context, r
 
 	getNextPage := func(ctx context.Context, req ListPrivateEndpointRulesRequest) (*ListNccAzurePrivateEndpointRulesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListPrivateEndpointRules(ctx, req)
+		return a.NetworkConnectivityService.ListPrivateEndpointRules(ctx, req)
 	}
 	getItems := func(resp *ListNccAzurePrivateEndpointRulesResponse) []NccAzurePrivateEndpointRule {
 		return resp.Items
@@ -1670,7 +1359,7 @@ func (a *NetworkConnectivityAPI) ListPrivateEndpointRulesAll(ctx context.Context
 //
 // Gets an array of private endpoint rules.
 func (a *NetworkConnectivityAPI) ListPrivateEndpointRulesByNetworkConnectivityConfigId(ctx context.Context, networkConnectivityConfigId string) (*ListNccAzurePrivateEndpointRulesResponse, error) {
-	return a.impl.ListPrivateEndpointRules(ctx, ListPrivateEndpointRulesRequest{
+	return a.NetworkConnectivityService.ListPrivateEndpointRules(ctx, ListPrivateEndpointRulesRequest{
 		NetworkConnectivityConfigId: networkConnectivityConfigId,
 	})
 }
@@ -1733,7 +1422,7 @@ type NotificationDestinationsInterface interface {
 
 func NewNotificationDestinations(client *client.DatabricksClient) *NotificationDestinationsAPI {
 	return &NotificationDestinationsAPI{
-		impl: &notificationDestinationsImpl{
+		NotificationDestinationsService: &notificationDestinationsImpl{
 			client: client,
 		},
 	}
@@ -1747,42 +1436,29 @@ func NewNotificationDestinations(client *client.DatabricksClient) *NotificationD
 type NotificationDestinationsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(NotificationDestinationsService)
-	impl NotificationDestinationsService
+	NotificationDestinationsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockNotificationDestinationsInterface instead.
 func (a *NotificationDestinationsAPI) WithImpl(impl NotificationDestinationsService) NotificationDestinationsInterface {
-	a.impl = impl
-	return a
+	return &NotificationDestinationsAPI{
+		NotificationDestinationsService: impl,
+	}
 }
 
 // Impl returns low-level NotificationDestinations API implementation
 // Deprecated: use MockNotificationDestinationsInterface instead.
 func (a *NotificationDestinationsAPI) Impl() NotificationDestinationsService {
-	return a.impl
-}
-
-// Create a notification destination.
-//
-// Creates a notification destination. Requires workspace admin permissions.
-func (a *NotificationDestinationsAPI) Create(ctx context.Context, request CreateNotificationDestinationRequest) (*NotificationDestination, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a notification destination.
-//
-// Deletes a notification destination. Requires workspace admin permissions.
-func (a *NotificationDestinationsAPI) Delete(ctx context.Context, request DeleteNotificationDestinationRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.NotificationDestinationsService
 }
 
 // Delete a notification destination.
 //
 // Deletes a notification destination. Requires workspace admin permissions.
 func (a *NotificationDestinationsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteNotificationDestinationRequest{
+	return a.NotificationDestinationsService.Delete(ctx, DeleteNotificationDestinationRequest{
 		Id: id,
 	})
 }
@@ -1790,15 +1466,8 @@ func (a *NotificationDestinationsAPI) DeleteById(ctx context.Context, id string)
 // Get a notification destination.
 //
 // Gets a notification destination.
-func (a *NotificationDestinationsAPI) Get(ctx context.Context, request GetNotificationDestinationRequest) (*NotificationDestination, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a notification destination.
-//
-// Gets a notification destination.
 func (a *NotificationDestinationsAPI) GetById(ctx context.Context, id string) (*NotificationDestination, error) {
-	return a.impl.Get(ctx, GetNotificationDestinationRequest{
+	return a.NotificationDestinationsService.Get(ctx, GetNotificationDestinationRequest{
 		Id: id,
 	})
 }
@@ -1812,7 +1481,7 @@ func (a *NotificationDestinationsAPI) List(ctx context.Context, request ListNoti
 
 	getNextPage := func(ctx context.Context, req ListNotificationDestinationsRequest) (*ListNotificationDestinationsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.NotificationDestinationsService.List(ctx, req)
 	}
 	getItems := func(resp *ListNotificationDestinationsResponse) []ListNotificationDestinationsResult {
 		return resp.Results
@@ -1840,14 +1509,6 @@ func (a *NotificationDestinationsAPI) List(ctx context.Context, request ListNoti
 func (a *NotificationDestinationsAPI) ListAll(ctx context.Context, request ListNotificationDestinationsRequest) ([]ListNotificationDestinationsResult, error) {
 	iterator := a.List(ctx, request)
 	return listing.ToSlice[ListNotificationDestinationsResult](ctx, iterator)
-}
-
-// Update a notification destination.
-//
-// Updates a notification destination. Requires workspace admin permissions. At
-// least one field is required in the request body.
-func (a *NotificationDestinationsAPI) Update(ctx context.Context, request UpdateNotificationDestinationRequest) (*NotificationDestination, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type PersonalComputeInterface interface {
@@ -1878,7 +1539,7 @@ type PersonalComputeInterface interface {
 
 func NewPersonalCompute(client *client.DatabricksClient) *PersonalComputeAPI {
 	return &PersonalComputeAPI{
-		impl: &personalComputeImpl{
+		PersonalComputeService: &personalComputeImpl{
 			client: client,
 		},
 	}
@@ -1896,42 +1557,22 @@ func NewPersonalCompute(client *client.DatabricksClient) *PersonalComputeAPI {
 type PersonalComputeAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(PersonalComputeService)
-	impl PersonalComputeService
+	PersonalComputeService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPersonalComputeInterface instead.
 func (a *PersonalComputeAPI) WithImpl(impl PersonalComputeService) PersonalComputeInterface {
-	a.impl = impl
-	return a
+	return &PersonalComputeAPI{
+		PersonalComputeService: impl,
+	}
 }
 
 // Impl returns low-level PersonalCompute API implementation
 // Deprecated: use MockPersonalComputeInterface instead.
 func (a *PersonalComputeAPI) Impl() PersonalComputeService {
-	return a.impl
-}
-
-// Delete Personal Compute setting.
-//
-// Reverts back the Personal Compute setting value to default (ON)
-func (a *PersonalComputeAPI) Delete(ctx context.Context, request DeletePersonalComputeSettingRequest) (*DeletePersonalComputeSettingResponse, error) {
-	return a.impl.Delete(ctx, request)
-}
-
-// Get Personal Compute setting.
-//
-// Gets the value of the Personal Compute setting.
-func (a *PersonalComputeAPI) Get(ctx context.Context, request GetPersonalComputeSettingRequest) (*PersonalComputeSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update Personal Compute setting.
-//
-// Updates the value of the Personal Compute setting.
-func (a *PersonalComputeAPI) Update(ctx context.Context, request UpdatePersonalComputeSettingRequest) (*PersonalComputeSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.PersonalComputeService
 }
 
 type RestrictWorkspaceAdminsInterface interface {
@@ -1971,7 +1612,7 @@ type RestrictWorkspaceAdminsInterface interface {
 
 func NewRestrictWorkspaceAdmins(client *client.DatabricksClient) *RestrictWorkspaceAdminsAPI {
 	return &RestrictWorkspaceAdminsAPI{
-		impl: &restrictWorkspaceAdminsImpl{
+		RestrictWorkspaceAdminsService: &restrictWorkspaceAdminsImpl{
 			client: client,
 		},
 	}
@@ -1992,51 +1633,22 @@ func NewRestrictWorkspaceAdmins(client *client.DatabricksClient) *RestrictWorksp
 type RestrictWorkspaceAdminsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(RestrictWorkspaceAdminsService)
-	impl RestrictWorkspaceAdminsService
+	RestrictWorkspaceAdminsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRestrictWorkspaceAdminsInterface instead.
 func (a *RestrictWorkspaceAdminsAPI) WithImpl(impl RestrictWorkspaceAdminsService) RestrictWorkspaceAdminsInterface {
-	a.impl = impl
-	return a
+	return &RestrictWorkspaceAdminsAPI{
+		RestrictWorkspaceAdminsService: impl,
+	}
 }
 
 // Impl returns low-level RestrictWorkspaceAdmins API implementation
 // Deprecated: use MockRestrictWorkspaceAdminsInterface instead.
 func (a *RestrictWorkspaceAdminsAPI) Impl() RestrictWorkspaceAdminsService {
-	return a.impl
-}
-
-// Delete the restrict workspace admins setting.
-//
-// Reverts the restrict workspace admins setting status for the workspace. A
-// fresh etag needs to be provided in `DELETE` requests (as a query parameter).
-// The etag can be retrieved by making a `GET` request before the DELETE
-// request. If the setting is updated/deleted concurrently, `DELETE` fails with
-// 409 and the request must be retried by using the fresh etag in the 409
-// response.
-func (a *RestrictWorkspaceAdminsAPI) Delete(ctx context.Context, request DeleteRestrictWorkspaceAdminsSettingRequest) (*DeleteRestrictWorkspaceAdminsSettingResponse, error) {
-	return a.impl.Delete(ctx, request)
-}
-
-// Get the restrict workspace admins setting.
-//
-// Gets the restrict workspace admins setting.
-func (a *RestrictWorkspaceAdminsAPI) Get(ctx context.Context, request GetRestrictWorkspaceAdminsSettingRequest) (*RestrictWorkspaceAdminsSetting, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Update the restrict workspace admins setting.
-//
-// Updates the restrict workspace admins setting for the workspace. A fresh etag
-// needs to be provided in `PATCH` requests (as part of the setting field). The
-// etag can be retrieved by making a GET request before the `PATCH` request. If
-// the setting is updated concurrently, `PATCH` fails with 409 and the request
-// must be retried by using the fresh etag in the 409 response.
-func (a *RestrictWorkspaceAdminsAPI) Update(ctx context.Context, request UpdateRestrictWorkspaceAdminsSettingRequest) (*RestrictWorkspaceAdminsSetting, error) {
-	return a.impl.Update(ctx, request)
+	return a.RestrictWorkspaceAdminsService
 }
 
 type SettingsInterface interface {
@@ -2102,7 +1714,7 @@ type SettingsInterface interface {
 
 func NewSettings(client *client.DatabricksClient) *SettingsAPI {
 	return &SettingsAPI{
-		impl: &settingsImpl{
+		SettingsService: &settingsImpl{
 			client: client,
 		},
 
@@ -2123,7 +1735,7 @@ func NewSettings(client *client.DatabricksClient) *SettingsAPI {
 type SettingsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(SettingsService)
-	impl SettingsService
+	SettingsService
 
 	// Controls whether automatic cluster update is enabled for the current
 	// workspace. By default, it is turned off.
@@ -2200,14 +1812,20 @@ func (a *SettingsAPI) RestrictWorkspaceAdmins() RestrictWorkspaceAdminsInterface
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSettingsInterface instead.
 func (a *SettingsAPI) WithImpl(impl SettingsService) SettingsInterface {
-	a.impl = impl
-	return a
+	return &SettingsAPI{
+		SettingsService:            impl,
+		automaticClusterUpdate:     a.automaticClusterUpdate,
+		complianceSecurityProfile:  a.complianceSecurityProfile,
+		defaultNamespace:           a.defaultNamespace,
+		enhancedSecurityMonitoring: a.enhancedSecurityMonitoring,
+		restrictWorkspaceAdmins:    a.restrictWorkspaceAdmins,
+	}
 }
 
 // Impl returns low-level Settings API implementation
 // Deprecated: use MockSettingsInterface instead.
 func (a *SettingsAPI) Impl() SettingsService {
-	return a.impl
+	return a.SettingsService
 }
 
 type TokenManagementInterface interface {
@@ -2303,7 +1921,7 @@ type TokenManagementInterface interface {
 
 func NewTokenManagement(client *client.DatabricksClient) *TokenManagementAPI {
 	return &TokenManagementAPI{
-		impl: &tokenManagementImpl{
+		TokenManagementService: &tokenManagementImpl{
 			client: client,
 		},
 	}
@@ -2315,75 +1933,40 @@ func NewTokenManagement(client *client.DatabricksClient) *TokenManagementAPI {
 type TokenManagementAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(TokenManagementService)
-	impl TokenManagementService
+	TokenManagementService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTokenManagementInterface instead.
 func (a *TokenManagementAPI) WithImpl(impl TokenManagementService) TokenManagementInterface {
-	a.impl = impl
-	return a
+	return &TokenManagementAPI{
+		TokenManagementService: impl,
+	}
 }
 
 // Impl returns low-level TokenManagement API implementation
 // Deprecated: use MockTokenManagementInterface instead.
 func (a *TokenManagementAPI) Impl() TokenManagementService {
-	return a.impl
-}
-
-// Create on-behalf token.
-//
-// Creates a token on behalf of a service principal.
-func (a *TokenManagementAPI) CreateOboToken(ctx context.Context, request CreateOboTokenRequest) (*CreateOboTokenResponse, error) {
-	return a.impl.CreateOboToken(ctx, request)
-}
-
-// Delete a token.
-//
-// Deletes a token, specified by its ID.
-func (a *TokenManagementAPI) Delete(ctx context.Context, request DeleteTokenManagementRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.TokenManagementService
 }
 
 // Delete a token.
 //
 // Deletes a token, specified by its ID.
 func (a *TokenManagementAPI) DeleteByTokenId(ctx context.Context, tokenId string) error {
-	return a.impl.Delete(ctx, DeleteTokenManagementRequest{
+	return a.TokenManagementService.Delete(ctx, DeleteTokenManagementRequest{
 		TokenId: tokenId,
 	})
-}
-
-// Get token info.
-//
-// Gets information about a token, specified by its ID.
-func (a *TokenManagementAPI) Get(ctx context.Context, request GetTokenManagementRequest) (*GetTokenResponse, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get token info.
 //
 // Gets information about a token, specified by its ID.
 func (a *TokenManagementAPI) GetByTokenId(ctx context.Context, tokenId string) (*GetTokenResponse, error) {
-	return a.impl.Get(ctx, GetTokenManagementRequest{
+	return a.TokenManagementService.Get(ctx, GetTokenManagementRequest{
 		TokenId: tokenId,
 	})
-}
-
-// Get token permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *TokenManagementAPI) GetPermissionLevels(ctx context.Context) (*GetTokenPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx)
-}
-
-// Get token permissions.
-//
-// Gets the permissions of all tokens. Tokens can inherit permissions from their
-// root object.
-func (a *TokenManagementAPI) GetPermissions(ctx context.Context) (*TokenPermissions, error) {
-	return a.impl.GetPermissions(ctx)
 }
 
 // List all tokens.
@@ -2395,7 +1978,7 @@ func (a *TokenManagementAPI) List(ctx context.Context, request ListTokenManageme
 
 	getNextPage := func(ctx context.Context, req ListTokenManagementRequest) (*ListTokensResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.TokenManagementService.List(ctx, req)
 	}
 	getItems := func(resp *ListTokensResponse) []TokenInfo {
 		return resp.TokenInfos
@@ -2472,22 +2055,6 @@ func (a *TokenManagementAPI) GetByComment(ctx context.Context, name string) (*To
 	return &alternatives[0], nil
 }
 
-// Set token permissions.
-//
-// Sets permissions on all tokens. Tokens can inherit permissions from their
-// root object.
-func (a *TokenManagementAPI) SetPermissions(ctx context.Context, request TokenPermissionsRequest) (*TokenPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Update token permissions.
-//
-// Updates the permissions on all tokens. Tokens can inherit permissions from
-// their root object.
-func (a *TokenManagementAPI) UpdatePermissions(ctx context.Context, request TokenPermissionsRequest) (*TokenPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
-}
-
 type TokensInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -2557,7 +2124,7 @@ type TokensInterface interface {
 
 func NewTokens(client *client.DatabricksClient) *TokensAPI {
 	return &TokensAPI{
-		impl: &tokensImpl{
+		TokensService: &tokensImpl{
 			client: client,
 		},
 	}
@@ -2568,41 +2135,22 @@ func NewTokens(client *client.DatabricksClient) *TokensAPI {
 type TokensAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(TokensService)
-	impl TokensService
+	TokensService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTokensInterface instead.
 func (a *TokensAPI) WithImpl(impl TokensService) TokensInterface {
-	a.impl = impl
-	return a
+	return &TokensAPI{
+		TokensService: impl,
+	}
 }
 
 // Impl returns low-level Tokens API implementation
 // Deprecated: use MockTokensInterface instead.
 func (a *TokensAPI) Impl() TokensService {
-	return a.impl
-}
-
-// Create a user token.
-//
-// Creates and returns a token for a user. If this call is made through token
-// authentication, it creates a token with the same client ID as the
-// authenticated token. If the user's token quota is exceeded, this call returns
-// an error **QUOTA_EXCEEDED**.
-func (a *TokensAPI) Create(ctx context.Context, request CreateTokenRequest) (*CreateTokenResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Revoke token.
-//
-// Revokes an access token.
-//
-// If a token with the specified ID is not valid, this call returns an error
-// **RESOURCE_DOES_NOT_EXIST**.
-func (a *TokensAPI) Delete(ctx context.Context, request RevokeTokenRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.TokensService
 }
 
 // Revoke token.
@@ -2612,7 +2160,7 @@ func (a *TokensAPI) Delete(ctx context.Context, request RevokeTokenRequest) erro
 // If a token with the specified ID is not valid, this call returns an error
 // **RESOURCE_DOES_NOT_EXIST**.
 func (a *TokensAPI) DeleteByTokenId(ctx context.Context, tokenId string) error {
-	return a.impl.Delete(ctx, RevokeTokenRequest{
+	return a.TokensService.Delete(ctx, RevokeTokenRequest{
 		TokenId: tokenId,
 	})
 }
@@ -2627,7 +2175,7 @@ func (a *TokensAPI) List(ctx context.Context) listing.Iterator[PublicTokenInfo] 
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListPublicTokensResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.TokensService.List(ctx)
 	}
 	getItems := func(resp *ListPublicTokensResponse) []PublicTokenInfo {
 		return resp.TokenInfos
@@ -2728,7 +2276,7 @@ type WorkspaceConfInterface interface {
 
 func NewWorkspaceConf(client *client.DatabricksClient) *WorkspaceConfAPI {
 	return &WorkspaceConfAPI{
-		impl: &workspaceConfImpl{
+		WorkspaceConfService: &workspaceConfImpl{
 			client: client,
 		},
 	}
@@ -2738,34 +2286,20 @@ func NewWorkspaceConf(client *client.DatabricksClient) *WorkspaceConfAPI {
 type WorkspaceConfAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(WorkspaceConfService)
-	impl WorkspaceConfService
+	WorkspaceConfService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceConfInterface instead.
 func (a *WorkspaceConfAPI) WithImpl(impl WorkspaceConfService) WorkspaceConfInterface {
-	a.impl = impl
-	return a
+	return &WorkspaceConfAPI{
+		WorkspaceConfService: impl,
+	}
 }
 
 // Impl returns low-level WorkspaceConf API implementation
 // Deprecated: use MockWorkspaceConfInterface instead.
 func (a *WorkspaceConfAPI) Impl() WorkspaceConfService {
-	return a.impl
-}
-
-// Check configuration status.
-//
-// Gets the configuration status for a workspace.
-func (a *WorkspaceConfAPI) GetStatus(ctx context.Context, request GetStatusRequest) (*map[string]string, error) {
-	return a.impl.GetStatus(ctx, request)
-}
-
-// Enable/disable features.
-//
-// Sets the configuration status for a workspace, including enabling or
-// disabling it.
-func (a *WorkspaceConfAPI) SetStatus(ctx context.Context, request WorkspaceConf) error {
-	return a.impl.SetStatus(ctx, request)
+	return a.WorkspaceConfService
 }

--- a/service/settings/api.go
+++ b/service/settings/api.go
@@ -166,9 +166,8 @@ type AccountIpAccessListsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountIpAccessListsInterface instead.
 func (a *AccountIpAccessListsAPI) WithImpl(impl AccountIpAccessListsService) AccountIpAccessListsInterface {
-	return &AccountIpAccessListsAPI{
-		AccountIpAccessListsService: impl,
-	}
+	a.AccountIpAccessListsService = impl
+	return a
 }
 
 // Impl returns low-level AccountIpAccessLists API implementation
@@ -388,12 +387,8 @@ func (a *AccountSettingsAPI) PersonalCompute() PersonalComputeInterface {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAccountSettingsInterface instead.
 func (a *AccountSettingsAPI) WithImpl(impl AccountSettingsService) AccountSettingsInterface {
-	return &AccountSettingsAPI{
-		AccountSettingsService: impl,
-		cspEnablementAccount:   a.cspEnablementAccount,
-		esmEnablementAccount:   a.esmEnablementAccount,
-		personalCompute:        a.personalCompute,
-	}
+	a.AccountSettingsService = impl
+	return a
 }
 
 // Impl returns low-level AccountSettings API implementation
@@ -447,9 +442,8 @@ type AutomaticClusterUpdateAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAutomaticClusterUpdateInterface instead.
 func (a *AutomaticClusterUpdateAPI) WithImpl(impl AutomaticClusterUpdateService) AutomaticClusterUpdateInterface {
-	return &AutomaticClusterUpdateAPI{
-		AutomaticClusterUpdateService: impl,
-	}
+	a.AutomaticClusterUpdateService = impl
+	return a
 }
 
 // Impl returns low-level AutomaticClusterUpdate API implementation
@@ -506,9 +500,8 @@ type ComplianceSecurityProfileAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockComplianceSecurityProfileInterface instead.
 func (a *ComplianceSecurityProfileAPI) WithImpl(impl ComplianceSecurityProfileService) ComplianceSecurityProfileInterface {
-	return &ComplianceSecurityProfileAPI{
-		ComplianceSecurityProfileService: impl,
-	}
+	a.ComplianceSecurityProfileService = impl
+	return a
 }
 
 // Impl returns low-level ComplianceSecurityProfile API implementation
@@ -554,9 +547,8 @@ type CredentialsManagerAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCredentialsManagerInterface instead.
 func (a *CredentialsManagerAPI) WithImpl(impl CredentialsManagerService) CredentialsManagerInterface {
-	return &CredentialsManagerAPI{
-		CredentialsManagerService: impl,
-	}
+	a.CredentialsManagerService = impl
+	return a
 }
 
 // Impl returns low-level CredentialsManager API implementation
@@ -612,9 +604,8 @@ type CspEnablementAccountAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCspEnablementAccountInterface instead.
 func (a *CspEnablementAccountAPI) WithImpl(impl CspEnablementAccountService) CspEnablementAccountInterface {
-	return &CspEnablementAccountAPI{
-		CspEnablementAccountService: impl,
-	}
+	a.CspEnablementAccountService = impl
+	return a
 }
 
 // Impl returns low-level CspEnablementAccount API implementation
@@ -689,9 +680,8 @@ type DefaultNamespaceAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDefaultNamespaceInterface instead.
 func (a *DefaultNamespaceAPI) WithImpl(impl DefaultNamespaceService) DefaultNamespaceInterface {
-	return &DefaultNamespaceAPI{
-		DefaultNamespaceService: impl,
-	}
+	a.DefaultNamespaceService = impl
+	return a
 }
 
 // Impl returns low-level DefaultNamespace API implementation
@@ -750,9 +740,8 @@ type EnhancedSecurityMonitoringAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockEnhancedSecurityMonitoringInterface instead.
 func (a *EnhancedSecurityMonitoringAPI) WithImpl(impl EnhancedSecurityMonitoringService) EnhancedSecurityMonitoringInterface {
-	return &EnhancedSecurityMonitoringAPI{
-		EnhancedSecurityMonitoringService: impl,
-	}
+	a.EnhancedSecurityMonitoringService = impl
+	return a
 }
 
 // Impl returns low-level EnhancedSecurityMonitoring API implementation
@@ -806,9 +795,8 @@ type EsmEnablementAccountAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockEsmEnablementAccountInterface instead.
 func (a *EsmEnablementAccountAPI) WithImpl(impl EsmEnablementAccountService) EsmEnablementAccountInterface {
-	return &EsmEnablementAccountAPI{
-		EsmEnablementAccountService: impl,
-	}
+	a.EsmEnablementAccountService = impl
+	return a
 }
 
 // Impl returns low-level EsmEnablementAccount API implementation
@@ -976,9 +964,8 @@ type IpAccessListsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockIpAccessListsInterface instead.
 func (a *IpAccessListsAPI) WithImpl(impl IpAccessListsService) IpAccessListsInterface {
-	return &IpAccessListsAPI{
-		IpAccessListsService: impl,
-	}
+	a.IpAccessListsService = impl
+	return a
 }
 
 // Impl returns low-level IpAccessLists API implementation
@@ -1223,9 +1210,8 @@ type NetworkConnectivityAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockNetworkConnectivityInterface instead.
 func (a *NetworkConnectivityAPI) WithImpl(impl NetworkConnectivityService) NetworkConnectivityInterface {
-	return &NetworkConnectivityAPI{
-		NetworkConnectivityService: impl,
-	}
+	a.NetworkConnectivityService = impl
+	return a
 }
 
 // Impl returns low-level NetworkConnectivity API implementation
@@ -1443,9 +1429,8 @@ type NotificationDestinationsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockNotificationDestinationsInterface instead.
 func (a *NotificationDestinationsAPI) WithImpl(impl NotificationDestinationsService) NotificationDestinationsInterface {
-	return &NotificationDestinationsAPI{
-		NotificationDestinationsService: impl,
-	}
+	a.NotificationDestinationsService = impl
+	return a
 }
 
 // Impl returns low-level NotificationDestinations API implementation
@@ -1564,9 +1549,8 @@ type PersonalComputeAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockPersonalComputeInterface instead.
 func (a *PersonalComputeAPI) WithImpl(impl PersonalComputeService) PersonalComputeInterface {
-	return &PersonalComputeAPI{
-		PersonalComputeService: impl,
-	}
+	a.PersonalComputeService = impl
+	return a
 }
 
 // Impl returns low-level PersonalCompute API implementation
@@ -1640,9 +1624,8 @@ type RestrictWorkspaceAdminsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRestrictWorkspaceAdminsInterface instead.
 func (a *RestrictWorkspaceAdminsAPI) WithImpl(impl RestrictWorkspaceAdminsService) RestrictWorkspaceAdminsInterface {
-	return &RestrictWorkspaceAdminsAPI{
-		RestrictWorkspaceAdminsService: impl,
-	}
+	a.RestrictWorkspaceAdminsService = impl
+	return a
 }
 
 // Impl returns low-level RestrictWorkspaceAdmins API implementation
@@ -1812,14 +1795,8 @@ func (a *SettingsAPI) RestrictWorkspaceAdmins() RestrictWorkspaceAdminsInterface
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSettingsInterface instead.
 func (a *SettingsAPI) WithImpl(impl SettingsService) SettingsInterface {
-	return &SettingsAPI{
-		SettingsService:            impl,
-		automaticClusterUpdate:     a.automaticClusterUpdate,
-		complianceSecurityProfile:  a.complianceSecurityProfile,
-		defaultNamespace:           a.defaultNamespace,
-		enhancedSecurityMonitoring: a.enhancedSecurityMonitoring,
-		restrictWorkspaceAdmins:    a.restrictWorkspaceAdmins,
-	}
+	a.SettingsService = impl
+	return a
 }
 
 // Impl returns low-level Settings API implementation
@@ -1940,9 +1917,8 @@ type TokenManagementAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTokenManagementInterface instead.
 func (a *TokenManagementAPI) WithImpl(impl TokenManagementService) TokenManagementInterface {
-	return &TokenManagementAPI{
-		TokenManagementService: impl,
-	}
+	a.TokenManagementService = impl
+	return a
 }
 
 // Impl returns low-level TokenManagement API implementation
@@ -2142,9 +2118,8 @@ type TokensAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockTokensInterface instead.
 func (a *TokensAPI) WithImpl(impl TokensService) TokensInterface {
-	return &TokensAPI{
-		TokensService: impl,
-	}
+	a.TokensService = impl
+	return a
 }
 
 // Impl returns low-level Tokens API implementation
@@ -2293,9 +2268,8 @@ type WorkspaceConfAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceConfInterface instead.
 func (a *WorkspaceConfAPI) WithImpl(impl WorkspaceConfService) WorkspaceConfInterface {
-	return &WorkspaceConfAPI{
-		WorkspaceConfService: impl,
-	}
+	a.WorkspaceConfService = impl
+	return a
 }
 
 // Impl returns low-level WorkspaceConf API implementation

--- a/service/sharing/api.go
+++ b/service/sharing/api.go
@@ -115,9 +115,8 @@ type CleanRoomsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCleanRoomsInterface instead.
 func (a *CleanRoomsAPI) WithImpl(impl CleanRoomsService) CleanRoomsInterface {
-	return &CleanRoomsAPI{
-		CleanRoomsService: impl,
-	}
+	a.CleanRoomsService = impl
+	return a
 }
 
 // Impl returns low-level CleanRooms API implementation
@@ -316,9 +315,8 @@ type ProvidersAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProvidersInterface instead.
 func (a *ProvidersAPI) WithImpl(impl ProvidersService) ProvidersInterface {
-	return &ProvidersAPI{
-		ProvidersService: impl,
-	}
+	a.ProvidersService = impl
+	return a
 }
 
 // Impl returns low-level Providers API implementation
@@ -528,9 +526,8 @@ type RecipientActivationAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRecipientActivationInterface instead.
 func (a *RecipientActivationAPI) WithImpl(impl RecipientActivationService) RecipientActivationInterface {
-	return &RecipientActivationAPI{
-		RecipientActivationService: impl,
-	}
+	a.RecipientActivationService = impl
+	return a
 }
 
 // Impl returns low-level RecipientActivation API implementation
@@ -692,9 +689,8 @@ type RecipientsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRecipientsInterface instead.
 func (a *RecipientsAPI) WithImpl(impl RecipientsService) RecipientsInterface {
-	return &RecipientsAPI{
-		RecipientsService: impl,
-	}
+	a.RecipientsService = impl
+	return a
 }
 
 // Impl returns low-level Recipients API implementation
@@ -931,9 +927,8 @@ type SharesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSharesInterface instead.
 func (a *SharesAPI) WithImpl(impl SharesService) SharesInterface {
-	return &SharesAPI{
-		SharesService: impl,
-	}
+	a.SharesService = impl
+	return a
 }
 
 // Impl returns low-level Shares API implementation

--- a/service/sharing/api.go
+++ b/service/sharing/api.go
@@ -93,7 +93,7 @@ type CleanRoomsInterface interface {
 
 func NewCleanRooms(client *client.DatabricksClient) *CleanRoomsAPI {
 	return &CleanRoomsAPI{
-		impl: &cleanRoomsImpl{
+		CleanRoomsService: &cleanRoomsImpl{
 			client: client,
 		},
 	}
@@ -108,37 +108,22 @@ func NewCleanRooms(client *client.DatabricksClient) *CleanRoomsAPI {
 type CleanRoomsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(CleanRoomsService)
-	impl CleanRoomsService
+	CleanRoomsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockCleanRoomsInterface instead.
 func (a *CleanRoomsAPI) WithImpl(impl CleanRoomsService) CleanRoomsInterface {
-	a.impl = impl
-	return a
+	return &CleanRoomsAPI{
+		CleanRoomsService: impl,
+	}
 }
 
 // Impl returns low-level CleanRooms API implementation
 // Deprecated: use MockCleanRoomsInterface instead.
 func (a *CleanRoomsAPI) Impl() CleanRoomsService {
-	return a.impl
-}
-
-// Create a clean room.
-//
-// Creates a new clean room with specified colaborators. The caller must be a
-// metastore admin or have the **CREATE_CLEAN_ROOM** privilege on the metastore.
-func (a *CleanRoomsAPI) Create(ctx context.Context, request CreateCleanRoom) (*CleanRoomInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a clean room.
-//
-// Deletes a data object clean room from the metastore. The caller must be an
-// owner of the clean room.
-func (a *CleanRoomsAPI) Delete(ctx context.Context, request DeleteCleanRoomRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.CleanRoomsService
 }
 
 // Delete a clean room.
@@ -146,7 +131,7 @@ func (a *CleanRoomsAPI) Delete(ctx context.Context, request DeleteCleanRoomReque
 // Deletes a data object clean room from the metastore. The caller must be an
 // owner of the clean room.
 func (a *CleanRoomsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteCleanRoomRequest{
+	return a.CleanRoomsService.Delete(ctx, DeleteCleanRoomRequest{
 		Name: name,
 	})
 }
@@ -155,16 +140,8 @@ func (a *CleanRoomsAPI) DeleteByName(ctx context.Context, name string) error {
 //
 // Gets a data object clean room from the metastore. The caller must be a
 // metastore admin or the owner of the clean room.
-func (a *CleanRoomsAPI) Get(ctx context.Context, request GetCleanRoomRequest) (*CleanRoomInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a clean room.
-//
-// Gets a data object clean room from the metastore. The caller must be a
-// metastore admin or the owner of the clean room.
 func (a *CleanRoomsAPI) GetByName(ctx context.Context, name string) (*CleanRoomInfo, error) {
-	return a.impl.Get(ctx, GetCleanRoomRequest{
+	return a.CleanRoomsService.Get(ctx, GetCleanRoomRequest{
 		Name: name,
 	})
 }
@@ -180,7 +157,7 @@ func (a *CleanRoomsAPI) List(ctx context.Context, request ListCleanRoomsRequest)
 
 	getNextPage := func(ctx context.Context, req ListCleanRoomsRequest) (*ListCleanRoomsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.CleanRoomsService.List(ctx, req)
 	}
 	getItems := func(resp *ListCleanRoomsResponse) []CleanRoomInfo {
 		return resp.CleanRooms
@@ -211,27 +188,6 @@ func (a *CleanRoomsAPI) ListAll(ctx context.Context, request ListCleanRoomsReque
 	iterator := a.List(ctx, request)
 	return listing.ToSliceN[CleanRoomInfo, int](ctx, iterator, request.MaxResults)
 
-}
-
-// Update a clean room.
-//
-// Updates the clean room with the changes and data objects in the request. The
-// caller must be the owner of the clean room or a metastore admin.
-//
-// When the caller is a metastore admin, only the __owner__ field can be
-// updated.
-//
-// In the case that the clean room name is changed **updateCleanRoom** requires
-// that the caller is both the clean room owner and a metastore admin.
-//
-// For each table that is added through this method, the clean room owner must
-// also have **SELECT** privilege on the table. The privilege must be maintained
-// indefinitely for recipients to be able to access the table. Typically, you
-// should use a group as the clean room owner.
-//
-// Table removals through **update** do not require additional privileges.
-func (a *CleanRoomsAPI) Update(ctx context.Context, request UpdateCleanRoom) (*CleanRoomInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type ProvidersInterface interface {
@@ -341,7 +297,7 @@ type ProvidersInterface interface {
 
 func NewProviders(client *client.DatabricksClient) *ProvidersAPI {
 	return &ProvidersAPI{
-		impl: &providersImpl{
+		ProvidersService: &providersImpl{
 			client: client,
 		},
 	}
@@ -353,37 +309,22 @@ func NewProviders(client *client.DatabricksClient) *ProvidersAPI {
 type ProvidersAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ProvidersService)
-	impl ProvidersService
+	ProvidersService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockProvidersInterface instead.
 func (a *ProvidersAPI) WithImpl(impl ProvidersService) ProvidersInterface {
-	a.impl = impl
-	return a
+	return &ProvidersAPI{
+		ProvidersService: impl,
+	}
 }
 
 // Impl returns low-level Providers API implementation
 // Deprecated: use MockProvidersInterface instead.
 func (a *ProvidersAPI) Impl() ProvidersService {
-	return a.impl
-}
-
-// Create an auth provider.
-//
-// Creates a new authentication provider minimally based on a name and
-// authentication type. The caller must be an admin on the metastore.
-func (a *ProvidersAPI) Create(ctx context.Context, request CreateProvider) (*ProviderInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a provider.
-//
-// Deletes an authentication provider, if the caller is a metastore admin or is
-// the owner of the provider.
-func (a *ProvidersAPI) Delete(ctx context.Context, request DeleteProviderRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ProvidersService
 }
 
 // Delete a provider.
@@ -391,7 +332,7 @@ func (a *ProvidersAPI) Delete(ctx context.Context, request DeleteProviderRequest
 // Deletes an authentication provider, if the caller is a metastore admin or is
 // the owner of the provider.
 func (a *ProvidersAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteProviderRequest{
+	return a.ProvidersService.Delete(ctx, DeleteProviderRequest{
 		Name: name,
 	})
 }
@@ -401,17 +342,8 @@ func (a *ProvidersAPI) DeleteByName(ctx context.Context, name string) error {
 // Gets a specific authentication provider. The caller must supply the name of
 // the provider, and must either be a metastore admin or the owner of the
 // provider.
-func (a *ProvidersAPI) Get(ctx context.Context, request GetProviderRequest) (*ProviderInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a provider.
-//
-// Gets a specific authentication provider. The caller must supply the name of
-// the provider, and must either be a metastore admin or the owner of the
-// provider.
 func (a *ProvidersAPI) GetByName(ctx context.Context, name string) (*ProviderInfo, error) {
-	return a.impl.Get(ctx, GetProviderRequest{
+	return a.ProvidersService.Get(ctx, GetProviderRequest{
 		Name: name,
 	})
 }
@@ -428,7 +360,7 @@ func (a *ProvidersAPI) List(ctx context.Context, request ListProvidersRequest) l
 
 	getNextPage := func(ctx context.Context, req ListProvidersRequest) (*ListProvidersResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ProvidersService.List(ctx, req)
 	}
 	getItems := func(resp *ListProvidersResponse) []ProviderInfo {
 		return resp.Providers
@@ -498,7 +430,7 @@ func (a *ProvidersAPI) ListShares(ctx context.Context, request ListSharesRequest
 
 	getNextPage := func(ctx context.Context, req ListSharesRequest) (*ListProviderSharesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListShares(ctx, req)
+		return a.ProvidersService.ListShares(ctx, req)
 	}
 	getItems := func(resp *ListProviderSharesResponse) []ProviderShare {
 		return resp.Shares
@@ -530,19 +462,9 @@ func (a *ProvidersAPI) ListSharesAll(ctx context.Context, request ListSharesRequ
 //
 // * the caller is a metastore admin, or * the caller is the owner.
 func (a *ProvidersAPI) ListSharesByName(ctx context.Context, name string) (*ListProviderSharesResponse, error) {
-	return a.impl.ListShares(ctx, ListSharesRequest{
+	return a.ProvidersService.ListShares(ctx, ListSharesRequest{
 		Name: name,
 	})
-}
-
-// Update a provider.
-//
-// Updates the information for an authentication provider, if the caller is a
-// metastore admin or is the owner of the provider. If the update changes the
-// provider name, the caller must be both a metastore admin and the owner of the
-// provider.
-func (a *ProvidersAPI) Update(ctx context.Context, request UpdateProvider) (*ProviderInfo, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type RecipientActivationInterface interface {
@@ -580,7 +502,7 @@ type RecipientActivationInterface interface {
 
 func NewRecipientActivation(client *client.DatabricksClient) *RecipientActivationAPI {
 	return &RecipientActivationAPI{
-		impl: &recipientActivationImpl{
+		RecipientActivationService: &recipientActivationImpl{
 			client: client,
 		},
 	}
@@ -599,35 +521,29 @@ func NewRecipientActivation(client *client.DatabricksClient) *RecipientActivatio
 type RecipientActivationAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(RecipientActivationService)
-	impl RecipientActivationService
+	RecipientActivationService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRecipientActivationInterface instead.
 func (a *RecipientActivationAPI) WithImpl(impl RecipientActivationService) RecipientActivationInterface {
-	a.impl = impl
-	return a
+	return &RecipientActivationAPI{
+		RecipientActivationService: impl,
+	}
 }
 
 // Impl returns low-level RecipientActivation API implementation
 // Deprecated: use MockRecipientActivationInterface instead.
 func (a *RecipientActivationAPI) Impl() RecipientActivationService {
-	return a.impl
-}
-
-// Get a share activation URL.
-//
-// Gets an activation URL for a share.
-func (a *RecipientActivationAPI) GetActivationUrlInfo(ctx context.Context, request GetActivationUrlInfoRequest) error {
-	return a.impl.GetActivationUrlInfo(ctx, request)
+	return a.RecipientActivationService
 }
 
 // Get a share activation URL.
 //
 // Gets an activation URL for a share.
 func (a *RecipientActivationAPI) GetActivationUrlInfoByActivationUrl(ctx context.Context, activationUrl string) error {
-	return a.impl.GetActivationUrlInfo(ctx, GetActivationUrlInfoRequest{
+	return a.RecipientActivationService.GetActivationUrlInfo(ctx, GetActivationUrlInfoRequest{
 		ActivationUrl: activationUrl,
 	})
 }
@@ -636,16 +552,8 @@ func (a *RecipientActivationAPI) GetActivationUrlInfoByActivationUrl(ctx context
 //
 // Retrieve access token with an activation url. This is a public API without
 // any authentication.
-func (a *RecipientActivationAPI) RetrieveToken(ctx context.Context, request RetrieveTokenRequest) (*RetrieveTokenResponse, error) {
-	return a.impl.RetrieveToken(ctx, request)
-}
-
-// Get an access token.
-//
-// Retrieve access token with an activation url. This is a public API without
-// any authentication.
 func (a *RecipientActivationAPI) RetrieveTokenByActivationUrl(ctx context.Context, activationUrl string) (*RetrieveTokenResponse, error) {
-	return a.impl.RetrieveToken(ctx, RetrieveTokenRequest{
+	return a.RecipientActivationService.RetrieveToken(ctx, RetrieveTokenRequest{
 		ActivationUrl: activationUrl,
 	})
 }
@@ -751,7 +659,7 @@ type RecipientsInterface interface {
 
 func NewRecipients(client *client.DatabricksClient) *RecipientsAPI {
 	return &RecipientsAPI{
-		impl: &recipientsImpl{
+		RecipientsService: &recipientsImpl{
 			client: client,
 		},
 	}
@@ -777,38 +685,22 @@ func NewRecipients(client *client.DatabricksClient) *RecipientsAPI {
 type RecipientsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(RecipientsService)
-	impl RecipientsService
+	RecipientsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockRecipientsInterface instead.
 func (a *RecipientsAPI) WithImpl(impl RecipientsService) RecipientsInterface {
-	a.impl = impl
-	return a
+	return &RecipientsAPI{
+		RecipientsService: impl,
+	}
 }
 
 // Impl returns low-level Recipients API implementation
 // Deprecated: use MockRecipientsInterface instead.
 func (a *RecipientsAPI) Impl() RecipientsService {
-	return a.impl
-}
-
-// Create a share recipient.
-//
-// Creates a new recipient with the delta sharing authentication type in the
-// metastore. The caller must be a metastore admin or has the
-// **CREATE_RECIPIENT** privilege on the metastore.
-func (a *RecipientsAPI) Create(ctx context.Context, request CreateRecipient) (*RecipientInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a share recipient.
-//
-// Deletes the specified recipient from the metastore. The caller must be the
-// owner of the recipient.
-func (a *RecipientsAPI) Delete(ctx context.Context, request DeleteRecipientRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.RecipientsService
 }
 
 // Delete a share recipient.
@@ -816,7 +708,7 @@ func (a *RecipientsAPI) Delete(ctx context.Context, request DeleteRecipientReque
 // Deletes the specified recipient from the metastore. The caller must be the
 // owner of the recipient.
 func (a *RecipientsAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteRecipientRequest{
+	return a.RecipientsService.Delete(ctx, DeleteRecipientRequest{
 		Name: name,
 	})
 }
@@ -826,17 +718,8 @@ func (a *RecipientsAPI) DeleteByName(ctx context.Context, name string) error {
 // Gets a share recipient from the metastore if:
 //
 // * the caller is the owner of the share recipient, or: * is a metastore admin
-func (a *RecipientsAPI) Get(ctx context.Context, request GetRecipientRequest) (*RecipientInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a share recipient.
-//
-// Gets a share recipient from the metastore if:
-//
-// * the caller is the owner of the share recipient, or: * is a metastore admin
 func (a *RecipientsAPI) GetByName(ctx context.Context, name string) (*RecipientInfo, error) {
-	return a.impl.Get(ctx, GetRecipientRequest{
+	return a.RecipientsService.Get(ctx, GetRecipientRequest{
 		Name: name,
 	})
 }
@@ -853,7 +736,7 @@ func (a *RecipientsAPI) List(ctx context.Context, request ListRecipientsRequest)
 
 	getNextPage := func(ctx context.Context, req ListRecipientsRequest) (*ListRecipientsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.RecipientsService.List(ctx, req)
 	}
 	getItems := func(resp *ListRecipientsResponse) []RecipientInfo {
 		return resp.Recipients
@@ -912,40 +795,14 @@ func (a *RecipientsAPI) RecipientInfoNameToMetastoreIdMap(ctx context.Context, r
 	return mapping, nil
 }
 
-// Rotate a token.
-//
-// Refreshes the specified recipient's delta sharing authentication token with
-// the provided token info. The caller must be the owner of the recipient.
-func (a *RecipientsAPI) RotateToken(ctx context.Context, request RotateRecipientToken) (*RecipientInfo, error) {
-	return a.impl.RotateToken(ctx, request)
-}
-
-// Get recipient share permissions.
-//
-// Gets the share permissions for the specified Recipient. The caller must be a
-// metastore admin or the owner of the Recipient.
-func (a *RecipientsAPI) SharePermissions(ctx context.Context, request SharePermissionsRequest) (*GetRecipientSharePermissionsResponse, error) {
-	return a.impl.SharePermissions(ctx, request)
-}
-
 // Get recipient share permissions.
 //
 // Gets the share permissions for the specified Recipient. The caller must be a
 // metastore admin or the owner of the Recipient.
 func (a *RecipientsAPI) SharePermissionsByName(ctx context.Context, name string) (*GetRecipientSharePermissionsResponse, error) {
-	return a.impl.SharePermissions(ctx, SharePermissionsRequest{
+	return a.RecipientsService.SharePermissions(ctx, SharePermissionsRequest{
 		Name: name,
 	})
-}
-
-// Update a share recipient.
-//
-// Updates an existing recipient in the metastore. The caller must be a
-// metastore admin or the owner of the recipient. If the recipient name will be
-// updated, the user must be both a metastore admin and the owner of the
-// recipient.
-func (a *RecipientsAPI) Update(ctx context.Context, request UpdateRecipient) error {
-	return a.impl.Update(ctx, request)
 }
 
 type SharesInterface interface {
@@ -1053,7 +910,7 @@ type SharesInterface interface {
 
 func NewShares(client *client.DatabricksClient) *SharesAPI {
 	return &SharesAPI{
-		impl: &sharesImpl{
+		SharesService: &sharesImpl{
 			client: client,
 		},
 	}
@@ -1067,38 +924,22 @@ func NewShares(client *client.DatabricksClient) *SharesAPI {
 type SharesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(SharesService)
-	impl SharesService
+	SharesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSharesInterface instead.
 func (a *SharesAPI) WithImpl(impl SharesService) SharesInterface {
-	a.impl = impl
-	return a
+	return &SharesAPI{
+		SharesService: impl,
+	}
 }
 
 // Impl returns low-level Shares API implementation
 // Deprecated: use MockSharesInterface instead.
 func (a *SharesAPI) Impl() SharesService {
-	return a.impl
-}
-
-// Create a share.
-//
-// Creates a new share for data objects. Data objects can be added after
-// creation with **update**. The caller must be a metastore admin or have the
-// **CREATE_SHARE** privilege on the metastore.
-func (a *SharesAPI) Create(ctx context.Context, request CreateShare) (*ShareInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a share.
-//
-// Deletes a data object share from the metastore. The caller must be an owner
-// of the share.
-func (a *SharesAPI) Delete(ctx context.Context, request DeleteShareRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.SharesService
 }
 
 // Delete a share.
@@ -1106,7 +947,7 @@ func (a *SharesAPI) Delete(ctx context.Context, request DeleteShareRequest) erro
 // Deletes a data object share from the metastore. The caller must be an owner
 // of the share.
 func (a *SharesAPI) DeleteByName(ctx context.Context, name string) error {
-	return a.impl.Delete(ctx, DeleteShareRequest{
+	return a.SharesService.Delete(ctx, DeleteShareRequest{
 		Name: name,
 	})
 }
@@ -1115,16 +956,8 @@ func (a *SharesAPI) DeleteByName(ctx context.Context, name string) error {
 //
 // Gets a data object share from the metastore. The caller must be a metastore
 // admin or the owner of the share.
-func (a *SharesAPI) Get(ctx context.Context, request GetShareRequest) (*ShareInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a share.
-//
-// Gets a data object share from the metastore. The caller must be a metastore
-// admin or the owner of the share.
 func (a *SharesAPI) GetByName(ctx context.Context, name string) (*ShareInfo, error) {
-	return a.impl.Get(ctx, GetShareRequest{
+	return a.SharesService.Get(ctx, GetShareRequest{
 		Name: name,
 	})
 }
@@ -1140,7 +973,7 @@ func (a *SharesAPI) List(ctx context.Context, request ListSharesRequest) listing
 
 	getNextPage := func(ctx context.Context, req ListSharesRequest) (*ListSharesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.SharesService.List(ctx, req)
 	}
 	getItems := func(resp *ListSharesResponse) []ShareInfo {
 		return resp.Shares
@@ -1177,51 +1010,8 @@ func (a *SharesAPI) ListAll(ctx context.Context, request ListSharesRequest) ([]S
 //
 // Gets the permissions for a data share from the metastore. The caller must be
 // a metastore admin or the owner of the share.
-func (a *SharesAPI) SharePermissions(ctx context.Context, request SharePermissionsRequest) (*catalog.PermissionsList, error) {
-	return a.impl.SharePermissions(ctx, request)
-}
-
-// Get permissions.
-//
-// Gets the permissions for a data share from the metastore. The caller must be
-// a metastore admin or the owner of the share.
 func (a *SharesAPI) SharePermissionsByName(ctx context.Context, name string) (*catalog.PermissionsList, error) {
-	return a.impl.SharePermissions(ctx, SharePermissionsRequest{
+	return a.SharesService.SharePermissions(ctx, SharePermissionsRequest{
 		Name: name,
 	})
-}
-
-// Update a share.
-//
-// Updates the share with the changes and data objects in the request. The
-// caller must be the owner of the share or a metastore admin.
-//
-// When the caller is a metastore admin, only the __owner__ field can be
-// updated.
-//
-// In the case that the share name is changed, **updateShare** requires that the
-// caller is both the share owner and a metastore admin.
-//
-// If there are notebook files in the share, the __storage_root__ field cannot
-// be updated.
-//
-// For each table that is added through this method, the share owner must also
-// have **SELECT** privilege on the table. This privilege must be maintained
-// indefinitely for recipients to be able to access the table. Typically, you
-// should use a group as the share owner.
-//
-// Table removals through **update** do not require additional privileges.
-func (a *SharesAPI) Update(ctx context.Context, request UpdateShare) (*ShareInfo, error) {
-	return a.impl.Update(ctx, request)
-}
-
-// Update permissions.
-//
-// Updates the permissions for a data share in the metastore. The caller must be
-// a metastore admin or an owner of the share.
-//
-// For new recipient grants, the user must also be the owner of the recipients.
-// recipient revocations do not require additional privileges.
-func (a *SharesAPI) UpdatePermissions(ctx context.Context, request UpdateSharePermissions) error {
-	return a.impl.UpdatePermissions(ctx, request)
 }

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -118,9 +118,8 @@ type AlertsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAlertsInterface instead.
 func (a *AlertsAPI) WithImpl(impl AlertsService) AlertsInterface {
-	return &AlertsAPI{
-		AlertsService: impl,
-	}
+	a.AlertsService = impl
+	return a
 }
 
 // Impl returns low-level Alerts API implementation
@@ -362,9 +361,8 @@ type AlertsLegacyAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAlertsLegacyInterface instead.
 func (a *AlertsLegacyAPI) WithImpl(impl AlertsLegacyService) AlertsLegacyInterface {
-	return &AlertsLegacyAPI{
-		AlertsLegacyService: impl,
-	}
+	a.AlertsLegacyService = impl
+	return a
 }
 
 // Impl returns low-level AlertsLegacy API implementation
@@ -496,9 +494,8 @@ type DashboardWidgetsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDashboardWidgetsInterface instead.
 func (a *DashboardWidgetsAPI) WithImpl(impl DashboardWidgetsService) DashboardWidgetsInterface {
-	return &DashboardWidgetsAPI{
-		DashboardWidgetsService: impl,
-	}
+	a.DashboardWidgetsService = impl
+	return a
 }
 
 // Impl returns low-level DashboardWidgets API implementation
@@ -627,9 +624,8 @@ type DashboardsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDashboardsInterface instead.
 func (a *DashboardsAPI) WithImpl(impl DashboardsService) DashboardsInterface {
-	return &DashboardsAPI{
-		DashboardsService: impl,
-	}
+	a.DashboardsService = impl
+	return a
 }
 
 // Impl returns low-level Dashboards API implementation
@@ -834,9 +830,8 @@ type DataSourcesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDataSourcesInterface instead.
 func (a *DataSourcesAPI) WithImpl(impl DataSourcesService) DataSourcesInterface {
-	return &DataSourcesAPI{
-		DataSourcesService: impl,
-	}
+	a.DataSourcesService = impl
+	return a
 }
 
 // Impl returns low-level DataSources API implementation
@@ -971,9 +966,8 @@ type DbsqlPermissionsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDbsqlPermissionsInterface instead.
 func (a *DbsqlPermissionsAPI) WithImpl(impl DbsqlPermissionsService) DbsqlPermissionsInterface {
-	return &DbsqlPermissionsAPI{
-		DbsqlPermissionsService: impl,
-	}
+	a.DbsqlPermissionsService = impl
+	return a
 }
 
 // Impl returns low-level DbsqlPermissions API implementation
@@ -1117,9 +1111,8 @@ type QueriesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueriesInterface instead.
 func (a *QueriesAPI) WithImpl(impl QueriesService) QueriesInterface {
-	return &QueriesAPI{
-		QueriesService: impl,
-	}
+	a.QueriesService = impl
+	return a
 }
 
 // Impl returns low-level Queries API implementation
@@ -1448,9 +1441,8 @@ type QueriesLegacyAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueriesLegacyInterface instead.
 func (a *QueriesLegacyAPI) WithImpl(impl QueriesLegacyService) QueriesLegacyInterface {
-	return &QueriesLegacyAPI{
-		QueriesLegacyService: impl,
-	}
+	a.QueriesLegacyService = impl
+	return a
 }
 
 // Impl returns low-level QueriesLegacy API implementation
@@ -1642,9 +1634,8 @@ type QueryHistoryAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueryHistoryInterface instead.
 func (a *QueryHistoryAPI) WithImpl(impl QueryHistoryService) QueryHistoryInterface {
-	return &QueryHistoryAPI{
-		QueryHistoryService: impl,
-	}
+	a.QueryHistoryService = impl
+	return a
 }
 
 // Impl returns low-level QueryHistory API implementation
@@ -1705,9 +1696,8 @@ type QueryVisualizationsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueryVisualizationsInterface instead.
 func (a *QueryVisualizationsAPI) WithImpl(impl QueryVisualizationsService) QueryVisualizationsInterface {
-	return &QueryVisualizationsAPI{
-		QueryVisualizationsService: impl,
-	}
+	a.QueryVisualizationsService = impl
+	return a
 }
 
 // Impl returns low-level QueryVisualizations API implementation
@@ -1792,9 +1782,8 @@ type QueryVisualizationsLegacyAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueryVisualizationsLegacyInterface instead.
 func (a *QueryVisualizationsLegacyAPI) WithImpl(impl QueryVisualizationsLegacyService) QueryVisualizationsLegacyInterface {
-	return &QueryVisualizationsLegacyAPI{
-		QueryVisualizationsLegacyService: impl,
-	}
+	a.QueryVisualizationsLegacyService = impl
+	return a
 }
 
 // Impl returns low-level QueryVisualizationsLegacy API implementation
@@ -2007,9 +1996,8 @@ type StatementExecutionAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockStatementExecutionInterface instead.
 func (a *StatementExecutionAPI) WithImpl(impl StatementExecutionService) StatementExecutionInterface {
-	return &StatementExecutionAPI{
-		StatementExecutionService: impl,
-	}
+	a.StatementExecutionService = impl
+	return a
 }
 
 // Impl returns low-level StatementExecution API implementation
@@ -2242,9 +2230,8 @@ type WarehousesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWarehousesInterface instead.
 func (a *WarehousesAPI) WithImpl(impl WarehousesService) WarehousesInterface {
-	return &WarehousesAPI{
-		WarehousesService: impl,
-	}
+	a.WarehousesService = impl
+	return a
 }
 
 // Impl returns low-level Warehouses API implementation

--- a/service/sql/api.go
+++ b/service/sql/api.go
@@ -97,7 +97,7 @@ type AlertsInterface interface {
 
 func NewAlerts(client *client.DatabricksClient) *AlertsAPI {
 	return &AlertsAPI{
-		impl: &alertsImpl{
+		AlertsService: &alertsImpl{
 			client: client,
 		},
 	}
@@ -111,37 +111,22 @@ func NewAlerts(client *client.DatabricksClient) *AlertsAPI {
 type AlertsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AlertsService)
-	impl AlertsService
+	AlertsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAlertsInterface instead.
 func (a *AlertsAPI) WithImpl(impl AlertsService) AlertsInterface {
-	a.impl = impl
-	return a
+	return &AlertsAPI{
+		AlertsService: impl,
+	}
 }
 
 // Impl returns low-level Alerts API implementation
 // Deprecated: use MockAlertsInterface instead.
 func (a *AlertsAPI) Impl() AlertsService {
-	return a.impl
-}
-
-// Create an alert.
-//
-// Creates an alert.
-func (a *AlertsAPI) Create(ctx context.Context, request CreateAlertRequest) (*Alert, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an alert.
-//
-// Moves an alert to the trash. Trashed alerts immediately disappear from
-// searches and list views, and can no longer trigger. You can restore a trashed
-// alert through the UI. A trashed alert is permanently deleted after 30 days.
-func (a *AlertsAPI) Delete(ctx context.Context, request TrashAlertRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AlertsService
 }
 
 // Delete an alert.
@@ -150,7 +135,7 @@ func (a *AlertsAPI) Delete(ctx context.Context, request TrashAlertRequest) error
 // searches and list views, and can no longer trigger. You can restore a trashed
 // alert through the UI. A trashed alert is permanently deleted after 30 days.
 func (a *AlertsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, TrashAlertRequest{
+	return a.AlertsService.Delete(ctx, TrashAlertRequest{
 		Id: id,
 	})
 }
@@ -158,15 +143,8 @@ func (a *AlertsAPI) DeleteById(ctx context.Context, id string) error {
 // Get an alert.
 //
 // Gets an alert.
-func (a *AlertsAPI) Get(ctx context.Context, request GetAlertRequest) (*Alert, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get an alert.
-//
-// Gets an alert.
 func (a *AlertsAPI) GetById(ctx context.Context, id string) (*Alert, error) {
-	return a.impl.Get(ctx, GetAlertRequest{
+	return a.AlertsService.Get(ctx, GetAlertRequest{
 		Id: id,
 	})
 }
@@ -182,7 +160,7 @@ func (a *AlertsAPI) List(ctx context.Context, request ListAlertsRequest) listing
 
 	getNextPage := func(ctx context.Context, req ListAlertsRequest) (*ListAlertsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.AlertsService.List(ctx, req)
 	}
 	getItems := func(resp *ListAlertsResponse) []ListAlertsResponseAlert {
 		return resp.Results
@@ -265,13 +243,6 @@ func (a *AlertsAPI) GetByDisplayName(ctx context.Context, name string) (*ListAle
 		return nil, fmt.Errorf("there are %d instances of ListAlertsResponseAlert named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update an alert.
-//
-// Updates an alert.
-func (a *AlertsAPI) Update(ctx context.Context, request UpdateAlertRequest) (*Alert, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type AlertsLegacyInterface interface {
@@ -367,7 +338,7 @@ type AlertsLegacyInterface interface {
 
 func NewAlertsLegacy(client *client.DatabricksClient) *AlertsLegacyAPI {
 	return &AlertsLegacyAPI{
-		impl: &alertsLegacyImpl{
+		AlertsLegacyService: &alertsLegacyImpl{
 			client: client,
 		},
 	}
@@ -384,45 +355,22 @@ func NewAlertsLegacy(client *client.DatabricksClient) *AlertsLegacyAPI {
 type AlertsLegacyAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(AlertsLegacyService)
-	impl AlertsLegacyService
+	AlertsLegacyService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockAlertsLegacyInterface instead.
 func (a *AlertsLegacyAPI) WithImpl(impl AlertsLegacyService) AlertsLegacyInterface {
-	a.impl = impl
-	return a
+	return &AlertsLegacyAPI{
+		AlertsLegacyService: impl,
+	}
 }
 
 // Impl returns low-level AlertsLegacy API implementation
 // Deprecated: use MockAlertsLegacyInterface instead.
 func (a *AlertsLegacyAPI) Impl() AlertsLegacyService {
-	return a.impl
-}
-
-// Create an alert.
-//
-// Creates an alert. An alert is a Databricks SQL object that periodically runs
-// a query, evaluates a condition of its result, and notifies users or
-// notification destinations if the condition was met.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:alerts/create instead.
-func (a *AlertsLegacyAPI) Create(ctx context.Context, request CreateAlert) (*LegacyAlert, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete an alert.
-//
-// Deletes an alert. Deleted alerts are no longer accessible and cannot be
-// restored. **Note**: Unlike queries and dashboards, alerts cannot be moved to
-// the trash.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:alerts/delete instead.
-func (a *AlertsLegacyAPI) Delete(ctx context.Context, request DeleteAlertsLegacyRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.AlertsLegacyService
 }
 
 // Delete an alert.
@@ -434,19 +382,9 @@ func (a *AlertsLegacyAPI) Delete(ctx context.Context, request DeleteAlertsLegacy
 // **Note**: A new version of the Databricks SQL API is now available. Please
 // use :method:alerts/delete instead.
 func (a *AlertsLegacyAPI) DeleteByAlertId(ctx context.Context, alertId string) error {
-	return a.impl.Delete(ctx, DeleteAlertsLegacyRequest{
+	return a.AlertsLegacyService.Delete(ctx, DeleteAlertsLegacyRequest{
 		AlertId: alertId,
 	})
-}
-
-// Get an alert.
-//
-// Gets an alert.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:alerts/get instead.
-func (a *AlertsLegacyAPI) Get(ctx context.Context, request GetAlertsLegacyRequest) (*LegacyAlert, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get an alert.
@@ -456,19 +394,9 @@ func (a *AlertsLegacyAPI) Get(ctx context.Context, request GetAlertsLegacyReques
 // **Note**: A new version of the Databricks SQL API is now available. Please
 // use :method:alerts/get instead.
 func (a *AlertsLegacyAPI) GetByAlertId(ctx context.Context, alertId string) (*LegacyAlert, error) {
-	return a.impl.Get(ctx, GetAlertsLegacyRequest{
+	return a.AlertsLegacyService.Get(ctx, GetAlertsLegacyRequest{
 		AlertId: alertId,
 	})
-}
-
-// Get alerts.
-//
-// Gets a list of alerts.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:alerts/list instead.
-func (a *AlertsLegacyAPI) List(ctx context.Context) ([]LegacyAlert, error) {
-	return a.impl.List(ctx)
 }
 
 // LegacyAlertNameToIdMap calls [AlertsLegacyAPI.List] and creates a map of results with [LegacyAlert].Name as key and [LegacyAlert].Id as value.
@@ -524,16 +452,6 @@ func (a *AlertsLegacyAPI) GetByName(ctx context.Context, name string) (*LegacyAl
 	return &alternatives[0], nil
 }
 
-// Update an alert.
-//
-// Updates an alert.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:alerts/update instead.
-func (a *AlertsLegacyAPI) Update(ctx context.Context, request EditAlert) error {
-	return a.impl.Update(ctx, request)
-}
-
 type DashboardWidgetsInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -559,7 +477,7 @@ type DashboardWidgetsInterface interface {
 
 func NewDashboardWidgets(client *client.DatabricksClient) *DashboardWidgetsAPI {
 	return &DashboardWidgetsAPI{
-		impl: &dashboardWidgetsImpl{
+		DashboardWidgetsService: &dashboardWidgetsImpl{
 			client: client,
 		},
 	}
@@ -571,43 +489,29 @@ func NewDashboardWidgets(client *client.DatabricksClient) *DashboardWidgetsAPI {
 type DashboardWidgetsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(DashboardWidgetsService)
-	impl DashboardWidgetsService
+	DashboardWidgetsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDashboardWidgetsInterface instead.
 func (a *DashboardWidgetsAPI) WithImpl(impl DashboardWidgetsService) DashboardWidgetsInterface {
-	a.impl = impl
-	return a
+	return &DashboardWidgetsAPI{
+		DashboardWidgetsService: impl,
+	}
 }
 
 // Impl returns low-level DashboardWidgets API implementation
 // Deprecated: use MockDashboardWidgetsInterface instead.
 func (a *DashboardWidgetsAPI) Impl() DashboardWidgetsService {
-	return a.impl
-}
-
-// Add widget to a dashboard.
-func (a *DashboardWidgetsAPI) Create(ctx context.Context, request CreateWidget) (*Widget, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Remove widget.
-func (a *DashboardWidgetsAPI) Delete(ctx context.Context, request DeleteDashboardWidgetRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.DashboardWidgetsService
 }
 
 // Remove widget.
 func (a *DashboardWidgetsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteDashboardWidgetRequest{
+	return a.DashboardWidgetsService.Delete(ctx, DeleteDashboardWidgetRequest{
 		Id: id,
 	})
-}
-
-// Update existing widget.
-func (a *DashboardWidgetsAPI) Update(ctx context.Context, request CreateWidget) (*Widget, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type DashboardsInterface interface {
@@ -701,7 +605,7 @@ type DashboardsInterface interface {
 
 func NewDashboards(client *client.DatabricksClient) *DashboardsAPI {
 	return &DashboardsAPI{
-		impl: &dashboardsImpl{
+		DashboardsService: &dashboardsImpl{
 			client: client,
 		},
 	}
@@ -716,34 +620,22 @@ func NewDashboards(client *client.DatabricksClient) *DashboardsAPI {
 type DashboardsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(DashboardsService)
-	impl DashboardsService
+	DashboardsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDashboardsInterface instead.
 func (a *DashboardsAPI) WithImpl(impl DashboardsService) DashboardsInterface {
-	a.impl = impl
-	return a
+	return &DashboardsAPI{
+		DashboardsService: impl,
+	}
 }
 
 // Impl returns low-level Dashboards API implementation
 // Deprecated: use MockDashboardsInterface instead.
 func (a *DashboardsAPI) Impl() DashboardsService {
-	return a.impl
-}
-
-// Create a dashboard object.
-func (a *DashboardsAPI) Create(ctx context.Context, request DashboardPostContent) (*Dashboard, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Remove a dashboard.
-//
-// Moves a dashboard to the trash. Trashed dashboards do not appear in list
-// views or searches, and cannot be shared.
-func (a *DashboardsAPI) Delete(ctx context.Context, request DeleteDashboardRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.DashboardsService
 }
 
 // Remove a dashboard.
@@ -751,7 +643,7 @@ func (a *DashboardsAPI) Delete(ctx context.Context, request DeleteDashboardReque
 // Moves a dashboard to the trash. Trashed dashboards do not appear in list
 // views or searches, and cannot be shared.
 func (a *DashboardsAPI) DeleteByDashboardId(ctx context.Context, dashboardId string) error {
-	return a.impl.Delete(ctx, DeleteDashboardRequest{
+	return a.DashboardsService.Delete(ctx, DeleteDashboardRequest{
 		DashboardId: dashboardId,
 	})
 }
@@ -760,16 +652,8 @@ func (a *DashboardsAPI) DeleteByDashboardId(ctx context.Context, dashboardId str
 //
 // Returns a JSON representation of a dashboard object, including its
 // visualization and query objects.
-func (a *DashboardsAPI) Get(ctx context.Context, request GetDashboardRequest) (*Dashboard, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Retrieve a definition.
-//
-// Returns a JSON representation of a dashboard object, including its
-// visualization and query objects.
 func (a *DashboardsAPI) GetByDashboardId(ctx context.Context, dashboardId string) (*Dashboard, error) {
-	return a.impl.Get(ctx, GetDashboardRequest{
+	return a.DashboardsService.Get(ctx, GetDashboardRequest{
 		DashboardId: dashboardId,
 	})
 }
@@ -788,7 +672,7 @@ func (a *DashboardsAPI) List(ctx context.Context, request ListDashboardsRequest)
 
 	getNextPage := func(ctx context.Context, req ListDashboardsRequest) (*ListResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.DashboardsService.List(ctx, req)
 	}
 	getItems := func(resp *ListResponse) []Dashboard {
 		return resp.Results
@@ -880,23 +764,6 @@ func (a *DashboardsAPI) GetByName(ctx context.Context, name string) (*Dashboard,
 	return &alternatives[0], nil
 }
 
-// Restore a dashboard.
-//
-// A restored dashboard appears in list views and searches and can be shared.
-func (a *DashboardsAPI) Restore(ctx context.Context, request RestoreDashboardRequest) error {
-	return a.impl.Restore(ctx, request)
-}
-
-// Change a dashboard definition.
-//
-// Modify this dashboard definition. This operation only affects attributes of
-// the dashboard object. It does not add, modify, or remove widgets.
-//
-// **Note**: You cannot undo this operation.
-func (a *DashboardsAPI) Update(ctx context.Context, request DashboardEditContent) (*Dashboard, error) {
-	return a.impl.Update(ctx, request)
-}
-
 type DataSourcesInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -938,7 +805,7 @@ type DataSourcesInterface interface {
 
 func NewDataSources(client *client.DatabricksClient) *DataSourcesAPI {
 	return &DataSourcesAPI{
-		impl: &dataSourcesImpl{
+		DataSourcesService: &dataSourcesImpl{
 			client: client,
 		},
 	}
@@ -960,33 +827,22 @@ func NewDataSources(client *client.DatabricksClient) *DataSourcesAPI {
 type DataSourcesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(DataSourcesService)
-	impl DataSourcesService
+	DataSourcesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDataSourcesInterface instead.
 func (a *DataSourcesAPI) WithImpl(impl DataSourcesService) DataSourcesInterface {
-	a.impl = impl
-	return a
+	return &DataSourcesAPI{
+		DataSourcesService: impl,
+	}
 }
 
 // Impl returns low-level DataSources API implementation
 // Deprecated: use MockDataSourcesInterface instead.
 func (a *DataSourcesAPI) Impl() DataSourcesService {
-	return a.impl
-}
-
-// Get a list of SQL warehouses.
-//
-// Retrieves a full list of SQL warehouses available in this workspace. All
-// fields that appear in this API response are enumerated for clarity. However,
-// you need only a SQL warehouse's `id` to create new queries against it.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:warehouses/list instead.
-func (a *DataSourcesAPI) List(ctx context.Context) ([]DataSource, error) {
-	return a.impl.List(ctx)
+	return a.DataSourcesService
 }
 
 // DataSourceNameToIdMap calls [DataSourcesAPI.List] and creates a map of results with [DataSource].Name as key and [DataSource].Id as value.
@@ -1083,7 +939,7 @@ type DbsqlPermissionsInterface interface {
 
 func NewDbsqlPermissions(client *client.DatabricksClient) *DbsqlPermissionsAPI {
 	return &DbsqlPermissionsAPI{
-		impl: &dbsqlPermissionsImpl{
+		DbsqlPermissionsService: &dbsqlPermissionsImpl{
 			client: client,
 		},
 	}
@@ -1108,29 +964,22 @@ func NewDbsqlPermissions(client *client.DatabricksClient) *DbsqlPermissionsAPI {
 type DbsqlPermissionsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(DbsqlPermissionsService)
-	impl DbsqlPermissionsService
+	DbsqlPermissionsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockDbsqlPermissionsInterface instead.
 func (a *DbsqlPermissionsAPI) WithImpl(impl DbsqlPermissionsService) DbsqlPermissionsInterface {
-	a.impl = impl
-	return a
+	return &DbsqlPermissionsAPI{
+		DbsqlPermissionsService: impl,
+	}
 }
 
 // Impl returns low-level DbsqlPermissions API implementation
 // Deprecated: use MockDbsqlPermissionsInterface instead.
 func (a *DbsqlPermissionsAPI) Impl() DbsqlPermissionsService {
-	return a.impl
-}
-
-// Get object ACL.
-//
-// Gets a JSON representation of the access control list (ACL) for a specified
-// object.
-func (a *DbsqlPermissionsAPI) Get(ctx context.Context, request GetDbsqlPermissionRequest) (*GetResponse, error) {
-	return a.impl.Get(ctx, request)
+	return a.DbsqlPermissionsService
 }
 
 // Get object ACL.
@@ -1138,30 +987,10 @@ func (a *DbsqlPermissionsAPI) Get(ctx context.Context, request GetDbsqlPermissio
 // Gets a JSON representation of the access control list (ACL) for a specified
 // object.
 func (a *DbsqlPermissionsAPI) GetByObjectTypeAndObjectId(ctx context.Context, objectType ObjectTypePlural, objectId string) (*GetResponse, error) {
-	return a.impl.Get(ctx, GetDbsqlPermissionRequest{
+	return a.DbsqlPermissionsService.Get(ctx, GetDbsqlPermissionRequest{
 		ObjectType: objectType,
 		ObjectId:   objectId,
 	})
-}
-
-// Set object ACL.
-//
-// Sets the access control list (ACL) for a specified object. This operation
-// will complete rewrite the ACL.
-func (a *DbsqlPermissionsAPI) Set(ctx context.Context, request SetRequest) (*SetResponse, error) {
-	return a.impl.Set(ctx, request)
-}
-
-// Transfer object ownership.
-//
-// Transfers ownership of a dashboard, query, or alert to an active user.
-// Requires an admin API key.
-//
-// **Note**: A new version of the Databricks SQL API is now available. For
-// queries and alerts, please use :method:queries/update and
-// :method:alerts/update respectively instead.
-func (a *DbsqlPermissionsAPI) TransferOwnership(ctx context.Context, request TransferOwnershipRequest) (*Success, error) {
-	return a.impl.TransferOwnership(ctx, request)
 }
 
 type QueriesInterface interface {
@@ -1268,7 +1097,7 @@ type QueriesInterface interface {
 
 func NewQueries(client *client.DatabricksClient) *QueriesAPI {
 	return &QueriesAPI{
-		impl: &queriesImpl{
+		QueriesService: &queriesImpl{
 			client: client,
 		},
 	}
@@ -1281,38 +1110,22 @@ func NewQueries(client *client.DatabricksClient) *QueriesAPI {
 type QueriesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(QueriesService)
-	impl QueriesService
+	QueriesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueriesInterface instead.
 func (a *QueriesAPI) WithImpl(impl QueriesService) QueriesInterface {
-	a.impl = impl
-	return a
+	return &QueriesAPI{
+		QueriesService: impl,
+	}
 }
 
 // Impl returns low-level Queries API implementation
 // Deprecated: use MockQueriesInterface instead.
 func (a *QueriesAPI) Impl() QueriesService {
-	return a.impl
-}
-
-// Create a query.
-//
-// Creates a query.
-func (a *QueriesAPI) Create(ctx context.Context, request CreateQueryRequest) (*Query, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a query.
-//
-// Moves a query to the trash. Trashed queries immediately disappear from
-// searches and list views, and cannot be used for alerts. You can restore a
-// trashed query through the UI. A trashed query is permanently deleted after 30
-// days.
-func (a *QueriesAPI) Delete(ctx context.Context, request TrashQueryRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.QueriesService
 }
 
 // Delete a query.
@@ -1322,7 +1135,7 @@ func (a *QueriesAPI) Delete(ctx context.Context, request TrashQueryRequest) erro
 // trashed query through the UI. A trashed query is permanently deleted after 30
 // days.
 func (a *QueriesAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, TrashQueryRequest{
+	return a.QueriesService.Delete(ctx, TrashQueryRequest{
 		Id: id,
 	})
 }
@@ -1330,15 +1143,8 @@ func (a *QueriesAPI) DeleteById(ctx context.Context, id string) error {
 // Get a query.
 //
 // Gets a query.
-func (a *QueriesAPI) Get(ctx context.Context, request GetQueryRequest) (*Query, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a query.
-//
-// Gets a query.
 func (a *QueriesAPI) GetById(ctx context.Context, id string) (*Query, error) {
-	return a.impl.Get(ctx, GetQueryRequest{
+	return a.QueriesService.Get(ctx, GetQueryRequest{
 		Id: id,
 	})
 }
@@ -1354,7 +1160,7 @@ func (a *QueriesAPI) List(ctx context.Context, request ListQueriesRequest) listi
 
 	getNextPage := func(ctx context.Context, req ListQueriesRequest) (*ListQueryObjectsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.QueriesService.List(ctx, req)
 	}
 	getItems := func(resp *ListQueryObjectsResponse) []ListQueryObjectsResponseQuery {
 		return resp.Results
@@ -1448,7 +1254,7 @@ func (a *QueriesAPI) ListVisualizations(ctx context.Context, request ListVisuali
 
 	getNextPage := func(ctx context.Context, req ListVisualizationsForQueryRequest) (*ListVisualizationsForQueryResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListVisualizations(ctx, req)
+		return a.QueriesService.ListVisualizations(ctx, req)
 	}
 	getItems := func(resp *ListVisualizationsForQueryResponse) []Visualization {
 		return resp.Results
@@ -1482,16 +1288,9 @@ func (a *QueriesAPI) ListVisualizationsAll(ctx context.Context, request ListVisu
 //
 // Gets a list of visualizations on a query.
 func (a *QueriesAPI) ListVisualizationsById(ctx context.Context, id string) (*ListVisualizationsForQueryResponse, error) {
-	return a.impl.ListVisualizations(ctx, ListVisualizationsForQueryRequest{
+	return a.QueriesService.ListVisualizations(ctx, ListVisualizationsForQueryRequest{
 		Id: id,
 	})
-}
-
-// Update a query.
-//
-// Updates a query.
-func (a *QueriesAPI) Update(ctx context.Context, request UpdateQueryRequest) (*Query, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type QueriesLegacyInterface interface {
@@ -1626,7 +1425,7 @@ type QueriesLegacyInterface interface {
 
 func NewQueriesLegacy(client *client.DatabricksClient) *QueriesLegacyAPI {
 	return &QueriesLegacyAPI{
-		impl: &queriesLegacyImpl{
+		QueriesLegacyService: &queriesLegacyImpl{
 			client: client,
 		},
 	}
@@ -1642,51 +1441,22 @@ func NewQueriesLegacy(client *client.DatabricksClient) *QueriesLegacyAPI {
 type QueriesLegacyAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(QueriesLegacyService)
-	impl QueriesLegacyService
+	QueriesLegacyService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueriesLegacyInterface instead.
 func (a *QueriesLegacyAPI) WithImpl(impl QueriesLegacyService) QueriesLegacyInterface {
-	a.impl = impl
-	return a
+	return &QueriesLegacyAPI{
+		QueriesLegacyService: impl,
+	}
 }
 
 // Impl returns low-level QueriesLegacy API implementation
 // Deprecated: use MockQueriesLegacyInterface instead.
 func (a *QueriesLegacyAPI) Impl() QueriesLegacyService {
-	return a.impl
-}
-
-// Create a new query definition.
-//
-// Creates a new query definition. Queries created with this endpoint belong to
-// the authenticated user making the request.
-//
-// The `data_source_id` field specifies the ID of the SQL warehouse to run this
-// query against. You can use the Data Sources API to see a complete list of
-// available SQL warehouses. Or you can copy the `data_source_id` from an
-// existing query.
-//
-// **Note**: You cannot add a visualization until you create the query.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queries/create instead.
-func (a *QueriesLegacyAPI) Create(ctx context.Context, request QueryPostContent) (*LegacyQuery, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a query.
-//
-// Moves a query to the trash. Trashed queries immediately disappear from
-// searches and list views, and they cannot be used for alerts. The trash is
-// deleted after 30 days.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queries/delete instead.
-func (a *QueriesLegacyAPI) Delete(ctx context.Context, request DeleteQueriesLegacyRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.QueriesLegacyService
 }
 
 // Delete a query.
@@ -1698,7 +1468,7 @@ func (a *QueriesLegacyAPI) Delete(ctx context.Context, request DeleteQueriesLega
 // **Note**: A new version of the Databricks SQL API is now available. Please
 // use :method:queries/delete instead.
 func (a *QueriesLegacyAPI) DeleteByQueryId(ctx context.Context, queryId string) error {
-	return a.impl.Delete(ctx, DeleteQueriesLegacyRequest{
+	return a.QueriesLegacyService.Delete(ctx, DeleteQueriesLegacyRequest{
 		QueryId: queryId,
 	})
 }
@@ -1710,19 +1480,8 @@ func (a *QueriesLegacyAPI) DeleteByQueryId(ctx context.Context, queryId string) 
 //
 // **Note**: A new version of the Databricks SQL API is now available. Please
 // use :method:queries/get instead.
-func (a *QueriesLegacyAPI) Get(ctx context.Context, request GetQueriesLegacyRequest) (*LegacyQuery, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a query definition.
-//
-// Retrieve a query object definition along with contextual permissions
-// information about the currently authenticated user.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queries/get instead.
 func (a *QueriesLegacyAPI) GetByQueryId(ctx context.Context, queryId string) (*LegacyQuery, error) {
-	return a.impl.Get(ctx, GetQueriesLegacyRequest{
+	return a.QueriesLegacyService.Get(ctx, GetQueriesLegacyRequest{
 		QueryId: queryId,
 	})
 }
@@ -1745,7 +1504,7 @@ func (a *QueriesLegacyAPI) List(ctx context.Context, request ListQueriesLegacyRe
 
 	getNextPage := func(ctx context.Context, req ListQueriesLegacyRequest) (*QueryList, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.QueriesLegacyService.List(ctx, req)
 	}
 	getItems := func(resp *QueryList) []LegacyQuery {
 		return resp.Results
@@ -1841,29 +1600,6 @@ func (a *QueriesLegacyAPI) GetByName(ctx context.Context, name string) (*LegacyQ
 	return &alternatives[0], nil
 }
 
-// Restore a query.
-//
-// Restore a query that has been moved to the trash. A restored query appears in
-// list views and searches. You can use restored queries for alerts.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// see the latest version.
-func (a *QueriesLegacyAPI) Restore(ctx context.Context, request RestoreQueriesLegacyRequest) error {
-	return a.impl.Restore(ctx, request)
-}
-
-// Change a query definition.
-//
-// Modify this query definition.
-//
-// **Note**: You cannot undo this operation.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queries/update instead.
-func (a *QueriesLegacyAPI) Update(ctx context.Context, request QueryEditContent) (*LegacyQuery, error) {
-	return a.impl.Update(ctx, request)
-}
-
 type QueryHistoryInterface interface {
 	// WithImpl could be used to override low-level API implementations for unit
 	// testing purposes with [github.com/golang/mock] or other mocking frameworks.
@@ -1888,7 +1624,7 @@ type QueryHistoryInterface interface {
 
 func NewQueryHistory(client *client.DatabricksClient) *QueryHistoryAPI {
 	return &QueryHistoryAPI{
-		impl: &queryHistoryImpl{
+		QueryHistoryService: &queryHistoryImpl{
 			client: client,
 		},
 	}
@@ -1899,34 +1635,22 @@ func NewQueryHistory(client *client.DatabricksClient) *QueryHistoryAPI {
 type QueryHistoryAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(QueryHistoryService)
-	impl QueryHistoryService
+	QueryHistoryService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueryHistoryInterface instead.
 func (a *QueryHistoryAPI) WithImpl(impl QueryHistoryService) QueryHistoryInterface {
-	a.impl = impl
-	return a
+	return &QueryHistoryAPI{
+		QueryHistoryService: impl,
+	}
 }
 
 // Impl returns low-level QueryHistory API implementation
 // Deprecated: use MockQueryHistoryInterface instead.
 func (a *QueryHistoryAPI) Impl() QueryHistoryService {
-	return a.impl
-}
-
-// List Queries.
-//
-// List the history of queries through SQL warehouses, serverless compute, and
-// DLT.
-//
-// You can filter by user ID, warehouse ID, status, and time range. Most
-// recently started queries are returned first (up to max_results in request).
-// The pagination token returned in response can be used to list subsequent
-// query statuses.
-func (a *QueryHistoryAPI) List(ctx context.Context, request ListQueryHistoryRequest) (*ListQueriesResponse, error) {
-	return a.impl.List(ctx, request)
+	return a.QueryHistoryService
 }
 
 type QueryVisualizationsInterface interface {
@@ -1962,7 +1686,7 @@ type QueryVisualizationsInterface interface {
 
 func NewQueryVisualizations(client *client.DatabricksClient) *QueryVisualizationsAPI {
 	return &QueryVisualizationsAPI{
-		impl: &queryVisualizationsImpl{
+		QueryVisualizationsService: &queryVisualizationsImpl{
 			client: client,
 		},
 	}
@@ -1974,51 +1698,31 @@ func NewQueryVisualizations(client *client.DatabricksClient) *QueryVisualization
 type QueryVisualizationsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(QueryVisualizationsService)
-	impl QueryVisualizationsService
+	QueryVisualizationsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueryVisualizationsInterface instead.
 func (a *QueryVisualizationsAPI) WithImpl(impl QueryVisualizationsService) QueryVisualizationsInterface {
-	a.impl = impl
-	return a
+	return &QueryVisualizationsAPI{
+		QueryVisualizationsService: impl,
+	}
 }
 
 // Impl returns low-level QueryVisualizations API implementation
 // Deprecated: use MockQueryVisualizationsInterface instead.
 func (a *QueryVisualizationsAPI) Impl() QueryVisualizationsService {
-	return a.impl
-}
-
-// Add a visualization to a query.
-//
-// Adds a visualization to a query.
-func (a *QueryVisualizationsAPI) Create(ctx context.Context, request CreateVisualizationRequest) (*Visualization, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Remove a visualization.
-//
-// Removes a visualization.
-func (a *QueryVisualizationsAPI) Delete(ctx context.Context, request DeleteVisualizationRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.QueryVisualizationsService
 }
 
 // Remove a visualization.
 //
 // Removes a visualization.
 func (a *QueryVisualizationsAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteVisualizationRequest{
+	return a.QueryVisualizationsService.Delete(ctx, DeleteVisualizationRequest{
 		Id: id,
 	})
-}
-
-// Update a visualization.
-//
-// Updates a visualization.
-func (a *QueryVisualizationsAPI) Update(ctx context.Context, request UpdateVisualizationRequest) (*Visualization, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type QueryVisualizationsLegacyInterface interface {
@@ -2066,7 +1770,7 @@ type QueryVisualizationsLegacyInterface interface {
 
 func NewQueryVisualizationsLegacy(client *client.DatabricksClient) *QueryVisualizationsLegacyAPI {
 	return &QueryVisualizationsLegacyAPI{
-		impl: &queryVisualizationsLegacyImpl{
+		QueryVisualizationsLegacyService: &queryVisualizationsLegacyImpl{
 			client: client,
 		},
 	}
@@ -2081,41 +1785,22 @@ func NewQueryVisualizationsLegacy(client *client.DatabricksClient) *QueryVisuali
 type QueryVisualizationsLegacyAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(QueryVisualizationsLegacyService)
-	impl QueryVisualizationsLegacyService
+	QueryVisualizationsLegacyService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockQueryVisualizationsLegacyInterface instead.
 func (a *QueryVisualizationsLegacyAPI) WithImpl(impl QueryVisualizationsLegacyService) QueryVisualizationsLegacyInterface {
-	a.impl = impl
-	return a
+	return &QueryVisualizationsLegacyAPI{
+		QueryVisualizationsLegacyService: impl,
+	}
 }
 
 // Impl returns low-level QueryVisualizationsLegacy API implementation
 // Deprecated: use MockQueryVisualizationsLegacyInterface instead.
 func (a *QueryVisualizationsLegacyAPI) Impl() QueryVisualizationsLegacyService {
-	return a.impl
-}
-
-// Add visualization to a query.
-//
-// Creates visualization in the query.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queryvisualizations/create instead.
-func (a *QueryVisualizationsLegacyAPI) Create(ctx context.Context, request CreateQueryVisualizationsLegacyRequest) (*LegacyVisualization, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Remove visualization.
-//
-// Removes a visualization from the query.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queryvisualizations/delete instead.
-func (a *QueryVisualizationsLegacyAPI) Delete(ctx context.Context, request DeleteQueryVisualizationsLegacyRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.QueryVisualizationsLegacyService
 }
 
 // Remove visualization.
@@ -2125,19 +1810,9 @@ func (a *QueryVisualizationsLegacyAPI) Delete(ctx context.Context, request Delet
 // **Note**: A new version of the Databricks SQL API is now available. Please
 // use :method:queryvisualizations/delete instead.
 func (a *QueryVisualizationsLegacyAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteQueryVisualizationsLegacyRequest{
+	return a.QueryVisualizationsLegacyService.Delete(ctx, DeleteQueryVisualizationsLegacyRequest{
 		Id: id,
 	})
-}
-
-// Edit existing visualization.
-//
-// Updates visualization in the query.
-//
-// **Note**: A new version of the Databricks SQL API is now available. Please
-// use :method:queryvisualizations/update instead.
-func (a *QueryVisualizationsLegacyAPI) Update(ctx context.Context, request LegacyVisualization) (*LegacyVisualization, error) {
-	return a.impl.Update(ctx, request)
 }
 
 type StatementExecutionInterface interface {
@@ -2213,7 +1888,7 @@ type StatementExecutionInterface interface {
 
 func NewStatementExecution(client *client.DatabricksClient) *StatementExecutionAPI {
 	return &StatementExecutionAPI{
-		impl: &statementExecutionImpl{
+		StatementExecutionService: &statementExecutionImpl{
 			client: client,
 		},
 	}
@@ -2325,49 +2000,22 @@ func NewStatementExecution(client *client.DatabricksClient) *StatementExecutionA
 type StatementExecutionAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(StatementExecutionService)
-	impl StatementExecutionService
+	StatementExecutionService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockStatementExecutionInterface instead.
 func (a *StatementExecutionAPI) WithImpl(impl StatementExecutionService) StatementExecutionInterface {
-	a.impl = impl
-	return a
+	return &StatementExecutionAPI{
+		StatementExecutionService: impl,
+	}
 }
 
 // Impl returns low-level StatementExecution API implementation
 // Deprecated: use MockStatementExecutionInterface instead.
 func (a *StatementExecutionAPI) Impl() StatementExecutionService {
-	return a.impl
-}
-
-// Cancel statement execution.
-//
-// Requests that an executing statement be canceled. Callers must poll for
-// status to see the terminal state.
-func (a *StatementExecutionAPI) CancelExecution(ctx context.Context, request CancelExecutionRequest) error {
-	return a.impl.CancelExecution(ctx, request)
-}
-
-// Execute a SQL statement.
-func (a *StatementExecutionAPI) ExecuteStatement(ctx context.Context, request ExecuteStatementRequest) (*StatementResponse, error) {
-	return a.impl.ExecuteStatement(ctx, request)
-}
-
-// Get status, manifest, and result first chunk.
-//
-// This request can be used to poll for the statement's status. When the
-// `status.state` field is `SUCCEEDED` it will also return the result manifest
-// and the first chunk of the result data. When the statement is in the terminal
-// states `CANCELED`, `CLOSED` or `FAILED`, it returns HTTP 200 with the state
-// set. After at least 12 hours in terminal state, the statement is removed from
-// the warehouse and further calls will receive an HTTP 404 response.
-//
-// **NOTE** This call currently might take up to 5 seconds to get the latest
-// status and result.
-func (a *StatementExecutionAPI) GetStatement(ctx context.Context, request GetStatementRequest) (*StatementResponse, error) {
-	return a.impl.GetStatement(ctx, request)
+	return a.StatementExecutionService
 }
 
 // Get status, manifest, and result first chunk.
@@ -2382,7 +2030,7 @@ func (a *StatementExecutionAPI) GetStatement(ctx context.Context, request GetSta
 // **NOTE** This call currently might take up to 5 seconds to get the latest
 // status and result.
 func (a *StatementExecutionAPI) GetStatementByStatementId(ctx context.Context, statementId string) (*StatementResponse, error) {
-	return a.impl.GetStatement(ctx, GetStatementRequest{
+	return a.StatementExecutionService.GetStatement(ctx, GetStatementRequest{
 		StatementId: statementId,
 	})
 }
@@ -2397,22 +2045,8 @@ func (a *StatementExecutionAPI) GetStatementByStatementId(ctx context.Context, s
 // element described in the :method:statementexecution/getStatement request, and
 // similarly includes the `next_chunk_index` and `next_chunk_internal_link`
 // fields for simple iteration through the result set.
-func (a *StatementExecutionAPI) GetStatementResultChunkN(ctx context.Context, request GetStatementResultChunkNRequest) (*ResultData, error) {
-	return a.impl.GetStatementResultChunkN(ctx, request)
-}
-
-// Get result chunk by index.
-//
-// After the statement execution has `SUCCEEDED`, this request can be used to
-// fetch any chunk by index. Whereas the first chunk with `chunk_index=0` is
-// typically fetched with :method:statementexecution/executeStatement or
-// :method:statementexecution/getStatement, this request can be used to fetch
-// subsequent chunks. The response structure is identical to the nested `result`
-// element described in the :method:statementexecution/getStatement request, and
-// similarly includes the `next_chunk_index` and `next_chunk_internal_link`
-// fields for simple iteration through the result set.
 func (a *StatementExecutionAPI) GetStatementResultChunkNByStatementIdAndChunkIndex(ctx context.Context, statementId string, chunkIndex int) (*ResultData, error) {
-	return a.impl.GetStatementResultChunkN(ctx, GetStatementResultChunkNRequest{
+	return a.StatementExecutionService.GetStatementResultChunkN(ctx, GetStatementResultChunkNRequest{
 		StatementId: statementId,
 		ChunkIndex:  chunkIndex,
 	})
@@ -2589,7 +2223,7 @@ type WarehousesInterface interface {
 
 func NewWarehouses(client *client.DatabricksClient) *WarehousesAPI {
 	return &WarehousesAPI{
-		impl: &warehousesImpl{
+		WarehousesService: &warehousesImpl{
 			client: client,
 		},
 	}
@@ -2601,21 +2235,22 @@ func NewWarehouses(client *client.DatabricksClient) *WarehousesAPI {
 type WarehousesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(WarehousesService)
-	impl WarehousesService
+	WarehousesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWarehousesInterface instead.
 func (a *WarehousesAPI) WithImpl(impl WarehousesService) WarehousesInterface {
-	a.impl = impl
-	return a
+	return &WarehousesAPI{
+		WarehousesService: impl,
+	}
 }
 
 // Impl returns low-level Warehouses API implementation
 // Deprecated: use MockWarehousesInterface instead.
 func (a *WarehousesAPI) Impl() WarehousesService {
-	return a.impl
+	return a.WarehousesService
 }
 
 // WaitGetWarehouseRunning repeatedly calls [WarehousesAPI.Get] and waits to reach RUNNING state
@@ -2732,7 +2367,7 @@ func (w *WaitGetWarehouseStopped[R]) GetWithTimeout(timeout time.Duration) (*Get
 //
 // Creates a new SQL warehouse.
 func (a *WarehousesAPI) Create(ctx context.Context, createWarehouseRequest CreateWarehouseRequest) (*WaitGetWarehouseRunning[CreateWarehouseResponse], error) {
-	createWarehouseResponse, err := a.impl.Create(ctx, createWarehouseRequest)
+	createWarehouseResponse, err := a.WarehousesService.Create(ctx, createWarehouseRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -2777,15 +2412,8 @@ func (a *WarehousesAPI) CreateAndWait(ctx context.Context, createWarehouseReques
 // Delete a warehouse.
 //
 // Deletes a SQL warehouse.
-func (a *WarehousesAPI) Delete(ctx context.Context, request DeleteWarehouseRequest) error {
-	return a.impl.Delete(ctx, request)
-}
-
-// Delete a warehouse.
-//
-// Deletes a SQL warehouse.
 func (a *WarehousesAPI) DeleteById(ctx context.Context, id string) error {
-	return a.impl.Delete(ctx, DeleteWarehouseRequest{
+	return a.WarehousesService.Delete(ctx, DeleteWarehouseRequest{
 		Id: id,
 	})
 }
@@ -2794,7 +2422,7 @@ func (a *WarehousesAPI) DeleteById(ctx context.Context, id string) error {
 //
 // Updates the configuration for a SQL warehouse.
 func (a *WarehousesAPI) Edit(ctx context.Context, editWarehouseRequest EditWarehouseRequest) (*WaitGetWarehouseRunning[struct{}], error) {
-	err := a.impl.Edit(ctx, editWarehouseRequest)
+	err := a.WarehousesService.Edit(ctx, editWarehouseRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -2839,15 +2467,8 @@ func (a *WarehousesAPI) EditAndWait(ctx context.Context, editWarehouseRequest Ed
 // Get warehouse info.
 //
 // Gets the information for a single SQL warehouse.
-func (a *WarehousesAPI) Get(ctx context.Context, request GetWarehouseRequest) (*GetWarehouseResponse, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get warehouse info.
-//
-// Gets the information for a single SQL warehouse.
 func (a *WarehousesAPI) GetById(ctx context.Context, id string) (*GetWarehouseResponse, error) {
-	return a.impl.Get(ctx, GetWarehouseRequest{
+	return a.WarehousesService.Get(ctx, GetWarehouseRequest{
 		Id: id,
 	})
 }
@@ -2855,25 +2476,10 @@ func (a *WarehousesAPI) GetById(ctx context.Context, id string) (*GetWarehouseRe
 // Get SQL warehouse permission levels.
 //
 // Gets the permission levels that a user can have on an object.
-func (a *WarehousesAPI) GetPermissionLevels(ctx context.Context, request GetWarehousePermissionLevelsRequest) (*GetWarehousePermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
-}
-
-// Get SQL warehouse permission levels.
-//
-// Gets the permission levels that a user can have on an object.
 func (a *WarehousesAPI) GetPermissionLevelsByWarehouseId(ctx context.Context, warehouseId string) (*GetWarehousePermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetWarehousePermissionLevelsRequest{
+	return a.WarehousesService.GetPermissionLevels(ctx, GetWarehousePermissionLevelsRequest{
 		WarehouseId: warehouseId,
 	})
-}
-
-// Get SQL warehouse permissions.
-//
-// Gets the permissions of a SQL warehouse. SQL warehouses can inherit
-// permissions from their root object.
-func (a *WarehousesAPI) GetPermissions(ctx context.Context, request GetWarehousePermissionsRequest) (*WarehousePermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get SQL warehouse permissions.
@@ -2881,17 +2487,9 @@ func (a *WarehousesAPI) GetPermissions(ctx context.Context, request GetWarehouse
 // Gets the permissions of a SQL warehouse. SQL warehouses can inherit
 // permissions from their root object.
 func (a *WarehousesAPI) GetPermissionsByWarehouseId(ctx context.Context, warehouseId string) (*WarehousePermissions, error) {
-	return a.impl.GetPermissions(ctx, GetWarehousePermissionsRequest{
+	return a.WarehousesService.GetPermissions(ctx, GetWarehousePermissionsRequest{
 		WarehouseId: warehouseId,
 	})
-}
-
-// Get the workspace configuration.
-//
-// Gets the workspace level configuration that is shared by all SQL warehouses
-// in a workspace.
-func (a *WarehousesAPI) GetWorkspaceWarehouseConfig(ctx context.Context) (*GetWorkspaceWarehouseConfigResponse, error) {
-	return a.impl.GetWorkspaceWarehouseConfig(ctx)
 }
 
 // List warehouses.
@@ -2903,7 +2501,7 @@ func (a *WarehousesAPI) List(ctx context.Context, request ListWarehousesRequest)
 
 	getNextPage := func(ctx context.Context, req ListWarehousesRequest) (*ListWarehousesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.WarehousesService.List(ctx, req)
 	}
 	getItems := func(resp *ListWarehousesResponse) []EndpointInfo {
 		return resp.Warehouses
@@ -2980,27 +2578,11 @@ func (a *WarehousesAPI) GetByName(ctx context.Context, name string) (*EndpointIn
 	return &alternatives[0], nil
 }
 
-// Set SQL warehouse permissions.
-//
-// Sets permissions on a SQL warehouse. SQL warehouses can inherit permissions
-// from their root object.
-func (a *WarehousesAPI) SetPermissions(ctx context.Context, request WarehousePermissionsRequest) (*WarehousePermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Set the workspace configuration.
-//
-// Sets the workspace level configuration that is shared by all SQL warehouses
-// in a workspace.
-func (a *WarehousesAPI) SetWorkspaceWarehouseConfig(ctx context.Context, request SetWorkspaceWarehouseConfigRequest) error {
-	return a.impl.SetWorkspaceWarehouseConfig(ctx, request)
-}
-
 // Start a warehouse.
 //
 // Starts a SQL warehouse.
 func (a *WarehousesAPI) Start(ctx context.Context, startRequest StartRequest) (*WaitGetWarehouseRunning[struct{}], error) {
-	err := a.impl.Start(ctx, startRequest)
+	err := a.WarehousesService.Start(ctx, startRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -3046,7 +2628,7 @@ func (a *WarehousesAPI) StartAndWait(ctx context.Context, startRequest StartRequ
 //
 // Stops a SQL warehouse.
 func (a *WarehousesAPI) Stop(ctx context.Context, stopRequest StopRequest) (*WaitGetWarehouseStopped[struct{}], error) {
-	err := a.impl.Stop(ctx, stopRequest)
+	err := a.WarehousesService.Stop(ctx, stopRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -3086,12 +2668,4 @@ func (a *WarehousesAPI) StopAndWait(ctx context.Context, stopRequest StopRequest
 		}
 	}
 	return wait.Get()
-}
-
-// Update SQL warehouse permissions.
-//
-// Updates the permissions on a SQL warehouse. SQL warehouses can inherit
-// permissions from their root object.
-func (a *WarehousesAPI) UpdatePermissions(ctx context.Context, request WarehousePermissionsRequest) (*WarehousePermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }

--- a/service/sql/model.go
+++ b/service/sql/model.go
@@ -398,6 +398,8 @@ const ChannelNameChannelNamePreview ChannelName = `CHANNEL_NAME_PREVIEW`
 
 const ChannelNameChannelNamePrevious ChannelName = `CHANNEL_NAME_PREVIOUS`
 
+const ChannelNameChannelNameUnspecified ChannelName = `CHANNEL_NAME_UNSPECIFIED`
+
 // String representation for [fmt.Print]
 func (f *ChannelName) String() string {
 	return string(*f)
@@ -406,11 +408,11 @@ func (f *ChannelName) String() string {
 // Set raw string value and validate it against allowed values
 func (f *ChannelName) Set(v string) error {
 	switch v {
-	case `CHANNEL_NAME_CURRENT`, `CHANNEL_NAME_CUSTOM`, `CHANNEL_NAME_PREVIEW`, `CHANNEL_NAME_PREVIOUS`:
+	case `CHANNEL_NAME_CURRENT`, `CHANNEL_NAME_CUSTOM`, `CHANNEL_NAME_PREVIEW`, `CHANNEL_NAME_PREVIOUS`, `CHANNEL_NAME_UNSPECIFIED`:
 		*f = ChannelName(v)
 		return nil
 	default:
-		return fmt.Errorf(`value "%s" is not one of "CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS"`, v)
+		return fmt.Errorf(`value "%s" is not one of "CHANNEL_NAME_CURRENT", "CHANNEL_NAME_CUSTOM", "CHANNEL_NAME_PREVIEW", "CHANNEL_NAME_PREVIOUS", "CHANNEL_NAME_UNSPECIFIED"`, v)
 	}
 }
 

--- a/service/sql/utilities.go
+++ b/service/sql/utilities.go
@@ -14,7 +14,7 @@ type statementExecutionAPIUtilities interface {
 
 // [EXPERIMENTAL] Execute a query and wait for results to be available
 func (a *StatementExecutionAPI) ExecuteAndWait(ctx context.Context, request ExecuteStatementRequest) (*StatementResponse, error) {
-	immediateResponse, err := a.impl.ExecuteStatement(ctx, request)
+	immediateResponse, err := a.ExecuteStatement(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/service/vectorsearch/api.go
+++ b/service/vectorsearch/api.go
@@ -83,9 +83,8 @@ type VectorSearchEndpointsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVectorSearchEndpointsInterface instead.
 func (a *VectorSearchEndpointsAPI) WithImpl(impl VectorSearchEndpointsService) VectorSearchEndpointsInterface {
-	return &VectorSearchEndpointsAPI{
-		VectorSearchEndpointsService: impl,
-	}
+	a.VectorSearchEndpointsService = impl
+	return a
 }
 
 // Impl returns low-level VectorSearchEndpoints API implementation
@@ -356,9 +355,8 @@ type VectorSearchIndexesAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVectorSearchIndexesInterface instead.
 func (a *VectorSearchIndexesAPI) WithImpl(impl VectorSearchIndexesService) VectorSearchIndexesInterface {
-	return &VectorSearchIndexesAPI{
-		VectorSearchIndexesService: impl,
-	}
+	a.VectorSearchIndexesService = impl
+	return a
 }
 
 // Impl returns low-level VectorSearchIndexes API implementation

--- a/service/vectorsearch/api.go
+++ b/service/vectorsearch/api.go
@@ -66,7 +66,7 @@ type VectorSearchEndpointsInterface interface {
 
 func NewVectorSearchEndpoints(client *client.DatabricksClient) *VectorSearchEndpointsAPI {
 	return &VectorSearchEndpointsAPI{
-		impl: &vectorSearchEndpointsImpl{
+		VectorSearchEndpointsService: &vectorSearchEndpointsImpl{
 			client: client,
 		},
 	}
@@ -76,21 +76,22 @@ func NewVectorSearchEndpoints(client *client.DatabricksClient) *VectorSearchEndp
 type VectorSearchEndpointsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(VectorSearchEndpointsService)
-	impl VectorSearchEndpointsService
+	VectorSearchEndpointsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVectorSearchEndpointsInterface instead.
 func (a *VectorSearchEndpointsAPI) WithImpl(impl VectorSearchEndpointsService) VectorSearchEndpointsInterface {
-	a.impl = impl
-	return a
+	return &VectorSearchEndpointsAPI{
+		VectorSearchEndpointsService: impl,
+	}
 }
 
 // Impl returns low-level VectorSearchEndpoints API implementation
 // Deprecated: use MockVectorSearchEndpointsInterface instead.
 func (a *VectorSearchEndpointsAPI) Impl() VectorSearchEndpointsService {
-	return a.impl
+	return a.VectorSearchEndpointsService
 }
 
 // WaitGetEndpointVectorSearchEndpointOnline repeatedly calls [VectorSearchEndpointsAPI.GetEndpoint] and waits to reach ONLINE state
@@ -154,7 +155,7 @@ func (w *WaitGetEndpointVectorSearchEndpointOnline[R]) GetWithTimeout(timeout ti
 //
 // Create a new endpoint.
 func (a *VectorSearchEndpointsAPI) CreateEndpoint(ctx context.Context, createEndpoint CreateEndpoint) (*WaitGetEndpointVectorSearchEndpointOnline[EndpointInfo], error) {
-	endpointInfo, err := a.impl.CreateEndpoint(ctx, createEndpoint)
+	endpointInfo, err := a.VectorSearchEndpointsService.CreateEndpoint(ctx, createEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -197,25 +198,15 @@ func (a *VectorSearchEndpointsAPI) CreateEndpointAndWait(ctx context.Context, cr
 }
 
 // Delete an endpoint.
-func (a *VectorSearchEndpointsAPI) DeleteEndpoint(ctx context.Context, request DeleteEndpointRequest) error {
-	return a.impl.DeleteEndpoint(ctx, request)
-}
-
-// Delete an endpoint.
 func (a *VectorSearchEndpointsAPI) DeleteEndpointByEndpointName(ctx context.Context, endpointName string) error {
-	return a.impl.DeleteEndpoint(ctx, DeleteEndpointRequest{
+	return a.VectorSearchEndpointsService.DeleteEndpoint(ctx, DeleteEndpointRequest{
 		EndpointName: endpointName,
 	})
 }
 
 // Get an endpoint.
-func (a *VectorSearchEndpointsAPI) GetEndpoint(ctx context.Context, request GetEndpointRequest) (*EndpointInfo, error) {
-	return a.impl.GetEndpoint(ctx, request)
-}
-
-// Get an endpoint.
 func (a *VectorSearchEndpointsAPI) GetEndpointByEndpointName(ctx context.Context, endpointName string) (*EndpointInfo, error) {
-	return a.impl.GetEndpoint(ctx, GetEndpointRequest{
+	return a.VectorSearchEndpointsService.GetEndpoint(ctx, GetEndpointRequest{
 		EndpointName: endpointName,
 	})
 }
@@ -227,7 +218,7 @@ func (a *VectorSearchEndpointsAPI) ListEndpoints(ctx context.Context, request Li
 
 	getNextPage := func(ctx context.Context, req ListEndpointsRequest) (*ListEndpointResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListEndpoints(ctx, req)
+		return a.VectorSearchEndpointsService.ListEndpoints(ctx, req)
 	}
 	getItems := func(resp *ListEndpointResponse) []EndpointInfo {
 		return resp.Endpoints
@@ -339,7 +330,7 @@ type VectorSearchIndexesInterface interface {
 
 func NewVectorSearchIndexes(client *client.DatabricksClient) *VectorSearchIndexesAPI {
 	return &VectorSearchIndexesAPI{
-		impl: &vectorSearchIndexesImpl{
+		VectorSearchIndexesService: &vectorSearchIndexesImpl{
 			client: client,
 		},
 	}
@@ -358,49 +349,29 @@ func NewVectorSearchIndexes(client *client.DatabricksClient) *VectorSearchIndexe
 type VectorSearchIndexesAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(VectorSearchIndexesService)
-	impl VectorSearchIndexesService
+	VectorSearchIndexesService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockVectorSearchIndexesInterface instead.
 func (a *VectorSearchIndexesAPI) WithImpl(impl VectorSearchIndexesService) VectorSearchIndexesInterface {
-	a.impl = impl
-	return a
+	return &VectorSearchIndexesAPI{
+		VectorSearchIndexesService: impl,
+	}
 }
 
 // Impl returns low-level VectorSearchIndexes API implementation
 // Deprecated: use MockVectorSearchIndexesInterface instead.
 func (a *VectorSearchIndexesAPI) Impl() VectorSearchIndexesService {
-	return a.impl
-}
-
-// Create an index.
-//
-// Create a new index.
-func (a *VectorSearchIndexesAPI) CreateIndex(ctx context.Context, request CreateVectorIndexRequest) (*CreateVectorIndexResponse, error) {
-	return a.impl.CreateIndex(ctx, request)
-}
-
-// Delete data from index.
-//
-// Handles the deletion of data from a specified vector index.
-func (a *VectorSearchIndexesAPI) DeleteDataVectorIndex(ctx context.Context, request DeleteDataVectorIndexRequest) (*DeleteDataVectorIndexResponse, error) {
-	return a.impl.DeleteDataVectorIndex(ctx, request)
-}
-
-// Delete an index.
-//
-// Delete an index.
-func (a *VectorSearchIndexesAPI) DeleteIndex(ctx context.Context, request DeleteIndexRequest) error {
-	return a.impl.DeleteIndex(ctx, request)
+	return a.VectorSearchIndexesService
 }
 
 // Delete an index.
 //
 // Delete an index.
 func (a *VectorSearchIndexesAPI) DeleteIndexByIndexName(ctx context.Context, indexName string) error {
-	return a.impl.DeleteIndex(ctx, DeleteIndexRequest{
+	return a.VectorSearchIndexesService.DeleteIndex(ctx, DeleteIndexRequest{
 		IndexName: indexName,
 	})
 }
@@ -408,15 +379,8 @@ func (a *VectorSearchIndexesAPI) DeleteIndexByIndexName(ctx context.Context, ind
 // Get an index.
 //
 // Get an index.
-func (a *VectorSearchIndexesAPI) GetIndex(ctx context.Context, request GetIndexRequest) (*VectorIndex, error) {
-	return a.impl.GetIndex(ctx, request)
-}
-
-// Get an index.
-//
-// Get an index.
 func (a *VectorSearchIndexesAPI) GetIndexByIndexName(ctx context.Context, indexName string) (*VectorIndex, error) {
-	return a.impl.GetIndex(ctx, GetIndexRequest{
+	return a.VectorSearchIndexesService.GetIndex(ctx, GetIndexRequest{
 		IndexName: indexName,
 	})
 }
@@ -430,7 +394,7 @@ func (a *VectorSearchIndexesAPI) ListIndexes(ctx context.Context, request ListIn
 
 	getNextPage := func(ctx context.Context, req ListIndexesRequest) (*ListVectorIndexesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListIndexes(ctx, req)
+		return a.VectorSearchIndexesService.ListIndexes(ctx, req)
 	}
 	getItems := func(resp *ListVectorIndexesResponse) []MiniVectorIndex {
 		return resp.VectorIndexes
@@ -458,41 +422,4 @@ func (a *VectorSearchIndexesAPI) ListIndexes(ctx context.Context, request ListIn
 func (a *VectorSearchIndexesAPI) ListIndexesAll(ctx context.Context, request ListIndexesRequest) ([]MiniVectorIndex, error) {
 	iterator := a.ListIndexes(ctx, request)
 	return listing.ToSlice[MiniVectorIndex](ctx, iterator)
-}
-
-// Query an index.
-//
-// Query the specified vector index.
-func (a *VectorSearchIndexesAPI) QueryIndex(ctx context.Context, request QueryVectorIndexRequest) (*QueryVectorIndexResponse, error) {
-	return a.impl.QueryIndex(ctx, request)
-}
-
-// Query next page.
-//
-// Use `next_page_token` returned from previous `QueryVectorIndex` or
-// `QueryVectorIndexNextPage` request to fetch next page of results.
-func (a *VectorSearchIndexesAPI) QueryNextPage(ctx context.Context, request QueryVectorIndexNextPageRequest) (*QueryVectorIndexResponse, error) {
-	return a.impl.QueryNextPage(ctx, request)
-}
-
-// Scan an index.
-//
-// Scan the specified vector index and return the first `num_results` entries
-// after the exclusive `primary_key`.
-func (a *VectorSearchIndexesAPI) ScanIndex(ctx context.Context, request ScanVectorIndexRequest) (*ScanVectorIndexResponse, error) {
-	return a.impl.ScanIndex(ctx, request)
-}
-
-// Synchronize an index.
-//
-// Triggers a synchronization process for a specified vector index.
-func (a *VectorSearchIndexesAPI) SyncIndex(ctx context.Context, request SyncIndexRequest) error {
-	return a.impl.SyncIndex(ctx, request)
-}
-
-// Upsert data into an index.
-//
-// Handles the upserting of data into a specified vector index.
-func (a *VectorSearchIndexesAPI) UpsertDataVectorIndex(ctx context.Context, request UpsertDataVectorIndexRequest) (*UpsertDataVectorIndexResponse, error) {
-	return a.impl.UpsertDataVectorIndex(ctx, request)
 }

--- a/service/workspace/api.go
+++ b/service/workspace/api.go
@@ -92,7 +92,7 @@ type GitCredentialsInterface interface {
 
 func NewGitCredentials(client *client.DatabricksClient) *GitCredentialsAPI {
 	return &GitCredentialsAPI{
-		impl: &gitCredentialsImpl{
+		GitCredentialsService: &gitCredentialsImpl{
 			client: client,
 		},
 	}
@@ -107,45 +107,29 @@ func NewGitCredentials(client *client.DatabricksClient) *GitCredentialsAPI {
 type GitCredentialsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(GitCredentialsService)
-	impl GitCredentialsService
+	GitCredentialsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGitCredentialsInterface instead.
 func (a *GitCredentialsAPI) WithImpl(impl GitCredentialsService) GitCredentialsInterface {
-	a.impl = impl
-	return a
+	return &GitCredentialsAPI{
+		GitCredentialsService: impl,
+	}
 }
 
 // Impl returns low-level GitCredentials API implementation
 // Deprecated: use MockGitCredentialsInterface instead.
 func (a *GitCredentialsAPI) Impl() GitCredentialsService {
-	return a.impl
-}
-
-// Create a credential entry.
-//
-// Creates a Git credential entry for the user. Only one Git credential per user
-// is supported, so any attempts to create credentials if an entry already
-// exists will fail. Use the PATCH endpoint to update existing credentials, or
-// the DELETE endpoint to delete existing credentials.
-func (a *GitCredentialsAPI) Create(ctx context.Context, request CreateCredentials) (*CreateCredentialsResponse, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a credential.
-//
-// Deletes the specified Git credential.
-func (a *GitCredentialsAPI) Delete(ctx context.Context, request DeleteGitCredentialRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.GitCredentialsService
 }
 
 // Delete a credential.
 //
 // Deletes the specified Git credential.
 func (a *GitCredentialsAPI) DeleteByCredentialId(ctx context.Context, credentialId int64) error {
-	return a.impl.Delete(ctx, DeleteGitCredentialRequest{
+	return a.GitCredentialsService.Delete(ctx, DeleteGitCredentialRequest{
 		CredentialId: credentialId,
 	})
 }
@@ -153,15 +137,8 @@ func (a *GitCredentialsAPI) DeleteByCredentialId(ctx context.Context, credential
 // Get a credential entry.
 //
 // Gets the Git credential with the specified credential ID.
-func (a *GitCredentialsAPI) Get(ctx context.Context, request GetGitCredentialRequest) (*CredentialInfo, error) {
-	return a.impl.Get(ctx, request)
-}
-
-// Get a credential entry.
-//
-// Gets the Git credential with the specified credential ID.
 func (a *GitCredentialsAPI) GetByCredentialId(ctx context.Context, credentialId int64) (*CredentialInfo, error) {
-	return a.impl.Get(ctx, GetGitCredentialRequest{
+	return a.GitCredentialsService.Get(ctx, GetGitCredentialRequest{
 		CredentialId: credentialId,
 	})
 }
@@ -177,7 +154,7 @@ func (a *GitCredentialsAPI) List(ctx context.Context) listing.Iterator[Credentia
 
 	getNextPage := func(ctx context.Context, req struct{}) (*GetCredentialsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx)
+		return a.GitCredentialsService.List(ctx)
 	}
 	getItems := func(resp *GetCredentialsResponse) []CredentialInfo {
 		return resp.Credentials
@@ -253,13 +230,6 @@ func (a *GitCredentialsAPI) GetByGitProvider(ctx context.Context, name string) (
 		return nil, fmt.Errorf("there are %d instances of CredentialInfo named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Update a credential.
-//
-// Updates the specified Git credential.
-func (a *GitCredentialsAPI) Update(ctx context.Context, request UpdateCredentials) error {
-	return a.impl.Update(ctx, request)
 }
 
 type ReposInterface interface {
@@ -376,7 +346,7 @@ type ReposInterface interface {
 
 func NewRepos(client *client.DatabricksClient) *ReposAPI {
 	return &ReposAPI{
-		impl: &reposImpl{
+		ReposService: &reposImpl{
 			client: client,
 		},
 	}
@@ -395,86 +365,49 @@ func NewRepos(client *client.DatabricksClient) *ReposAPI {
 type ReposAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(ReposService)
-	impl ReposService
+	ReposService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockReposInterface instead.
 func (a *ReposAPI) WithImpl(impl ReposService) ReposInterface {
-	a.impl = impl
-	return a
+	return &ReposAPI{
+		ReposService: impl,
+	}
 }
 
 // Impl returns low-level Repos API implementation
 // Deprecated: use MockReposInterface instead.
 func (a *ReposAPI) Impl() ReposService {
-	return a.impl
-}
-
-// Create a repo.
-//
-// Creates a repo in the workspace and links it to the remote Git repo
-// specified. Note that repos created programmatically must be linked to a
-// remote Git repo, unlike repos created in the browser.
-func (a *ReposAPI) Create(ctx context.Context, request CreateRepo) (*RepoInfo, error) {
-	return a.impl.Create(ctx, request)
-}
-
-// Delete a repo.
-//
-// Deletes the specified repo.
-func (a *ReposAPI) Delete(ctx context.Context, request DeleteRepoRequest) error {
-	return a.impl.Delete(ctx, request)
+	return a.ReposService
 }
 
 // Delete a repo.
 //
 // Deletes the specified repo.
 func (a *ReposAPI) DeleteByRepoId(ctx context.Context, repoId int64) error {
-	return a.impl.Delete(ctx, DeleteRepoRequest{
+	return a.ReposService.Delete(ctx, DeleteRepoRequest{
 		RepoId: repoId,
 	})
-}
-
-// Get a repo.
-//
-// Returns the repo with the given repo ID.
-func (a *ReposAPI) Get(ctx context.Context, request GetRepoRequest) (*RepoInfo, error) {
-	return a.impl.Get(ctx, request)
 }
 
 // Get a repo.
 //
 // Returns the repo with the given repo ID.
 func (a *ReposAPI) GetByRepoId(ctx context.Context, repoId int64) (*RepoInfo, error) {
-	return a.impl.Get(ctx, GetRepoRequest{
+	return a.ReposService.Get(ctx, GetRepoRequest{
 		RepoId: repoId,
 	})
-}
-
-// Get repo permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *ReposAPI) GetPermissionLevels(ctx context.Context, request GetRepoPermissionLevelsRequest) (*GetRepoPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
 }
 
 // Get repo permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *ReposAPI) GetPermissionLevelsByRepoId(ctx context.Context, repoId string) (*GetRepoPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetRepoPermissionLevelsRequest{
+	return a.ReposService.GetPermissionLevels(ctx, GetRepoPermissionLevelsRequest{
 		RepoId: repoId,
 	})
-}
-
-// Get repo permissions.
-//
-// Gets the permissions of a repo. Repos can inherit permissions from their root
-// object.
-func (a *ReposAPI) GetPermissions(ctx context.Context, request GetRepoPermissionsRequest) (*RepoPermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get repo permissions.
@@ -482,7 +415,7 @@ func (a *ReposAPI) GetPermissions(ctx context.Context, request GetRepoPermission
 // Gets the permissions of a repo. Repos can inherit permissions from their root
 // object.
 func (a *ReposAPI) GetPermissionsByRepoId(ctx context.Context, repoId string) (*RepoPermissions, error) {
-	return a.impl.GetPermissions(ctx, GetRepoPermissionsRequest{
+	return a.ReposService.GetPermissions(ctx, GetRepoPermissionsRequest{
 		RepoId: repoId,
 	})
 }
@@ -497,7 +430,7 @@ func (a *ReposAPI) List(ctx context.Context, request ListReposRequest) listing.I
 
 	getNextPage := func(ctx context.Context, req ListReposRequest) (*ListReposResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.ReposService.List(ctx, req)
 	}
 	getItems := func(resp *ListReposResponse) []RepoInfo {
 		return resp.Repos
@@ -579,30 +512,6 @@ func (a *ReposAPI) GetByPath(ctx context.Context, name string) (*RepoInfo, error
 		return nil, fmt.Errorf("there are %d instances of RepoInfo named '%s'", len(alternatives), name)
 	}
 	return &alternatives[0], nil
-}
-
-// Set repo permissions.
-//
-// Sets permissions on a repo. Repos can inherit permissions from their root
-// object.
-func (a *ReposAPI) SetPermissions(ctx context.Context, request RepoPermissionsRequest) (*RepoPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Update a repo.
-//
-// Updates the repo to a different branch or tag, or updates the repo to the
-// latest commit on the same branch.
-func (a *ReposAPI) Update(ctx context.Context, request UpdateRepo) error {
-	return a.impl.Update(ctx, request)
-}
-
-// Update repo permissions.
-//
-// Updates the permissions on a repo. Repos can inherit permissions from their
-// root object.
-func (a *ReposAPI) UpdatePermissions(ctx context.Context, request RepoPermissionsRequest) (*RepoPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }
 
 type SecretsInterface interface {
@@ -835,7 +744,7 @@ type SecretsInterface interface {
 
 func NewSecrets(client *client.DatabricksClient) *SecretsAPI {
 	return &SecretsAPI{
-		impl: &secretsImpl{
+		SecretsService: &secretsImpl{
 			client: client,
 		},
 	}
@@ -856,52 +765,22 @@ func NewSecrets(client *client.DatabricksClient) *SecretsAPI {
 type SecretsAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(SecretsService)
-	impl SecretsService
+	SecretsService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSecretsInterface instead.
 func (a *SecretsAPI) WithImpl(impl SecretsService) SecretsInterface {
-	a.impl = impl
-	return a
+	return &SecretsAPI{
+		SecretsService: impl,
+	}
 }
 
 // Impl returns low-level Secrets API implementation
 // Deprecated: use MockSecretsInterface instead.
 func (a *SecretsAPI) Impl() SecretsService {
-	return a.impl
-}
-
-// Create a new secret scope.
-//
-// The scope name must consist of alphanumeric characters, dashes, underscores,
-// and periods, and may not exceed 128 characters.
-func (a *SecretsAPI) CreateScope(ctx context.Context, request CreateScope) error {
-	return a.impl.CreateScope(ctx, request)
-}
-
-// Delete an ACL.
-//
-// Deletes the given ACL on the given scope.
-//
-// Users must have the `MANAGE` permission to invoke this API. Throws
-// `RESOURCE_DOES_NOT_EXIST` if no such secret scope, principal, or ACL exists.
-// Throws `PERMISSION_DENIED` if the user does not have permission to make this
-// API call.
-func (a *SecretsAPI) DeleteAcl(ctx context.Context, request DeleteAcl) error {
-	return a.impl.DeleteAcl(ctx, request)
-}
-
-// Delete a secret scope.
-//
-// Deletes a secret scope.
-//
-// Throws `RESOURCE_DOES_NOT_EXIST` if the scope does not exist. Throws
-// `PERMISSION_DENIED` if the user does not have permission to make this API
-// call.
-func (a *SecretsAPI) DeleteScope(ctx context.Context, request DeleteScope) error {
-	return a.impl.DeleteScope(ctx, request)
+	return a.SecretsService
 }
 
 // Delete a secret scope.
@@ -912,51 +791,9 @@ func (a *SecretsAPI) DeleteScope(ctx context.Context, request DeleteScope) error
 // `PERMISSION_DENIED` if the user does not have permission to make this API
 // call.
 func (a *SecretsAPI) DeleteScopeByScope(ctx context.Context, scope string) error {
-	return a.impl.DeleteScope(ctx, DeleteScope{
+	return a.SecretsService.DeleteScope(ctx, DeleteScope{
 		Scope: scope,
 	})
-}
-
-// Delete a secret.
-//
-// Deletes the secret stored in this secret scope. You must have `WRITE` or
-// `MANAGE` permission on the secret scope.
-//
-// Throws `RESOURCE_DOES_NOT_EXIST` if no such secret scope or secret exists.
-// Throws `PERMISSION_DENIED` if the user does not have permission to make this
-// API call.
-func (a *SecretsAPI) DeleteSecret(ctx context.Context, request DeleteSecret) error {
-	return a.impl.DeleteSecret(ctx, request)
-}
-
-// Get secret ACL details.
-//
-// Gets the details about the given ACL, such as the group and permission. Users
-// must have the `MANAGE` permission to invoke this API.
-//
-// Throws `RESOURCE_DOES_NOT_EXIST` if no such secret scope exists. Throws
-// `PERMISSION_DENIED` if the user does not have permission to make this API
-// call.
-func (a *SecretsAPI) GetAcl(ctx context.Context, request GetAclRequest) (*AclItem, error) {
-	return a.impl.GetAcl(ctx, request)
-}
-
-// Get a secret.
-//
-// Gets the bytes representation of a secret value for the specified scope and
-// key.
-//
-// Users need the READ permission to make this call.
-//
-// Note that the secret value returned is in bytes. The interpretation of the
-// bytes is determined by the caller in DBUtils and the type the data is decoded
-// into.
-//
-// Throws “PERMISSION_DENIED“ if the user does not have permission to make
-// this API call. Throws “RESOURCE_DOES_NOT_EXIST“ if no such secret or secret
-// scope exists.
-func (a *SecretsAPI) GetSecret(ctx context.Context, request GetSecretRequest) (*GetSecretResponse, error) {
-	return a.impl.GetSecret(ctx, request)
 }
 
 // Lists ACLs.
@@ -973,7 +810,7 @@ func (a *SecretsAPI) ListAcls(ctx context.Context, request ListAclsRequest) list
 
 	getNextPage := func(ctx context.Context, req ListAclsRequest) (*ListAclsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListAcls(ctx, req)
+		return a.SecretsService.ListAcls(ctx, req)
 	}
 	getItems := func(resp *ListAclsResponse) []AclItem {
 		return resp.Items
@@ -1011,7 +848,7 @@ func (a *SecretsAPI) ListAclsAll(ctx context.Context, request ListAclsRequest) (
 // `PERMISSION_DENIED` if the user does not have permission to make this API
 // call.
 func (a *SecretsAPI) ListAclsByScope(ctx context.Context, scope string) (*ListAclsResponse, error) {
-	return a.impl.ListAcls(ctx, ListAclsRequest{
+	return a.SecretsService.ListAcls(ctx, ListAclsRequest{
 		Scope: scope,
 	})
 }
@@ -1029,7 +866,7 @@ func (a *SecretsAPI) ListScopes(ctx context.Context) listing.Iterator[SecretScop
 
 	getNextPage := func(ctx context.Context, req struct{}) (*ListScopesResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListScopes(ctx)
+		return a.SecretsService.ListScopes(ctx)
 	}
 	getItems := func(resp *ListScopesResponse) []SecretScope {
 		return resp.Scopes
@@ -1072,7 +909,7 @@ func (a *SecretsAPI) ListSecrets(ctx context.Context, request ListSecretsRequest
 
 	getNextPage := func(ctx context.Context, req ListSecretsRequest) (*ListSecretsResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.ListSecrets(ctx, req)
+		return a.SecretsService.ListSecrets(ctx, req)
 	}
 	getItems := func(resp *ListSecretsResponse) []SecretMetadata {
 		return resp.Secrets
@@ -1114,66 +951,9 @@ func (a *SecretsAPI) ListSecretsAll(ctx context.Context, request ListSecretsRequ
 // `PERMISSION_DENIED` if the user does not have permission to make this API
 // call.
 func (a *SecretsAPI) ListSecretsByScope(ctx context.Context, scope string) (*ListSecretsResponse, error) {
-	return a.impl.ListSecrets(ctx, ListSecretsRequest{
+	return a.SecretsService.ListSecrets(ctx, ListSecretsRequest{
 		Scope: scope,
 	})
-}
-
-// Create/update an ACL.
-//
-// Creates or overwrites the Access Control List (ACL) associated with the given
-// principal (user or group) on the specified scope point.
-//
-// In general, a user or group will use the most powerful permission available
-// to them, and permissions are ordered as follows:
-//
-// * `MANAGE` - Allowed to change ACLs, and read and write to this secret scope.
-// * `WRITE` - Allowed to read and write to this secret scope. * `READ` -
-// Allowed to read this secret scope and list what secrets are available.
-//
-// Note that in general, secret values can only be read from within a command on
-// a cluster (for example, through a notebook). There is no API to read the
-// actual secret value material outside of a cluster. However, the user's
-// permission will be applied based on who is executing the command, and they
-// must have at least READ permission.
-//
-// Users must have the `MANAGE` permission to invoke this API.
-//
-// The principal is a user or group name corresponding to an existing Databricks
-// principal to be granted or revoked access.
-//
-// Throws `RESOURCE_DOES_NOT_EXIST` if no such secret scope exists. Throws
-// `RESOURCE_ALREADY_EXISTS` if a permission for the principal already exists.
-// Throws `INVALID_PARAMETER_VALUE` if the permission or principal is invalid.
-// Throws `PERMISSION_DENIED` if the user does not have permission to make this
-// API call.
-func (a *SecretsAPI) PutAcl(ctx context.Context, request PutAcl) error {
-	return a.impl.PutAcl(ctx, request)
-}
-
-// Add a secret.
-//
-// Inserts a secret under the provided scope with the given name. If a secret
-// already exists with the same name, this command overwrites the existing
-// secret's value. The server encrypts the secret using the secret scope's
-// encryption settings before storing it.
-//
-// You must have `WRITE` or `MANAGE` permission on the secret scope. The secret
-// key must consist of alphanumeric characters, dashes, underscores, and
-// periods, and cannot exceed 128 characters. The maximum allowed secret value
-// size is 128 KB. The maximum number of secrets in a given scope is 1000.
-//
-// The input fields "string_value" or "bytes_value" specify the type of the
-// secret, which will determine the value returned when the secret value is
-// requested. Exactly one must be specified.
-//
-// Throws `RESOURCE_DOES_NOT_EXIST` if no such secret scope exists. Throws
-// `RESOURCE_LIMIT_EXCEEDED` if maximum number of secrets in scope is exceeded.
-// Throws `INVALID_PARAMETER_VALUE` if the key name or value length is invalid.
-// Throws `PERMISSION_DENIED` if the user does not have permission to make this
-// API call.
-func (a *SecretsAPI) PutSecret(ctx context.Context, request PutSecret) error {
-	return a.impl.PutSecret(ctx, request)
 }
 
 type WorkspaceInterface interface {
@@ -1326,7 +1106,7 @@ type WorkspaceInterface interface {
 
 func NewWorkspace(client *client.DatabricksClient) *WorkspaceAPI {
 	return &WorkspaceAPI{
-		impl: &workspaceImpl{
+		WorkspaceService: &workspaceImpl{
 			client: client,
 		},
 	}
@@ -1340,74 +1120,32 @@ func NewWorkspace(client *client.DatabricksClient) *WorkspaceAPI {
 type WorkspaceAPI struct {
 	// impl contains low-level REST API interface, that could be overridden
 	// through WithImpl(WorkspaceService)
-	impl WorkspaceService
+	WorkspaceService
 }
 
 // WithImpl could be used to override low-level API implementations for unit
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceInterface instead.
 func (a *WorkspaceAPI) WithImpl(impl WorkspaceService) WorkspaceInterface {
-	a.impl = impl
-	return a
+	return &WorkspaceAPI{
+		WorkspaceService: impl,
+	}
 }
 
 // Impl returns low-level Workspace API implementation
 // Deprecated: use MockWorkspaceInterface instead.
 func (a *WorkspaceAPI) Impl() WorkspaceService {
-	return a.impl
-}
-
-// Delete a workspace object.
-//
-// Deletes an object or a directory (and optionally recursively deletes all
-// objects in the directory). * If `path` does not exist, this call returns an
-// error `RESOURCE_DOES_NOT_EXIST`. * If `path` is a non-empty directory and
-// `recursive` is set to `false`, this call returns an error
-// `DIRECTORY_NOT_EMPTY`.
-//
-// Object deletion cannot be undone and deleting a directory recursively is not
-// atomic.
-func (a *WorkspaceAPI) Delete(ctx context.Context, request Delete) error {
-	return a.impl.Delete(ctx, request)
-}
-
-// Export a workspace object.
-//
-// Exports an object or the contents of an entire directory.
-//
-// If `path` does not exist, this call returns an error
-// `RESOURCE_DOES_NOT_EXIST`.
-//
-// If the exported data would exceed size limit, this call returns
-// `MAX_NOTEBOOK_SIZE_EXCEEDED`. Currently, this API does not support exporting
-// a library.
-func (a *WorkspaceAPI) Export(ctx context.Context, request ExportRequest) (*ExportResponse, error) {
-	return a.impl.Export(ctx, request)
-}
-
-// Get workspace object permission levels.
-//
-// Gets the permission levels that a user can have on an object.
-func (a *WorkspaceAPI) GetPermissionLevels(ctx context.Context, request GetWorkspaceObjectPermissionLevelsRequest) (*GetWorkspaceObjectPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, request)
+	return a.WorkspaceService
 }
 
 // Get workspace object permission levels.
 //
 // Gets the permission levels that a user can have on an object.
 func (a *WorkspaceAPI) GetPermissionLevelsByWorkspaceObjectTypeAndWorkspaceObjectId(ctx context.Context, workspaceObjectType string, workspaceObjectId string) (*GetWorkspaceObjectPermissionLevelsResponse, error) {
-	return a.impl.GetPermissionLevels(ctx, GetWorkspaceObjectPermissionLevelsRequest{
+	return a.WorkspaceService.GetPermissionLevels(ctx, GetWorkspaceObjectPermissionLevelsRequest{
 		WorkspaceObjectType: workspaceObjectType,
 		WorkspaceObjectId:   workspaceObjectId,
 	})
-}
-
-// Get workspace object permissions.
-//
-// Gets the permissions of a workspace object. Workspace objects can inherit
-// permissions from their parent objects or root object.
-func (a *WorkspaceAPI) GetPermissions(ctx context.Context, request GetWorkspaceObjectPermissionsRequest) (*WorkspaceObjectPermissions, error) {
-	return a.impl.GetPermissions(ctx, request)
 }
 
 // Get workspace object permissions.
@@ -1415,7 +1153,7 @@ func (a *WorkspaceAPI) GetPermissions(ctx context.Context, request GetWorkspaceO
 // Gets the permissions of a workspace object. Workspace objects can inherit
 // permissions from their parent objects or root object.
 func (a *WorkspaceAPI) GetPermissionsByWorkspaceObjectTypeAndWorkspaceObjectId(ctx context.Context, workspaceObjectType string, workspaceObjectId string) (*WorkspaceObjectPermissions, error) {
-	return a.impl.GetPermissions(ctx, GetWorkspaceObjectPermissionsRequest{
+	return a.WorkspaceService.GetPermissions(ctx, GetWorkspaceObjectPermissionsRequest{
 		WorkspaceObjectType: workspaceObjectType,
 		WorkspaceObjectId:   workspaceObjectId,
 	})
@@ -1425,30 +1163,10 @@ func (a *WorkspaceAPI) GetPermissionsByWorkspaceObjectTypeAndWorkspaceObjectId(c
 //
 // Gets the status of an object or a directory. If `path` does not exist, this
 // call returns an error `RESOURCE_DOES_NOT_EXIST`.
-func (a *WorkspaceAPI) GetStatus(ctx context.Context, request GetStatusRequest) (*ObjectInfo, error) {
-	return a.impl.GetStatus(ctx, request)
-}
-
-// Get status.
-//
-// Gets the status of an object or a directory. If `path` does not exist, this
-// call returns an error `RESOURCE_DOES_NOT_EXIST`.
 func (a *WorkspaceAPI) GetStatusByPath(ctx context.Context, path string) (*ObjectInfo, error) {
-	return a.impl.GetStatus(ctx, GetStatusRequest{
+	return a.WorkspaceService.GetStatus(ctx, GetStatusRequest{
 		Path: path,
 	})
-}
-
-// Import a workspace object.
-//
-// Imports a workspace object (for example, a notebook or file) or the contents
-// of an entire directory. If `path` already exists and `overwrite` is set to
-// `false`, this call returns an error `RESOURCE_ALREADY_EXISTS`. To import a
-// directory, you can use either the `DBC` format or the `SOURCE` format with
-// the `language` field unset. To import a single file as `SOURCE`, you must set
-// the `language` field.
-func (a *WorkspaceAPI) Import(ctx context.Context, request Import) error {
-	return a.impl.Import(ctx, request)
 }
 
 // List contents.
@@ -1462,7 +1180,7 @@ func (a *WorkspaceAPI) List(ctx context.Context, request ListWorkspaceRequest) l
 
 	getNextPage := func(ctx context.Context, req ListWorkspaceRequest) (*ListResponse, error) {
 		ctx = useragent.InContext(ctx, "sdk-feature", "pagination")
-		return a.impl.List(ctx, req)
+		return a.WorkspaceService.List(ctx, req)
 	}
 	getItems := func(resp *ListResponse) []ObjectInfo {
 		return resp.Objects
@@ -1549,36 +1267,8 @@ func (a *WorkspaceAPI) GetByPath(ctx context.Context, name string) (*ObjectInfo,
 //
 // Note that if this operation fails it may have succeeded in creating some of
 // the necessary parent directories.
-func (a *WorkspaceAPI) Mkdirs(ctx context.Context, request Mkdirs) error {
-	return a.impl.Mkdirs(ctx, request)
-}
-
-// Create a directory.
-//
-// Creates the specified directory (and necessary parent directories if they do
-// not exist). If there is an object (not a directory) at any prefix of the
-// input path, this call returns an error `RESOURCE_ALREADY_EXISTS`.
-//
-// Note that if this operation fails it may have succeeded in creating some of
-// the necessary parent directories.
 func (a *WorkspaceAPI) MkdirsByPath(ctx context.Context, path string) error {
-	return a.impl.Mkdirs(ctx, Mkdirs{
+	return a.WorkspaceService.Mkdirs(ctx, Mkdirs{
 		Path: path,
 	})
-}
-
-// Set workspace object permissions.
-//
-// Sets permissions on a workspace object. Workspace objects can inherit
-// permissions from their parent objects or root object.
-func (a *WorkspaceAPI) SetPermissions(ctx context.Context, request WorkspaceObjectPermissionsRequest) (*WorkspaceObjectPermissions, error) {
-	return a.impl.SetPermissions(ctx, request)
-}
-
-// Update workspace object permissions.
-//
-// Updates the permissions on a workspace object. Workspace objects can inherit
-// permissions from their parent objects or root object.
-func (a *WorkspaceAPI) UpdatePermissions(ctx context.Context, request WorkspaceObjectPermissionsRequest) (*WorkspaceObjectPermissions, error) {
-	return a.impl.UpdatePermissions(ctx, request)
 }

--- a/service/workspace/api.go
+++ b/service/workspace/api.go
@@ -114,9 +114,8 @@ type GitCredentialsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockGitCredentialsInterface instead.
 func (a *GitCredentialsAPI) WithImpl(impl GitCredentialsService) GitCredentialsInterface {
-	return &GitCredentialsAPI{
-		GitCredentialsService: impl,
-	}
+	a.GitCredentialsService = impl
+	return a
 }
 
 // Impl returns low-level GitCredentials API implementation
@@ -372,9 +371,8 @@ type ReposAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockReposInterface instead.
 func (a *ReposAPI) WithImpl(impl ReposService) ReposInterface {
-	return &ReposAPI{
-		ReposService: impl,
-	}
+	a.ReposService = impl
+	return a
 }
 
 // Impl returns low-level Repos API implementation
@@ -772,9 +770,8 @@ type SecretsAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockSecretsInterface instead.
 func (a *SecretsAPI) WithImpl(impl SecretsService) SecretsInterface {
-	return &SecretsAPI{
-		SecretsService: impl,
-	}
+	a.SecretsService = impl
+	return a
 }
 
 // Impl returns low-level Secrets API implementation
@@ -1127,9 +1124,8 @@ type WorkspaceAPI struct {
 // testing purposes with [github.com/golang/mock] or other mocking frameworks.
 // Deprecated: use MockWorkspaceInterface instead.
 func (a *WorkspaceAPI) WithImpl(impl WorkspaceService) WorkspaceInterface {
-	return &WorkspaceAPI{
-		WorkspaceService: impl,
-	}
+	a.WorkspaceService = impl
+	return a
 }
 
 // Impl returns low-level Workspace API implementation

--- a/service/workspace/utilities.go
+++ b/service/workspace/utilities.go
@@ -204,9 +204,9 @@ func (a *WorkspaceAPI) Upload(ctx context.Context, path string, r io.Reader, opt
 	if err != nil {
 		return fmt.Errorf("write close: %w", err)
 	}
-	impl, ok := a.impl.(*workspaceImpl)
+	impl, ok := a.WorkspaceService.(*workspaceImpl)
 	if !ok {
-		return fmt.Errorf("wrong impl: %v", a.impl)
+		return fmt.Errorf("wrong impl: %v", a.WorkspaceService)
 	}
 	headers := map[string]string{
 		"Content-Type": w.FormDataContentType(),
@@ -239,9 +239,9 @@ func DownloadFormat(f ExportFormat) func(q map[string]any) {
 //
 // Returns [bytes.Buffer] of the path contents.
 func (a *WorkspaceAPI) Download(ctx context.Context, path string, opts ...DownloadOption) (io.ReadCloser, error) {
-	impl, ok := a.impl.(*workspaceImpl)
+	impl, ok := a.WorkspaceService.(*workspaceImpl)
 	if !ok {
-		return nil, fmt.Errorf("wrong impl: %v", a.impl)
+		return nil, fmt.Errorf("wrong impl: %v", a.WorkspaceService)
 	}
 	var buf bytes.Buffer
 	query := map[string]any{"path": path, "direct_download": true}


### PR DESCRIPTION
## Changes

This PR changes the template to auto-generate Go code to enable mixins by leveraging Go embedding. 

One positive side-effect of this PR is that it significantly reduces the amount of auto-generated code.

After this change, methods can be overridden by adding the overriding method to the `ServiceNameAPI` struct. For example:

```go
// -------------------------------------------------------
// Generated code.
// -------------------------------------------------------

type FooService interface {
	Foo() string
	Bar() string
}

type FooAPI struct {
	FooService
}

type fooImpl struct{}

func (impl *fooImpl) Foo() string {
	return "foo"
}

func (impl *fooImpl) Bar() string {
	return "bar"
}

// -------------------------------------------------------
// Method that shadows the original Foo method inherited
// from fooImpl.
// -------------------------------------------------------

func (api *FooAPI) Foo() string {
	return fmt.Sprintf("extension: %s", api.fooImpl.Foo())
}
```

## Tests

Run unit tests and integrations tests. 

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

