### PR TITLE
[Internal] Add error mapping for GetRun

### DIFF
--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -66,6 +66,15 @@ var ErrorOverrides = []ErrorOverride{
 		ErrorCodeMatcher:  regexp.MustCompile(INVALID_PARAMETER_VALUE),
 		OverrideErrorCode: RESOURCE_DOES_NOT_EXIST,
 	},
+	{
+		Name:              "Job Runs InvalidParameterValue=>ResourceDoesNotExist",
+		PathRegex:         regexp.MustCompile(`^/api/2\.\d/jobs/runs/get`),
+		Verb:              "GET",
+		StatusCodeMatcher: regexp.MustCompile(`^400$`),
+		MessageMatcher:    regexp.MustCompile("(Run .* does not exist|Run: .* in job: .* doesn't exist)"),
+		ErrorCodeMatcher:  regexp.MustCompile(INVALID_PARAMETER_VALUE),
+		OverrideErrorCode: RESOURCE_DOES_NOT_EXIST,
+	},
 }
 
 var TransientErrorRegexes = []*regexp.Regexp{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Added error override for Get Run similarly to Get Job. Error messages: https://github.com/databricks/universe/blob/2e44b4d42c0832acc3a06792cbb285609b77e956/elastic-spark-common/message/JobsMessages.scala#L555
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [x] `make fmt` applied
- [ ] relevant integration tests applied

