### PR TITLE
[Internal] Fix integration tests

### DIFF
--- a/internal/account_client_test.go
+++ b/internal/account_client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMwsAccAccountClient_GetWorkspaceClient_NoTranspile(t *testing.T) {
-	ctx, a := accountTest(t)
+	ctx, a := ucacctTest(t)
 	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
 	ws, err := a.Workspaces.GetByWorkspaceId(ctx, int64(workspaceId))
 	require.NoError(t, err)

--- a/internal/clusters_test.go
+++ b/internal/clusters_test.go
@@ -150,6 +150,11 @@ func TestAccClustersApiIntegration(t *testing.T) {
 	assert.Equal(t, 10, byId.AutoterminationMinutes)
 	assert.Equal(t, 2, byId.NumWorkers)
 
+	// Test getting the cluster by name
+	byName, err := w.Clusters.GetByClusterName(ctx, byId.ClusterName)
+	require.NoError(t, err)
+	assert.Equal(t, byId.ClusterId, byName.ClusterId)
+
 	// Terminate the cluster
 	_, err = w.Clusters.DeleteByClusterIdAndWait(ctx, clstr.ClusterId)
 	require.NoError(t, err)
@@ -158,10 +163,6 @@ func TestAccClustersApiIntegration(t *testing.T) {
 	byId, err = w.Clusters.GetByClusterId(ctx, clstr.ClusterId)
 	require.NoError(t, err)
 	assert.Equal(t, byId.State, compute.StateTerminated)
-
-	byName, err := w.Clusters.GetByClusterName(ctx, byId.ClusterName)
-	require.NoError(t, err)
-	assert.Equal(t, byId.ClusterId, byName.ClusterId)
 
 	// Start cluster and wait until it's running again
 	_, err = w.Clusters.StartByClusterIdAndWait(ctx, clstr.ClusterId)

--- a/internal/warehouses_test.go
+++ b/internal/warehouses_test.go
@@ -16,6 +16,14 @@ func TestAccSqlWarehouses(t *testing.T) {
 		ClusterSize:    "2X-Small",
 		MaxNumClusters: 1,
 		AutoStopMins:   10,
+		Tags: &sql.EndpointTags{
+			CustomTags: []sql.EndpointTagPair{
+				{
+					Key:   "Owner",
+					Value: "eng-dev-ecosystem-team@databricks.com",
+				},
+			},
+		},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes
There are three issues affecting our integration tests today:
1. When authenticated as a service principal, GetWorkspaceClient only works if the target workspace is a UC-enabled workspace. Currently, the test targets a non-UC workspace, so I've changed it to target a UC workspace.
2. In our AWS environment, clusters/warehouses can only be created if they have an "Owner" tag. I've updated TestAccSqlWarehouses to add this tag corresponding to our team.
3. There was a change in the behavior of cluster listing. Previously, list clusters API would return recently terminated clusters. However, now that doesn't seem to be the case. I've raised this with the appropriate backend team. In the meantime, I've updated the integration test to do all listing operations while the cluster is running.

## Tests
Triggered the integration tests on this PR.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

