### PR TITLE
[Internal] Fix GetWorkspaceClient test & GCP SQL Warehouse Creation test

### DIFF
--- a/internal/account_client_test.go
+++ b/internal/account_client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMwsAccAccountClient_GetWorkspaceClient_NoTranspile(t *testing.T) {
+func TestUcAccAccountClient_GetWorkspaceClient_NoTranspile(t *testing.T) {
 	ctx, a := ucacctTest(t)
 	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "TEST_WORKSPACE_ID"))
 	ws, err := a.Workspaces.GetByWorkspaceId(ctx, int64(workspaceId))

--- a/internal/warehouses_test.go
+++ b/internal/warehouses_test.go
@@ -20,7 +20,7 @@ func TestAccSqlWarehouses(t *testing.T) {
 			CustomTags: []sql.EndpointTagPair{
 				{
 					Key:   "Owner",
-					Value: "eng-dev-ecosystem-team@databricks.com",
+					Value: "eng-dev-ecosystem-team_at_databricks.com",
 				},
 			},
 		},


### PR DESCRIPTION
## Changes
This test should only be triggered in UC Account-level test runner.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

