### PR TITLE
[Internal] Pin runs/submit to API 2.1

### DIFF
--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -147,5 +147,5 @@ func TestJobs2Dot2Compatability(t *testing.T) {
 	require.NotNil(t, jobs)
 	require.NotNil(t, jobs.services["Jobs"])
 	require.Equal(t, "/api/2.1/jobs/get", jobs.services["Jobs"].methods["get"].Path)
-	require.Equal(t, "/api/2.2/jobs/runs/submit", jobs.services["Jobs"].methods["submitRun"].Path)
+	require.Equal(t, "/api/2.1/jobs/runs/submit", jobs.services["Jobs"].methods["submitRun"].Path)
 }

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -491,12 +491,12 @@ func (svc *Service) getPathStyle(op *openapi.Operation) openapi.PathStyle {
 }
 
 var jobs2Dot1Apis = map[string]struct{}{
-	"/api/2.2/jobs/create":    {},
-	"/api/2.2/jobs/update":    {},
-	"/api/2.2/jobs/list":      {},
-	"/api/2.2/jobs/get":       {},
-	"/api/2.2/jobs/reset":     {},
-	"/api/2.2/jobs/runs/list": {},
+	"/api/2.2/jobs/create":      {},
+	"/api/2.2/jobs/update":      {},
+	"/api/2.2/jobs/list":        {},
+	"/api/2.2/jobs/get":         {},
+	"/api/2.2/jobs/reset":       {},
+	"/api/2.2/jobs/runs/list":   {},
 	"/api/2.2/jobs/runs/submit": {},
 }
 

--- a/openapi/code/service.go
+++ b/openapi/code/service.go
@@ -497,6 +497,7 @@ var jobs2Dot1Apis = map[string]struct{}{
 	"/api/2.2/jobs/get":       {},
 	"/api/2.2/jobs/reset":     {},
 	"/api/2.2/jobs/runs/list": {},
+	"/api/2.2/jobs/runs/submit": {},
 }
 
 func (svc *Service) pinJobsApisTo2Dot1(path string) string {


### PR DESCRIPTION
## Changes
Queueing by default affects API 2.2 too, so we need to lock this API endpoint too

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

