### PR TITLE
[Fix] Fix default-auth example when less than 10 clusters

### DIFF
--- a/examples/default-auth/main.go
+++ b/examples/default-auth/main.go
@@ -13,7 +13,5 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	for _, c := range all[:10] {
-		println(c.ClusterName)
-	}
+	println("Found %d clusters.", len(all))
 }


### PR DESCRIPTION
## Changes

This PR fixes the `default-auth` example which raised an out-of-bound exception if the account has less than 10 clusters.

Note: the goal of the example is to demonstrate the auth mechanism, not to iterate on workspaces. 

## Tests

Unit test + run the example 

- [x] `make test` passing
- [x] `make fmt` applied
- [x] relevant integration tests applied

