### PR TITLE
[Internal] Add terraform aliases to Entity

### DIFF
--- a/openapi/code/entity.go
+++ b/openapi/code/entity.go
@@ -87,7 +87,12 @@ type Entity struct {
 	fields        map[string]*Field
 
 	// Schema references the OpenAPI schema this entity was created from.
-	Schema *openapi.Schema
+	Schema    *openapi.Schema
+	Terraform *Terraform
+}
+
+type Terraform struct {
+	Alias string
 }
 
 // Whether the Entity contains a basic GoLang type which is not required

--- a/openapi/code/load_test.go
+++ b/openapi/code/load_test.go
@@ -19,6 +19,7 @@ func TestNested(t *testing.T) {
 	require.Contains(t, batch.packages["settings"].services, "Settings")
 	require.Contains(t, batch.packages["settings"].services["Settings"].subservices, "DefaultNamespace")
 	require.Equal(t, batch.packages["settings"].services["DefaultNamespace"].ParentService.Name, "Settings")
+	require.Equal(t, batch.packages["settings"].services["DefaultNamespace"].methods["cancel"].Response.fields["last-modified"].Entity.Terraform.Alias, "new_name")
 }
 
 func TestBasic(t *testing.T) {

--- a/openapi/code/package.go
+++ b/openapi/code/package.go
@@ -155,6 +155,10 @@ func (pkg *Package) schemaToEntity(s *openapi.Schema, path []string, hasName boo
 	e.IsComputed = s.IsComputed
 	e.RequiredOrder = s.Required
 
+	if s.Terraform != nil {
+		e.Terraform = &Terraform{Alias: s.Terraform.Alias}
+	}
+
 	switch {
 	case len(s.Enum) != 0:
 		return pkg.makeEnum(e, s, path)

--- a/openapi/model.go
+++ b/openapi/model.go
@@ -262,6 +262,11 @@ type Schema struct {
 	Properties       map[string]*Schema `json:"properties,omitempty"`
 	ArrayValue       *Schema            `json:"items,omitempty"`
 	MapValue         *Schema            `json:"additionalProperties,omitempty"`
+	Terraform        *Terraform         `json:"x-databricks-terraform,omitempty"`
+}
+
+type Terraform struct {
+	Alias string `json:"alias,omitempty"`
 }
 
 func (s *Schema) IsEnum() bool {

--- a/openapi/testdata/spec_subservices.json
+++ b/openapi/testdata/spec_subservices.json
@@ -198,7 +198,10 @@
       "ModificationTime": {
         "description": "Last modification time of given file in milliseconds since unix epoch.",
         "type": "integer",
-        "format": "int64"
+        "format": "int64",
+        "x-databricks-terraform":{
+          "alias": "new_name"
+        }
       },
       "ResultType": {
         "enum": [


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Add terraform aliases to Entity. Such that aliases can be used for names in terraform provider.
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

