### PR TITLE
[Internal] Fixed logging for Go SDK

### DIFF
--- a/config/auth_azure_msi_test.go
+++ b/config/auth_azure_msi_test.go
@@ -7,15 +7,8 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
-	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/stretchr/testify/require"
 )
-
-func init() {
-	logger.DefaultLogger = &logger.SimpleLogger{
-		Level: logger.LevelDebug,
-	}
-}
 
 func someValidToken(bearer string) any {
 	return map[string]any{

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,8 +4,6 @@ import (
 	"context"
 )
 
-var DefaultLogger Logger = &SimpleLogger{}
-
 // Level maps to the logging levels in [Logger].
 type Level int
 
@@ -44,7 +42,7 @@ type Logger interface {
 func Get(ctx context.Context) Logger {
 	logger, ok := FromContext(ctx)
 	if !ok {
-		logger = DefaultLogger
+		logger = &SimpleLogger{}
 	}
 	return logger
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,6 +7,8 @@ import (
 // Level maps to the logging levels in [Logger].
 type Level int
 
+var DefaultLogger Logger = &SimpleLogger{}
+
 const (
 	LevelTrace = -8
 	LevelDebug = -4
@@ -42,7 +44,7 @@ type Logger interface {
 func Get(ctx context.Context) Logger {
 	logger, ok := FromContext(ctx)
 	if !ok {
-		logger = &SimpleLogger{}
+		logger = DefaultLogger
 	}
 	return logger
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var TestDefaultLogger Logger = &SimpleLogger{}
+
 func TestGetLogger(t *testing.T) {
 	t.Cleanup(func() {
-		DefaultLogger = &SimpleLogger{}
+		TestDefaultLogger = &SimpleLogger{}
 	})
 
 	t1 := &SimpleLogger{}
 	t2 := &SimpleLogger{}
-	DefaultLogger = t1
+	TestDefaultLogger = t1
 
 	logger := Get(context.Background())
 	assert.Equal(t, logger, t1)
@@ -26,7 +28,7 @@ func TestGetLogger(t *testing.T) {
 
 func TestWhenInfoLevelThenDebugDisabled(t *testing.T) {
 	t.Cleanup(func() {
-		DefaultLogger = &SimpleLogger{}
+		TestDefaultLogger = &SimpleLogger{}
 	})
 
 	infoLevelLogger := &SimpleLogger{


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We use the global pointer to logger which is also modified in tests. Due to this it gets set to nil and doesn't do the logging at any level. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Verified locally that logs work that weren't previously. 
- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

