### PR TITLE
[Fix] Do not specify `--tenant` flag when fetching managed identity access token from the CLI

### DIFF
--- a/config/auth_azure_cli.go
+++ b/config/auth_azure_cli.go
@@ -159,7 +159,7 @@ func (ts *azureCliTokenSource) Token() (*oauth2.Token, error) {
 	}).WithExtra(extra), nil
 }
 
-const azCliTenantSpecifiedWithManagedIdentityError = `ERROR: Tenant shouldn't be specified for managed identity account`
+const azCliTenantSpecifiedWithManagedIdentityError = `Tenant shouldn't be specified for managed identity account`
 
 func (ts *azureCliTokenSource) getTokenBytes() ([]byte, error) {
 	bs, err := ts.getTokenBytesWithTenantId(ts.azureTenantId)

--- a/config/auth_azure_cli_test.go
+++ b/config/auth_azure_cli_test.go
@@ -255,10 +255,10 @@ func TestAzureCliCredentials_DoNotSpecifyTenantIdWithMSI(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.userName, func(t *testing.T) {
 			env.CleanupEnvironment(t)
-			os.Setenv("PATH", testdataPath())
-			os.Setenv("FAIL_IF_TENANT_ID_SET", "true")
-			os.Setenv("AZ_USER_NAME", c.userName)
-			os.Setenv("AZ_USER_TYPE", "servicePrincipal")
+			t.Setenv("PATH", testdataPath())
+			t.Setenv("FAIL_IF_TENANT_ID_SET", "true")
+			t.Setenv("AZ_USER_NAME", c.userName)
+			t.Setenv("AZ_USER_TYPE", "servicePrincipal")
 			aa := AzureCliCredentials{}
 			_, err := aa.Configure(context.Background(), &Config{
 				Host:          "https://adb-xyz.c.azuredatabricks.net/",

--- a/config/auth_azure_cli_test.go
+++ b/config/auth_azure_cli_test.go
@@ -245,6 +245,20 @@ func TestAzureCliCredentials_DoNotFetchIfTenantIdAlreadySet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAzureCliCredentials_RetryIfTenantIdSetWithManagedIdentity(t *testing.T) {
+	env.CleanupEnvironment(t)
+	os.Setenv("PATH", testdataPath())
+	os.Setenv("FAIL_IF_TENANT_ID_SET", "true")
+	aa := AzureCliCredentials{}
+	_, err := aa.Configure(context.Background(), &Config{
+		Host:                     "https://adb-xyz.c.azuredatabricks.net/",
+		AzureTenantID:            "123",
+		// The tenant is specified, so the SDK doesn't need to fetch it.
+		azureTenantIdFetchClient: makeFailingClient(errDummy),
+	})
+	assert.NoError(t, err)
+}
+
 // TODO: this test should rather be on sequencing
 // func TestConfigureWithAzureCLI_SP(t *testing.T) {
 // 	aa := DatabricksClient{

--- a/config/auth_azure_cli_test.go
+++ b/config/auth_azure_cli_test.go
@@ -245,18 +245,28 @@ func TestAzureCliCredentials_DoNotFetchIfTenantIdAlreadySet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestAzureCliCredentials_RetryIfTenantIdSetWithManagedIdentity(t *testing.T) {
-	env.CleanupEnvironment(t)
-	os.Setenv("PATH", testdataPath())
-	os.Setenv("FAIL_IF_TENANT_ID_SET", "true")
-	aa := AzureCliCredentials{}
-	_, err := aa.Configure(context.Background(), &Config{
-		Host:                     "https://adb-xyz.c.azuredatabricks.net/",
-		AzureTenantID:            "123",
-		// The tenant is specified, so the SDK doesn't need to fetch it.
-		azureTenantIdFetchClient: makeFailingClient(errDummy),
-	})
-	assert.NoError(t, err)
+func TestAzureCliCredentials_DoNotSpecifyTenantIdWithMSI(t *testing.T) {
+	cases := []struct {
+		userName string
+	}{
+		{"systemAssignedIdentity"},
+		{"userAssignedIdentity"},
+	}
+	for _, c := range cases {
+		t.Run(c.userName, func(t *testing.T) {
+			env.CleanupEnvironment(t)
+			os.Setenv("PATH", testdataPath())
+			os.Setenv("FAIL_IF_TENANT_ID_SET", "true")
+			os.Setenv("AZ_USER_NAME", c.userName)
+			os.Setenv("AZ_USER_TYPE", "servicePrincipal")
+			aa := AzureCliCredentials{}
+			_, err := aa.Configure(context.Background(), &Config{
+				Host:          "https://adb-xyz.c.azuredatabricks.net/",
+				AzureTenantID: "123",
+			})
+			assert.NoError(t, err)
+		})
+	}
 }
 
 // TODO: this test should rather be on sequencing

--- a/config/auth_azure_msi_test.go
+++ b/config/auth_azure_msi_test.go
@@ -82,45 +82,6 @@ func TestMsiHappyFlow(t *testing.T) {
 	})
 }
 
-func TestMsiHappyFlowNoResourceId(t *testing.T) {
-	assertHeaders(t, &Config{
-		AzureUseMSI:     true,
-		AzureResourceID: "/a/b/c",
-		HTTPTransport: fixtures.MappingTransport{
-			"GET /metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F": {
-				ExpectedHeaders: map[string]string{
-					"Accept":   "application/json",
-					"Metadata": "true",
-				},
-				Response: someValidToken("bcd"),
-			},
-			"GET /a/b/c?api-version=2018-04-01": {
-				Response: `{"properties": {
-					"workspaceUrl": "https://abc"
-				}}`,
-			},
-			"GET /metadata/identity/oauth2/token?api-version=2018-02-01&resource=2ff814a6-3304-4ab8-85cb-cd0e6f879c1d": {
-				ExpectedHeaders: map[string]string{
-					"Accept":   "application/json",
-					"Metadata": "true",
-				},
-				Response: someValidToken("cde"),
-			},
-			"GET /metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.core.windows.net%2F": {
-				ExpectedHeaders: map[string]string{
-					"Accept":   "application/json",
-					"Metadata": "true",
-				},
-				Response: someValidToken("def"),
-			},
-		},
-	}, map[string]string{
-		"Authorization":                            "Bearer cde",
-		"X-Databricks-Azure-Sp-Management-Token":   "def",
-		"X-Databricks-Azure-Workspace-Resource-Id": "/a/b/c",
-	})
-}
-
 func TestMsiFailsOnResolveWorkspace(t *testing.T) {
 	_, err := authenticateRequest(&Config{
 		AzureUseMSI:     true,

--- a/config/testdata/az
+++ b/config/testdata/az
@@ -27,6 +27,16 @@ if [ -n "$COUNT" ]; then
     echo -n x >> "$COUNT"
 fi
 
+# If FAIL_IF_TENANT_ID_SET is set & --tenant-id is passed, fail.
+if [ -n "$FAIL_IF_TENANT_ID_SET" ]; then
+    for arg in "$@"; do
+        if [[ "$arg" == "--tenant-id" ]]; then
+            echo "ERROR: Tenant shouldn't be specified for managed identity account"
+            exit 1
+        fi
+    done
+fi
+
 # Macos
 EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
 if [ -z "${EXP}" ]; then

--- a/config/testdata/az
+++ b/config/testdata/az
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# If the arguments are "account show", return the account details.
+if [ "$1" == "account" ] && [ "$2" == "show" ]; then
+    /bin/echo "{
+    \"environmentName\": \"AzureCloud\",
+    \"id\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+    \"isDefault\": true,
+    \"name\": \"Pay-As-You-Go\",
+    \"state\": \"Enabled\",
+    \"tenantId\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+    \"user\": {
+        \"name\": \"${AZ_USER_NAME:-testuser@databricks.com}\",
+        \"type\": \"${AZ_USER_TYPE:-user}\"
+    }
+}"
+    exit 0
+fi
+
 if [ "yes" == "$FAIL" ]; then
     >&2 /bin/echo "This is just a failing script."
     exit 1

--- a/config/testdata/az
+++ b/config/testdata/az
@@ -31,7 +31,7 @@ fi
 if [ -n "$FAIL_IF_TENANT_ID_SET" ]; then
     for arg in "$@"; do
         if [[ "$arg" == "--tenant" ]]; then
-            echo "ERROR: Tenant shouldn't be specified for managed identity account"
+            echo 1>&2 "ERROR: Tenant shouldn't be specified for managed identity account"
             exit 1
         fi
     done

--- a/config/testdata/az
+++ b/config/testdata/az
@@ -30,7 +30,7 @@ fi
 # If FAIL_IF_TENANT_ID_SET is set & --tenant-id is passed, fail.
 if [ -n "$FAIL_IF_TENANT_ID_SET" ]; then
     for arg in "$@"; do
-        if [[ "$arg" == "--tenant-id" ]]; then
+        if [[ "$arg" == "--tenant" ]]; then
             echo "ERROR: Tenant shouldn't be specified for managed identity account"
             exit 1
         fi


### PR DESCRIPTION
## Changes
Addresses https://github.com/databricks/terraform-provider-databricks/issues/3918.

The Azure CLI's `az account get-access-token` command does not allow specifying `--tenant` flag if it is authenticated via the CLI.

See https://github.com/hashicorp/go-azure-sdk/pull/910 for context; this implementation mimics the work done there.

## Tests
Unit tests ensure that all expected cases are treated as managed identities.

Added an integration test to verify that this works on machines using MSI with the Azure CLI installed.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

