### PR TITLE
[Fix] Update test to support new accounts

### DIFF
--- a/internal/billing_test.go
+++ b/internal/billing_test.go
@@ -16,8 +16,8 @@ func TestMwsAccUsageDownload(t *testing.T) {
 		t.SkipNow()
 	}
 	resp, err := a.BillableUsage.Download(ctx, billing.DownloadRequest{
-		StartMonth: "2023-01",
-		EndMonth:   "2023-02",
+		StartMonth: "2024-08",
+		EndMonth:   "2024-09",
 	})
 	require.NoError(t, err)
 	out, err := io.ReadAll(resp.Contents)


### PR DESCRIPTION
## Changes
Update test to support new accounts.
New accounts don't have data from 2023.

## Tests
- [X] `make test` passing
- [X] `make fmt` applied
- [X] relevant integration tests applied

