### PR TITLE
[Internal] Temporary ignore Metastore test failures

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -12,3 +12,6 @@ ignored_tests:
     - package: github.com/databricks/databricks-sdk-go/internal
       test_name: TestMwsAccBudgets
       comment: Oauth issues in 2.1 REST APIs. Tracked in https://databricks.atlassian.net/browse/ES-1197977
+    - package: github.com/databricks/databricks-sdk-go/internal
+      test_name: TestUcAccMetastores
+      comment: Metastores are limited in new accounts. Limit increase in https://databricks.atlassian.net/browse/ES-1242706


### PR DESCRIPTION
## Changes
Temporary ignore Metastore test failures.
Test fails in new account due to limit on Metastores.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [X] `make test` passing
- [X] `make fmt` applied
- [ ] relevant integration tests applied

