### PR TITLE
[Internal] Add TestAccCreateOboTokenOnAws to flaky test list

### DIFF
--- a/test-config.yaml
+++ b/test-config.yaml
@@ -15,3 +15,6 @@ ignored_tests:
     - package: github.com/databricks/databricks-sdk-go/internal
       test_name: TestUcAccMetastores
       comment: Metastores are limited in new accounts. Limit increase in https://databricks.atlassian.net/browse/ES-1242706
+    - package: github.com/databricks/databricks-sdk-go/internal
+      test_name: TestAccCreateOboTokenOnAws
+      comment: Flaky test. Tracked in https://databricks.atlassian.net/browse/ES-1243720


### PR DESCRIPTION
## Changes
Add TestAccCreateOboTokenOnAws to flaky test list

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

