### PR TITLE
[Fix] Fail fast when authenticating if host is not configured

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -363,7 +363,7 @@ func (c *Config) authenticateIfNeeded() error {
 	if c.Credentials == nil {
 		c.Credentials = &DefaultCredentials{}
 	}
-	if err := c.fixHostIfNeeded(); !errors.Is(err, ErrNoHostConfigured) {
+	if err := c.fixHostIfNeeded(); err != nil && !errors.Is(err, ErrNoHostConfigured) {
 		return err
 	}
 	ctx := c.refreshClient.InContextForOAuth2(c.refreshCtx)

--- a/config/config.go
+++ b/config/config.go
@@ -337,7 +337,8 @@ func (c *Config) WithTesting() *Config {
 }
 
 func (c *Config) CanonicalHostName() string {
-	c.fixHostIfNeeded()
+	// Missing host is tolerated here.
+	_ = c.fixHostIfNeeded()
 	return c.Host
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsAccountClient_AwsAccount(t *testing.T) {
@@ -51,4 +54,15 @@ func TestNewWithWorkspaceHost(t *testing.T) {
 	assert.Equal(t, "http://", c2.MetadataServiceURL)
 	// The new config will not be automatically resolved.
 	assert.False(t, c2.resolved)
+}
+
+func TestAuthenticate_InvalidHostSet(t *testing.T) {
+	c := &Config{
+		Host:  "https://:443",
+		Token: "abcdefg",
+	}
+	req, err := http.NewRequestWithContext(context.Background(), "GET", c.Host, nil)
+	require.NoError(t, err)
+	err = c.Authenticate(req)
+	assert.ErrorIs(t, err, ErrNoHostConfigured)
 }


### PR DESCRIPTION
## Changes
The SDK currently hangs when making API requests if the Host is set to a non-empty but invalid endpoint, such as `https://:443`. This PR adds a check during authentication to ensure that the hostname is defined, failing early if not. The underlying error is exported so other clients, such as the CLI or Terraform Provider, can provide specific advice when this happens.

## Tests
Added a unit test for this case.

- [ ] `make test` passing
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

