### PR TITLE
[Internal] Add test instructions for external contributors

### DIFF
--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -12,26 +12,74 @@ on:
       - main
 
 
-
 jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+
     steps:
-      - name: Check if external contribution
-        id: check_fork
+      # NOTE: The following checks may not be accurate depending on Org or Repo settings. 
+      - name: Check user and potential secret access
+        id: check-secrets-access
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "is_fork=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_fork=false" >> $GITHUB_OUTPUT
+          USER_LOGIN="${{ github.event.pull_request.user.login }}"
+          REPO_OWNER="${{ github.repository_owner }}"
+          REPO_NAME="${{ github.event.repository.name }}"
+          
+          echo "Pull request opened by: $USER_LOGIN"
+          
+          # Check if PR is from a fork
+          IS_FORK=$([[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]] && echo "true" || echo "false")
+          
+          HAS_ACCESS="false"
+          
+          # Check user's permission level on the repository
+          USER_PERMISSION=$(gh api repos/$REPO_OWNER/$REPO_NAME/collaborators/$USER_LOGIN/permission --jq '.permission')
+          
+          if [[ "$USER_PERMISSION" == "admin" || "$USER_PERMISSION" == "write" ]]; then
+            HAS_ACCESS="true"
+          elif [[ "$USER_PERMISSION" == "read" ]]; then
+            # For read access, we need to check if the user has been explicitly granted secret access
+            # This information is not directly available via API, so we'll make an assumption
+            # that read access does not imply secret access
+            HAS_ACCESS="false"
           fi
+          
+          # Check if repo owner is an organization
+          IS_ORG=$(gh api users/$REPO_OWNER --jq '.type == "Organization"')
+          
+          if [[ "$IS_ORG" == "true" && "$HAS_ACCESS" == "false" ]]; then
+            # Check if user is a member of any team with write or admin access to the repo
+            TEAMS_WITH_ACCESS=$(gh api repos/$REPO_OWNER/$REPO_NAME/teams --jq '.[] | select(.permission == "push" or .permission == "admin") | .slug')
+            for team in $TEAMS_WITH_ACCESS; do
+              IS_TEAM_MEMBER=$(gh api orgs/$REPO_OWNER/teams/$team/memberships/$USER_LOGIN --silent && echo "true" || echo "false")
+              if [[ "$IS_TEAM_MEMBER" == "true" ]]; then
+                HAS_ACCESS="true"
+                break
+              fi
+            done
+          fi
+          
+          # If it's a fork, set HAS_ACCESS to false regardless of other checks
+          if [[ "$IS_FORK" == "true" ]]; then
+            HAS_ACCESS="false"
+          fi
+          
+          echo "has_secrets_access=$HAS_ACCESS" >> $GITHUB_OUTPUT
+          if [[ "$HAS_ACCESS" == "true" ]]; then
+            echo "User $USER_LOGIN likely has access to secrets"
+          else
+            echo "User $USER_LOGIN likely does not have access to secrets"
+          fi
+
 
       - uses: actions/checkout@v4
 
       - name: Delete old comments
-        if: steps.check_fork.outputs.is_fork == 'true'
+        if: steps.check-secrets-access.outputs.has_secrets_access != 'true'
         env:
            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -48,9 +96,10 @@ jobs:
             fi
 
       - name: Comment on PR
-        if: steps.check_fork.outputs.is_fork == 'true'
+        if: steps.check-secrets-access.outputs.has_secrets_access != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body \
           "<!-- INTEGRATION_TESTS -->
@@ -58,8 +107,8 @@ jobs:
           [go/deco-tests-run/sdk-go](https://go/deco-tests-run/sdk-go)
 
           Inputs:
-          PR Number:${{github.event.pull_request.number}}
-          Commit SHA:${{ github.event.pull_request.head.sha }}
+          * PR number: ${{github.event.pull_request.number}}
+          * Commit SHA: \`${{ env.COMMIT_SHA }}\`
           
           Checks will be approved automatically on success.
           "

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -1,0 +1,65 @@
+name: PR Comment
+
+# WARNING:
+# THIS WORKFLOW ALWAYS RUNS FOR EXTERNAL CONTRIBUTORS WITHOUT ANY APPROVAL.
+# THIS WORKFLOW RUNS FROM MAIN BRANCH, NOT FROM THE PR BRANCH.
+# DO NOT PULL THE PR OR EXECUTE ANY CODE FROM THE PR.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+
+
+jobs:
+  comment-on-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check if external contribution
+        id: check_fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Delete old comments
+        if: steps.check_fork.outputs.is_fork == 'true'
+        env:
+           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            # Delete previous comment if it exists
+            previous_comment_ids=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --jq '.[] | select(.body | startswith("<!-- INTEGRATION_TESTS -->")) | .id')
+            echo "Previous comment IDs: $previous_comment_ids"
+            # Iterate over each comment ID and delete the comment
+            if [ ! -z "$previous_comment_ids" ]; then
+              echo "$previous_comment_ids" | while read -r comment_id; do
+                echo "Deleting comment with ID: $comment_id"
+                gh api "repos/${{ github.repository }}/issues/comments/$comment_id" -X DELETE
+              done
+            fi
+
+      - name: Comment on PR
+        if: steps.check_fork.outputs.is_fork == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body \
+          "<!-- INTEGRATION_TESTS -->
+          Run integration tests manually:
+          [go/deco-tests-run/sdk-go](https://go/deco-tests-run/sdk-go)
+
+          Inputs:
+          PR Number:${{github.event.pull_request.number}}
+          Commit SHA:${{ github.event.pull_request.head.sha }}
+          
+          Checks will be approved automatically on success.
+          "

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,11 +9,28 @@ on:
   
 
 jobs:
-  # Secrets are not available for forks.
+  check-token:
+    name: Check secrets access
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.set-token-status.outputs.has_token }}
+    steps:
+      - name: Check if GITHUB_TOKEN is set
+        id: set-token-status
+        run: |
+          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
+            echo "GITHUB_TOKEN is empty. User has no access to tokens."
+            echo "::set-output name=has_token::false"
+          else
+            echo "GITHUB_TOKEN is set. User has no access to tokens."
+            echo "::set-output name=has_token::true"
+          fi
+
   trigger-tests:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     name: Trigger Tests
     runs-on: ubuntu-latest
+    needs: check-token
+    if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
     environment: "test-trigger-is"
     
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,8 +9,9 @@ on:
   
 
 jobs:
+  # Secrets are not available for forks.
   trigger-tests:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     name: Trigger Tests
     runs-on: ubuntu-latest
     environment: "test-trigger-is"


### PR DESCRIPTION
## Changes

Add test instructions for external contributions. The instructions are meant for Databricks reviewers who will be running the integration tests.

## Tests
Temporary added the following target to trigger the workflow
```
pull_request:
    types: [opened, reopened, synchronize]
```
and changed the equality in the external check
```
          if [ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]; then
```

Result:
![Screenshot 2024-10-29 at 10 54 05](https://github.com/user-attachments/assets/a6bade55-e4ce-4aed-bbee-1249def2ab5f)


