### PR TITLE
[Internal] Update workflows to run on the `dev/sdk-mod` branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev/sdk-mod" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "dev/sdk-mod" ]
   schedule:
     - cron: '41 1 * * 0'
 

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -9,7 +9,7 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
     branches:
-      - main
+      - dev/sdk-mod
 
 jobs:
   comment-on-pr:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ on:
     # because the commit is identical, yet we need to perform it to
     # seed the build cache.
     branches:
-      - main
+      - dev/sdk-mod
 
 jobs:
   tests:


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the Github workflows to run on the `dev/sdk-mod` branch.

## How is this tested?

Tested by running these workflows on this PR. Integrations tests still need to be adjusted.

