### PR TITLE
[Internal] Scope the traversing directory in the Recursive list workspace test

### DIFF
--- a/internal/workspace_test.go
+++ b/internal/workspace_test.go
@@ -224,7 +224,7 @@ func TestAccWorkspaceRecursiveListNoTranspile(t *testing.T) {
 		workspace.UploadOverwrite())
 	require.NoError(t, err)
 
-	allMyNotebooks, err := w.Workspace.RecursiveList(ctx, filepath.Join("/Users", me(t, w).UserName))
+	allMyNotebooks, err := w.Workspace.RecursiveList(ctx, filepath.Join("/Users", me(t, w).UserName, ".sdk"))
 	require.NoError(t, err)
 	assert.True(t, len(allMyNotebooks) >= 1)
 }

--- a/internal/workspace_test.go
+++ b/internal/workspace_test.go
@@ -16,7 +16,7 @@ import (
 
 func myNotebookPath(t *testing.T, w *databricks.WorkspaceClient) string {
 	ctx := context.Background()
-	testDir := filepath.Join("/Users", me(t, w).UserName, ".sdk", RandomName("t-"))
+	testDir := filepath.Join("/Users", me(t, w).UserName, ".sdk", "notebooks", RandomName("t-"))
 	notebook := filepath.Join(testDir, RandomName("n-"))
 
 	err := w.Workspace.MkdirsByPath(ctx, testDir)


### PR DESCRIPTION
## What changes are proposed in this pull request?
What - The PR modifies the scope of directory traversal in the recursive list test. It limits the search to the ".sdk" directory, where the relevant notebook is created.

Why - The test was previously hitting API rate limits because it was scanning too many elements in the current traversing directory. By narrowing the scope to the ".sdk" directory, the test can now run more efficiently without encountering these limits.

## How is this tested?
This is itself an integration test.