### PR TITLE
[Internal] Add download target to MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ vendor:
 	@echo "✓ Filling vendor folder with library code ..."
 	@go mod vendor
 
+download:
+	@echo "✓ Downloading dependencies ..."
+	@go mod download
+
 doc:
 	@echo "Open http://localhost:6060"
 	@go run golang.org/x/tools/cmd/godoc@latest -http=localhost:6060
 
-.PHONY: fmt vendor fmt coverage test lint doc
+.PHONY: fmt vendor fmt coverage test lint doc download


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR introduces a download target which is a wrapper around `go mod download`. The rationale behind introducing this target is that we can change the underlying implementation of this target for `dev/sdk-mod` branch in which there is no go.mod at the root repository so we need to either manually run download for all the go modules or introduce a make target like [this](https://github.com/databricks/databricks-sdk-go/pull/1123/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52). One could say that we can just add this target for SDK mod but we need to update integration test workflows accordingly. I think this is a better way than having an if/else statement in the workflow.

## How is this tested?
Locally run `make download`