### PR TITLE
[Internal] Update Jobs `list` function to support paginated responses

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Documentation
 
 ### Internal Changes
+* Update Jobs ListJobs API to support paginated responses ([#1150](https://github.com/databricks/databricks-sdk-go/pull/1150))
 * Introduce automated tagging ([#1148](https://github.com/databricks/databricks-sdk-go/pull/1148)).
 * Update Jobs GetJob API to support paginated responses  ([#1133](https://github.com/databricks/databricks-sdk-go/pull/1133)).
 * Update Jobs GetRun API to support paginated responses  ([#1132](https://github.com/databricks/databricks-sdk-go/pull/1132)).

--- a/service/jobs/ext_api.go
+++ b/service/jobs/ext_api.go
@@ -6,6 +6,9 @@ import (
 	"github.com/databricks/databricks-sdk-go/listing"
 )
 
+// List fetches a list of jobs.
+// If expand_tasks is true, the response will include the full list of tasks and job_clusters for each job.
+// This function handles pagination two ways: paginates all the jobs in the list and paginates all the tasks and job_clusters for each job.
 func (a *JobsAPI) List(ctx context.Context, request ListJobsRequest) listing.Iterator[BaseJob] {
 	// Fetch jobs with limited elements in top level arrays
 	jobsList := a.jobsImpl.List(ctx, request)
@@ -20,7 +23,7 @@ func (a *JobsAPI) List(ctx context.Context, request ListJobsRequest) listing.Ite
 	}
 }
 
-// expandedJobsIterator is a custom iterator that expands job tasks.
+// expandedJobsIterator is a custom iterator that for each job calls job/get in order to fetch full list of tasks and job_clusters.
 type expandedJobsIterator struct {
 	originalIterator listing.Iterator[BaseJob]
 	service          *JobsAPI

--- a/service/jobs/ext_api_test.go
+++ b/service/jobs/ext_api_test.go
@@ -668,3 +668,616 @@ func TestGetJob(t *testing.T) {
 		assert.EqualValues(t, "env3", job.Settings.Environments[2].EnvironmentKey)
 	})
 }
+
+func TestListJobs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("jobs list with no task expansion", func(t *testing.T) {
+		var requestMocks qa.HTTPFixtures = []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/list?",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 100,
+							Settings: &JobSettings{
+								Name: "job_100",
+							},
+						},
+						{
+							JobId: 200,
+							Settings: &JobSettings{
+								Name: "job_200",
+							},
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/list?page_token=token1",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 300,
+							Settings: &JobSettings{
+								Name: "job_300",
+							},
+						},
+						{
+							JobId: 400,
+							Settings: &JobSettings{
+								Name: "job_400",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.1/jobs/list?",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 100,
+							Settings: &JobSettings{
+								Name: "job_100",
+							},
+						},
+						{
+							JobId: 200,
+							Settings: &JobSettings{
+								Name: "job_200",
+							},
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.1/jobs/list?page_token=token1",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 300,
+							Settings: &JobSettings{
+								Name: "job_300",
+							},
+						},
+						{
+							JobId: 400,
+							Settings: &JobSettings{
+								Name: "job_400",
+							},
+						},
+					},
+				},
+			},
+		}
+		client, server := requestMocks.Client(t)
+		defer server.Close()
+
+		mockJobsImpl := &jobsImpl{
+			client: client,
+		}
+		api := &JobsAPI{jobsImpl: *mockJobsImpl}
+
+		jobsList := api.List(ctx, ListJobsRequest{})
+		var allJobs []BaseJob
+		for jobsList.HasNext(ctx) {
+			job, err := jobsList.Next(ctx)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, job.JobId)
+			allJobs = append(allJobs, job)
+		}
+
+		assert.EqualValues(t, len(allJobs), 4)
+		assert.EqualValues(t, allJobs[0].JobId, 100)
+		assert.EqualValues(t, allJobs[2].JobId, 300)
+		assert.EqualValues(t, allJobs[3].JobId, 400)
+		assert.EqualValues(t, allJobs[3].Settings.Name, "job_400")
+	})
+
+	t.Run("jobs list with task expansion", func(t *testing.T) {
+		var requestMocks qa.HTTPFixtures = []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/list?expand_tasks=true",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 100,
+							Settings: &JobSettings{
+								Name: "job_100",
+								Tasks: []Task{
+									{
+										TaskKey: "job100_task1",
+									},
+									{
+										TaskKey: "job100_task2",
+									},
+								},
+								JobClusters: []JobCluster{
+									{
+										JobClusterKey: "job100_cluster1",
+									},
+									{
+										JobClusterKey: "job100_cluster2",
+									},
+								},
+								Parameters: []JobParameterDefinition{
+									{
+										Name:    "param1",
+										Default: "default1",
+									},
+									{
+										Name:    "param2",
+										Default: "default2",
+									},
+								},
+								Environments: []JobEnvironment{
+									{
+										EnvironmentKey: "env1",
+									},
+								},
+							},
+							HasMore: true,
+						},
+						{
+							JobId: 200,
+							Settings: &JobSettings{
+								Name: "job_200",
+								Tasks: []Task{
+									{
+										TaskKey: "job200_task1",
+									},
+									{
+										TaskKey: "job200_task2",
+									},
+								},
+								JobClusters: []JobCluster{
+									{
+										JobClusterKey: "job200_cluster1",
+									},
+								},
+								Environments: []JobEnvironment{
+									{
+										EnvironmentKey: "env1",
+									},
+								},
+							},
+							HasMore: true,
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/list?expand_tasks=true&page_token=token1",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 300,
+							Settings: &JobSettings{
+								Name: "job_300",
+								Tasks: []Task{
+									{
+										TaskKey: "job300_task1",
+									},
+								},
+							},
+						},
+						{
+							JobId: 400,
+							Settings: &JobSettings{
+								Name: "job_400",
+								Tasks: []Task{
+									{
+										TaskKey: "job400_task3",
+									},
+									{
+										TaskKey: "job400_task1",
+									},
+								},
+								Parameters: []JobParameterDefinition{
+									{
+										Name:    "param1",
+										Default: "default1",
+									},
+									{
+										Name:    "param2",
+										Default: "default2",
+									},
+								},
+							},
+							HasMore: true,
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=100",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job100_task1",
+							},
+							{
+								TaskKey: "job100_task2",
+							},
+						},
+						JobClusters: []JobCluster{
+							{
+								JobClusterKey: "job100_cluster1",
+							},
+							{
+								JobClusterKey: "job100_cluster2",
+							},
+						},
+						Parameters: []JobParameterDefinition{
+							{
+								Name:    "param1",
+								Default: "default1",
+							},
+							{
+								Name:    "param2",
+								Default: "default2",
+							},
+						},
+						Environments: []JobEnvironment{
+							{
+								EnvironmentKey: "env1",
+							},
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=100&page_token=token1",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job100_task3",
+							},
+							{
+								TaskKey: "job100_task4",
+							},
+						},
+						JobClusters: []JobCluster{
+							{
+								JobClusterKey: "job100_cluster3",
+							},
+							{
+								JobClusterKey: "job100_cluster4",
+							},
+						},
+						Parameters: []JobParameterDefinition{
+							{
+								Name:    "param3",
+								Default: "default3",
+							},
+						},
+						Environments: []JobEnvironment{
+							{
+								EnvironmentKey: "env2",
+							},
+						},
+					},
+					NextPageToken: "token2",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=100&page_token=token2",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job100_task5",
+							},
+						},
+						Environments: []JobEnvironment{
+							{
+								EnvironmentKey: "env3",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=200",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job200_task1",
+							},
+							{
+								TaskKey: "job200_task2",
+							},
+						},
+						JobClusters: []JobCluster{
+							{
+								JobClusterKey: "job200_cluster1",
+							},
+						},
+						Environments: []JobEnvironment{
+							{
+								EnvironmentKey: "env1",
+							},
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=200&page_token=token1",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job200_task3",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=400",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job400_task1",
+							},
+							{
+								TaskKey: "job400_task2",
+							},
+						},
+						Parameters: []JobParameterDefinition{
+							{
+								Name:    "param1",
+								Default: "default1",
+							},
+							{
+								Name:    "param2",
+								Default: "default2",
+							},
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.2/jobs/get?job_id=400&page_token=token1",
+				Response: Job{
+					Settings: &JobSettings{
+						Tasks: []Task{
+							{
+								TaskKey: "job400_task3",
+							},
+							{
+								TaskKey: "job400_task4",
+							},
+						},
+						Parameters: []JobParameterDefinition{
+							{
+								Name:    "param3",
+								Default: "default3",
+							},
+							{
+								Name:    "param4",
+								Default: "default4",
+							},
+						},
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/jobs/list?expand_tasks=true",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 100,
+							Settings: &JobSettings{
+								Name: "job_100",
+								Tasks: []Task{
+									{
+										TaskKey: "job100_task1",
+									},
+									{
+										TaskKey: "job100_task2",
+									},
+									{
+										TaskKey: "job100_task3",
+									},
+									{
+										TaskKey: "job100_task4",
+									},
+									{
+										TaskKey: "job100_task5",
+									},
+								},
+								JobClusters: []JobCluster{
+									{
+										JobClusterKey: "job100_cluster1",
+									},
+									{
+										JobClusterKey: "job100_cluster2",
+									},
+									{
+										JobClusterKey: "job100_cluster3",
+									},
+									{
+										JobClusterKey: "job100_cluster4",
+									},
+								},
+								Parameters: []JobParameterDefinition{
+									{
+										Name:    "param1",
+										Default: "default1",
+									},
+									{
+										Name:    "param2",
+										Default: "default2",
+									},
+									{
+										Name:    "param3",
+										Default: "default3",
+									},
+								},
+								Environments: []JobEnvironment{
+									{
+										EnvironmentKey: "env1",
+									},
+									{
+										EnvironmentKey: "env2",
+									},
+									{
+										EnvironmentKey: "env3",
+									},
+								},
+							},
+						},
+						{
+							JobId: 200,
+							Settings: &JobSettings{
+								Name: "job_200",
+								Tasks: []Task{
+									{
+										TaskKey: "job200_task1",
+									},
+									{
+										TaskKey: "job200_task2",
+									},
+									{
+										TaskKey: "job200_task3",
+									},
+								},
+								JobClusters: []JobCluster{
+									{
+										JobClusterKey: "job200_cluster1",
+									},
+								},
+								Environments: []JobEnvironment{
+									{
+										EnvironmentKey: "env1",
+									},
+								},
+							},
+						},
+					},
+					NextPageToken: "token1",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.1/jobs/list?expand_tasks=true&page_token=token1",
+				Response: ListJobsResponse{
+					Jobs: []BaseJob{
+						{
+							JobId: 300,
+							Settings: &JobSettings{
+								Name: "job_300",
+								Tasks: []Task{
+									{
+										TaskKey: "job300_task1",
+									},
+								},
+							},
+						},
+						{
+							JobId: 400,
+							Settings: &JobSettings{
+								Name: "job_400",
+								Tasks: []Task{
+									{
+										TaskKey: "job400_task1",
+									},
+									{
+										TaskKey: "job400_task2",
+									},
+									{
+										TaskKey: "job400_task4",
+									},
+									{
+										TaskKey: "job400_task5",
+									},
+								},
+								Parameters: []JobParameterDefinition{
+									{
+										Name:    "param1",
+										Default: "default1",
+									},
+									{
+										Name:    "param2",
+										Default: "default2",
+									},
+									{
+										Name:    "param3",
+										Default: "default3",
+									},
+									{
+										Name:    "param4",
+										Default: "default4",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		client, server := requestMocks.Client(t)
+		defer server.Close()
+
+		mockJobsImpl := &jobsImpl{
+			client: client,
+		}
+		api := &JobsAPI{jobsImpl: *mockJobsImpl}
+
+		jobsList := api.List(ctx, ListJobsRequest{ExpandTasks: true})
+		var allJobs []BaseJob
+		for jobsList.HasNext(ctx) {
+			job, err := jobsList.Next(ctx)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, job.JobId)
+			assert.Empty(t, job.HasMore)
+			allJobs = append(allJobs, job)
+		}
+
+		assert.Equal(t, 4, len(allJobs))
+		assert.Equal(t, 5, len(allJobs[0].Settings.Tasks))
+		assert.Equal(t, 4, len(allJobs[0].Settings.JobClusters))
+		assert.Equal(t, 3, len(allJobs[0].Settings.Parameters))
+		assert.Equal(t, 3, len(allJobs[0].Settings.Environments))
+		assert.Equal(t, 3, len(allJobs[1].Settings.Tasks))
+		assert.Equal(t, 1, len(allJobs[1].Settings.JobClusters))
+		assert.Empty(t, allJobs[1].Settings.Parameters)
+		assert.Equal(t, 1, len(allJobs[1].Settings.Environments))
+		assert.Equal(t, 1, len(allJobs[2].Settings.Tasks))
+		assert.Empty(t, allJobs[2].Settings.JobClusters)
+		assert.Empty(t, allJobs[2].Settings.Parameters)
+		assert.Empty(t, allJobs[2].Settings.Environments)
+		assert.EqualValues(t, 100, allJobs[0].JobId)
+		assert.EqualValues(t, 300, allJobs[2].JobId)
+		assert.EqualValues(t, 400, allJobs[3].JobId)
+		assert.EqualValues(t, "job_400", allJobs[3].Settings.Name)
+	})
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduces logic in the extension for jobs ListJobs call. The extended logic accounts for the new response format of API 2.2. API 2.1 format returns all tasks and job_cluster for each job in the jobs list. API 2.2 format truncates tasks and job_cluster to 100 elements. The extended ListJobs logic calls GetJob for each job in the list to populate the full list of tasks and job_clusters.

I added logic that reads jobs from the list and produces custom iterator struct `expandedJobsIterator` that is supposed to mimic python generators. The goal is to only read necessary elements from the API endpoint and not more.

## How is this tested?

Unit tests and manual tests. Manual tests were done in two modes: using API 2.2 and using API 2.1. So this code is compatible with both API versions.