### PR TITLE
[Internal] Update Jobs `list_runs` function to support paginated responses

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Documentation
 
 ### Internal Changes
+* Update Jobs ListRuns API to support paginated responses ([#1151](https://github.com/databricks/databricks-sdk-go/pull/1151))
 * Introduce automated tagging ([#1148](https://github.com/databricks/databricks-sdk-go/pull/1148)).
 * Update Jobs GetJob API to support paginated responses  ([#1133](https://github.com/databricks/databricks-sdk-go/pull/1133)).
 * Update Jobs GetRun API to support paginated responses  ([#1132](https://github.com/databricks/databricks-sdk-go/pull/1132)).

--- a/service/jobs/ext_api.go
+++ b/service/jobs/ext_api.go
@@ -6,6 +6,9 @@ import (
 	"github.com/databricks/databricks-sdk-go/listing"
 )
 
+// ListRuns fetches a list of job runs.
+// If expand_tasks is true, the response will include the full list of tasks and job_clusters for each run.
+// This function handles pagination two ways: paginates all the runs in the list and paginates all the tasks and job_clusters for each run.
 func (a *JobsAPI) ListRuns(ctx context.Context, request ListRunsRequest) listing.Iterator[BaseRun] {
 	runsList := a.jobsImpl.ListRuns(ctx, request)
 
@@ -19,7 +22,7 @@ func (a *JobsAPI) ListRuns(ctx context.Context, request ListRunsRequest) listing
 	}
 }
 
-// expandedRunsIterator is a custom iterator that expands run tasks.
+// expandedRunsIterator is a custom iterator that for each run calls runs/get in order to fetch full list of tasks and job_clusters.
 type expandedRunsIterator struct {
 	originalIterator listing.Iterator[BaseRun]
 	service          *JobsAPI

--- a/service/jobs/ext_api.go
+++ b/service/jobs/ext_api.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+
 	"github.com/databricks/databricks-sdk-go/listing"
 )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduces logic in the extension for jobs ListRuns call. The extended logic accounts for the new response format of API 2.2. API 2.1 format returns all tasks and job_cluster for each run in the runs list. API 2.2 format truncates tasks and job_cluster to 100 elements. The extended ListRuns logic calls GetRun for each run in the list to populate the full list of tasks and job_clusters.

I added logic that reads runs from the list and produces custom iterator struct `expandedRunsIterator` that is supposed to mimic python generators. The goal is to only read necessary elements from the API endpoint and not more.

## How is this tested?

Unit tests and manual tests. Manual tests were done in two modes: using API 2.2 and using API 2.1. So this code is compatible with both API versions.