### PR TITLE
[Fix] Correctly unmarshal any error details type

### DIFF
--- a/apierr/errors_test.go
+++ b/apierr/errors_test.go
@@ -3,6 +3,8 @@ package apierr
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +12,8 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/common"
-	"github.com/stretchr/testify/assert"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestAPIError_transientRegexMatches(t *testing.T) {
@@ -18,7 +21,9 @@ func TestAPIError_transientRegexMatches(t *testing.T) {
 		Message: "worker env WorkerEnvId(workerenv-XXXXX) not found",
 	}
 
-	assert.True(t, err.IsRetriable(context.Background()))
+	if !err.IsRetriable(context.Background()) {
+		t.Errorf("expected error to be retriable")
+	}
 }
 
 func makeTestReponseWrapper(statusCode int, resp string) common.ResponseWrapper {
@@ -40,61 +45,114 @@ func makeTestReponseWrapper(statusCode int, resp string) common.ResponseWrapper 
 
 func TestAPIError_GetAPIError(t *testing.T) {
 	testCases := []struct {
-		name           string
-		resp           common.ResponseWrapper
-		wantErrorIs    error
-		wantErrorCode  string
-		wantMessage    string
-		wantStatusCode int
-		wantDetails    []ErrorDetail
+		name        string
+		resp        common.ResponseWrapper
+		want        *APIError
+		wantErrorIs error
 	}{
 		{
-			name:           "empty response",
-			resp:           makeTestReponseWrapper(http.StatusNotFound, ""),
-			wantErrorIs:    ErrNotFound,
-			wantErrorCode:  "",
-			wantMessage:    "Not Found",
-			wantStatusCode: http.StatusNotFound,
+			name: "empty response",
+			resp: makeTestReponseWrapper(http.StatusNotFound, ""),
+			want: &APIError{
+				ErrorCode:  "",
+				Message:    "Not Found",
+				StatusCode: http.StatusNotFound,
+			},
+			wantErrorIs: ErrNotFound,
 		},
 		{
-			name:           "happy path",
-			resp:           makeTestReponseWrapper(http.StatusNotFound, `{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Cluster abc does not exist"}`),
-			wantErrorIs:    ErrResourceDoesNotExist,
-			wantErrorCode:  "RESOURCE_DOES_NOT_EXIST",
-			wantMessage:    "Cluster abc does not exist",
-			wantStatusCode: http.StatusNotFound,
+			name: "happy path",
+			resp: makeTestReponseWrapper(http.StatusNotFound, `{
+				"error_code": "RESOURCE_DOES_NOT_EXIST", 
+				"message": "Cluster abc does not exist"
+			}`),
+			want: &APIError{
+				ErrorCode:  "RESOURCE_DOES_NOT_EXIST",
+				Message:    "Cluster abc does not exist",
+				StatusCode: http.StatusNotFound,
+			},
+			wantErrorIs: ErrResourceDoesNotExist,
 		},
 		{
-			name:           "error details",
-			resp:           makeTestReponseWrapper(http.StatusNotFound, `{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Cluster abc does not exist", "details": [{"@type": "type", "reason": "reason", "domain": "domain", "metadata": {"key": "value"}}]}`),
-			wantErrorIs:    ErrResourceDoesNotExist,
-			wantErrorCode:  "RESOURCE_DOES_NOT_EXIST",
-			wantMessage:    "Cluster abc does not exist",
-			wantStatusCode: http.StatusNotFound,
-			wantDetails: []ErrorDetail{
-				{
+			name: "supported details",
+			resp: makeTestReponseWrapper(http.StatusNotFound, `{
+				"error_code": "RESOURCE_DOES_NOT_EXIST", 
+				"message": "Cluster abc does not exist", 
+				"details": [{"@type": "type", "reason": "reason", "domain": "domain", "metadata": {"key": "value"}}]
+			}`),
+			want: &APIError{
+				ErrorCode:  "RESOURCE_DOES_NOT_EXIST",
+				Message:    "Cluster abc does not exist",
+				StatusCode: http.StatusNotFound,
+				Details: []ErrorDetail{{
 					Type:     "type",
 					Reason:   "reason",
 					Domain:   "domain",
 					Metadata: map[string]string{"key": "value"},
+				}},
+				RawDetails: []json.RawMessage{[]byte(`{"@type": "type", "reason": "reason", "domain": "domain", "metadata": {"key": "value"}}`)},
+			},
+			wantErrorIs: ErrResourceDoesNotExist,
+		},
+		{
+			name: "unsupported details",
+			resp: makeTestReponseWrapper(http.StatusNotFound, `{
+				"error_code": "RESOURCE_DOES_NOT_EXIST", 
+				"message": "Cluster abc does not exist", 
+				"details": [{"@type": "type", "reason": 5}]
+			}`),
+			want: &APIError{
+				ErrorCode:  "RESOURCE_DOES_NOT_EXIST",
+				Message:    "Cluster abc does not exist",
+				StatusCode: http.StatusNotFound,
+				RawDetails: []json.RawMessage{[]byte(`{"@type": "type", "reason": 5}`)},
+			},
+			wantErrorIs: ErrResourceDoesNotExist,
+		},
+		{
+			name: "supported and unsupported details",
+			resp: makeTestReponseWrapper(http.StatusNotFound, `{
+				"error_code": "RESOURCE_DOES_NOT_EXIST", 
+				"message": "Cluster abc does not exist", 
+				"details": [{"@type": "type", "reason": 5}, {"@type": "type", "reason": "foo"}]
+			}`),
+			want: &APIError{
+				ErrorCode:  "RESOURCE_DOES_NOT_EXIST",
+				Message:    "Cluster abc does not exist",
+				StatusCode: http.StatusNotFound,
+				Details: []ErrorDetail{{
+					Type:   "type",
+					Reason: "foo",
+				}},
+				RawDetails: []json.RawMessage{
+					[]byte(`{"@type": "type", "reason": 5}`),
+					[]byte(`{"@type": "type", "reason": "foo"}`),
 				},
 			},
+			wantErrorIs: ErrResourceDoesNotExist,
 		},
 		{
-			name:           "string error response",
-			resp:           makeTestReponseWrapper(http.StatusBadRequest, `MALFORMED_REQUEST: vpc_endpoints malformed parameters: VPC Endpoint ... with use_case ... cannot be attached in ... list`),
-			wantErrorIs:    ErrBadRequest,
-			wantErrorCode:  "MALFORMED_REQUEST",
-			wantMessage:    "vpc_endpoints malformed parameters: VPC Endpoint ... with use_case ... cannot be attached in ... list",
-			wantStatusCode: http.StatusBadRequest,
+			name: "string error response",
+			resp: makeTestReponseWrapper(http.StatusBadRequest, `MALFORMED_REQUEST: vpc_endpoints malformed parameters: VPC Endpoint ... with use_case ... cannot be attached in ... list`),
+			want: &APIError{
+				ErrorCode:  "MALFORMED_REQUEST",
+				Message:    "vpc_endpoints malformed parameters: VPC Endpoint ... with use_case ... cannot be attached in ... list",
+				StatusCode: http.StatusBadRequest,
+			},
+			wantErrorIs: ErrBadRequest,
 		},
 		{
-			name:           "numeric error code",
-			resp:           makeTestReponseWrapper(http.StatusBadRequest, `{"error_code": 500, "message": "Cluster abc does not exist"}`),
-			wantErrorIs:    ErrBadRequest,
-			wantErrorCode:  "500",
-			wantMessage:    "Cluster abc does not exist",
-			wantStatusCode: http.StatusBadRequest,
+			name: "numeric error code",
+			resp: makeTestReponseWrapper(http.StatusBadRequest, `{
+				"error_code": 500, 
+				"message": "Cluster abc does not exist"}
+			`),
+			want: &APIError{
+				ErrorCode:  "500",
+				Message:    "Cluster abc does not exist",
+				StatusCode: http.StatusBadRequest,
+			},
+			wantErrorIs: ErrBadRequest,
 		},
 		{
 			name: "private link redirect",
@@ -109,10 +167,12 @@ func TestAPIError_GetAPIError(t *testing.T) {
 					},
 				},
 			},
-			wantErrorIs:    ErrPermissionDenied,
-			wantErrorCode:  "PRIVATE_LINK_VALIDATION_ERROR",
-			wantMessage:    "The requested workspace has Azure Private Link enabled and is not accessible from the current network. Ensure that Azure Private Link is properly configured and that your device has access to the Azure Private Link endpoint. For more information, see https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting.",
-			wantStatusCode: http.StatusForbidden,
+			want: &APIError{
+				ErrorCode:  "PRIVATE_LINK_VALIDATION_ERROR",
+				Message:    "The requested workspace has Azure Private Link enabled and is not accessible from the current network. Ensure that Azure Private Link is properly configured and that your device has access to the Azure Private Link endpoint. For more information, see https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting.",
+				StatusCode: http.StatusForbidden,
+			},
+			wantErrorIs: ErrPermissionDenied,
 		},
 		{
 			name: "applies overrides",
@@ -127,31 +187,38 @@ func TestAPIError_GetAPIError(t *testing.T) {
 					},
 				},
 				DebugBytes: []byte{},
-				ReadCloser: io.NopCloser(bytes.NewReader([]byte(`{"error_code": "INVALID_PARAMETER_VALUE", "message": "Cluster abc does not exist"}`))),
+				ReadCloser: io.NopCloser(bytes.NewReader([]byte(`{
+					"error_code": "INVALID_PARAMETER_VALUE", 
+					"message": "Cluster abc does not exist"}
+				`))),
 			},
-			wantErrorIs:    ErrResourceDoesNotExist,
-			wantErrorCode:  "INVALID_PARAMETER_VALUE",
-			wantMessage:    "Cluster abc does not exist",
-			wantStatusCode: http.StatusBadRequest,
+			want: &APIError{
+				ErrorCode:  "INVALID_PARAMETER_VALUE",
+				Message:    "Cluster abc does not exist",
+				StatusCode: http.StatusBadRequest,
+			},
+			wantErrorIs: ErrResourceDoesNotExist,
 		},
 		{
-			name:           "unexpected error",
-			resp:           makeTestReponseWrapper(http.StatusInternalServerError, `unparsable error message`),
-			wantErrorCode:  "INTERNAL_SERVER_ERROR",
-			wantMessage:    "unable to parse response. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\n```\nGET /api/2.0/myservice\n> * Host: \n<  500 Internal Server Error\n< unparsable error message\n```",
-			wantStatusCode: http.StatusInternalServerError,
+			name: "unexpected error",
+			resp: makeTestReponseWrapper(http.StatusInternalServerError, `unparsable error message`),
+			want: &APIError{
+				ErrorCode:  "INTERNAL_SERVER_ERROR",
+				Message:    "unable to parse response. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:\n```\nGET /api/2.0/myservice\n> * Host: \n<  500 Internal Server Error\n< unparsable error message\n```",
+				StatusCode: http.StatusInternalServerError,
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := GetAPIError(context.Background(), tc.resp).(*APIError)
-			assert.Equal(t, tc.wantErrorCode, got.ErrorCode)
-			assert.Equal(t, tc.wantMessage, got.Message)
-			assert.Equal(t, tc.wantStatusCode, got.StatusCode)
-			assert.Equal(t, tc.wantDetails, got.Details)
-			if tc.wantErrorIs != nil {
-				assert.ErrorIs(t, got, tc.wantErrorIs)
+			got := GetAPIError(context.Background(), tc.resp)
+
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreUnexported(APIError{})); diff != "" {
+				t.Errorf("unexpected error (-want +got):\n%s", diff)
+			}
+			if tc.wantErrorIs != nil && !errors.Is(got, tc.wantErrorIs) {
+				t.Errorf("errors.Is(%q, %q) failed", got, tc.wantErrorIs)
 			}
 		})
 	}

--- a/config/experimental/auth/client.go
+++ b/config/experimental/auth/client.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/config/credentials"
+	"golang.org/x/oauth2"
+)
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// OAuthClient is an interface for Databricks OAuth client.
+type OAuthClient struct {
+	client httpClient
+}
+
+const JWTGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+// Returns a new OAuth token using the provided token. The token must be a JWT token.
+// The resulting token is scoped to the authorization details provided.
+//
+// **NOTE:** Experimental: This API may change or be removed in a future release
+// without warning.
+func (oac *OAuthClient) GetOAuthToken(ctx context.Context, authDetails string, token *oauth2.Token) (*oauth2.Token, error) {
+	path := "/oidc/v1/token"
+	data := getOAuthTokenRequest{
+		GrantType:            JWTGrantType,
+		AuthorizationDetails: authDetails,
+		Assertion:            token.AccessToken,
+	}
+	var response credentials.OAuthToken
+	opts := []DoOption{
+		WithUrlEncodedData(data),
+		WithResponseUnmarshal(&response),
+	}
+	err := c.Do(ctx, http.MethodPost, path, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth2.Token{
+		AccessToken: response.AccessToken,
+		TokenType:   response.TokenType,
+		Expiry:      time.Now().Add(time.Duration(response.ExpiresIn) * time.Second),
+	}, nil
+}
+
+// GetOAuthTokenRequest is the request to get an OAuth token. It follows the
+// OAuth 2.0 Rich Authorization Requests specification.
+//
+// https://datatracker.ietf.org/doc/html/rfc9396
+type getOAuthTokenRequest struct {
+	// Defines the method used to get the token.
+	GrantType string `url:"grant_type"`
+	// An array of authorization details that the token should be scoped to. This needs to be passed in string format.
+	AuthorizationDetails string `url:"authorization_details"`
+	// The token that will be exchanged for an OAuth token.
+	Assertion string `url:"assertion"`
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates `APIError` to fully support the Databricks Error schema which does not specify a specific schema for error details. 

This not only allows users to extract missing information from the error but also remove the risk of unmarhsalling error if the returned error details were not compatible with the `ErrorDetails` type.

The change is backward compatible.

## How is this tested?

Added unit tests + slight refactor of the test suite. 