### PR TITLE
[Internal] add `poll.SimpleError` to mock waiter objects returning errors

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Documentation
 
 ### Internal Changes
+
+* Add `poll.SimpleError` to mock waiter objects returning errors  ([#1155](https://github.com/databricks/databricks-sdk-go/pull/1155))
 * Introduce automated tagging ([#1148](https://github.com/databricks/databricks-sdk-go/pull/1148)).
 * Update Jobs GetJob API to support paginated responses  ([#1133](https://github.com/databricks/databricks-sdk-go/pull/1133)).
 * Update Jobs GetRun API to support paginated responses  ([#1132](https://github.com/databricks/databricks-sdk-go/pull/1132)).

--- a/qa/poll/poll.go
+++ b/qa/poll/poll.go
@@ -9,3 +9,9 @@ func Simple[R any](r R) PollFunc[R] {
 		return &r, nil
 	}
 }
+
+func SimpleError[R any](err error) PollFunc[R] {
+	return func(_ time.Duration, _ func(*R)) (*R, error) {
+		return nil, err
+	}
+}

--- a/qa/poll/poll_test.go
+++ b/qa/poll/poll_test.go
@@ -1,6 +1,7 @@
 package poll_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/qa/poll"
@@ -17,4 +18,14 @@ func TestSimple(t *testing.T) {
 	res, err := waiter.Get()
 	assert.NoError(t, err)
 	assert.Equal(t, "test", res.Id)
+}
+
+func TestSimpleError(t *testing.T) {
+	waiter := sql.WaitGetWarehouseRunning[int]{
+		Poll: poll.SimpleError[sql.GetWarehouseResponse](errors.New("test")),
+	}
+	_, err := waiter.Get()
+	if assert.Error(t, err) {
+		assert.Equal(t, errors.New("test"), err)
+	}
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

in #769, `poll.Simple` method was added to simplify mocking of waiter objects. However, this only allows testing of happy path where no error is returned.

This PR adds the equivalent `poll.SimpleError` method to returns an error instead.

## How is this tested?
- [x] Unit test added