### PR TITLE
[Internal] Moved heading descriptions in comments for PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 ## What changes are proposed in this pull request?
-<!--
-Provide the readers and reviewers with the information they need to understand
+<!-- Provide the readers and reviewers with the information they need to understand
 this PR in a comprehensive manner. 
 
 Specifically, try to answer the two following questions:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## What changes are proposed in this pull request?
-
+<!--
 Provide the readers and reviewers with the information they need to understand
 this PR in a comprehensive manner. 
 
@@ -16,13 +16,15 @@ The “why part” is the most important of the two as it usually cannot be
 inferred from the code itself. A well-written PR description will help future
 developers (including your future self) to know how to interact and update your
 code.
+-->
+
 
 ## How is this tested?
-
-Describe any tests you have done; especially if test tests are not part of
+<!-- Describe any tests you have done; especially if test tests are not part of
 the unit tests (e.g. local tests).
 
 **ALWAYS ANSWER THIS QUESTION:** Answer with "N/A" if tests are not applicable
 to your PR (e.g. if the PR only modifies comments). Do not be afraid of 
 answering "Not tested" if the PR has not been tested. Being clear about what 
 has been done and not done provides important context to the reviewers. 
+-->


### PR DESCRIPTION
## What changes are proposed in this pull request?
<!--
Provide the readers and reviewers with the information they need to understand
this PR in a comprehensive manner. 

Specifically, try to answer the two following questions:

- **WHAT** changes are being made in the PR? This should be a summary of the 
  major changes to allow the reader to quickly understand the PR without having
  to look at the code. 
- **WHY** are these changes needed? This should provide the context that the 
  reader might be missing. For example, were there any decisions behind the 
  change that are not reflected in the code itself? 

The “why part” is the most important of the two as it usually cannot be 
inferred from the code itself. A well-written PR description will help future
developers (including your future self) to know how to interact and update your
code.
-->
The description for headings is meant to be read by the PR author to add proper information and hence should be moved under comments. This saves time by not having to manually remove these heading descriptions as they add noise to the actual PR changes if left as is. 

If this is approved, then will do this for other SDKs as well. 

## How is this tested?
<!-- Describe any tests you have done; especially if test tests are not part of
the unit tests (e.g. local tests).

**ALWAYS ANSWER THIS QUESTION:** Answer with "N/A" if tests are not applicable
to your PR (e.g. if the PR only modifies comments). Do not be afraid of 
answering "Not tested" if the PR has not been tested. Being clear about what 
has been done and not done provides important context to the reviewers. 
-->
N/A

NO_CHANGELOG=true