### PR TITLE
[Internal] Prepare `ApiClient` to replace `DatabricksClient`.

### DIFF
--- a/databricks/config/api_client.go
+++ b/databricks/config/api_client.go
@@ -28,6 +28,8 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 	}
 
 	return httpclient.ClientConfig{
+		AccountID:          cfg.AccountID,
+		Host:               cfg.Host,
 		RetryTimeout:       time.Duration(cfg.RetryTimeoutSeconds) * time.Second,
 		HTTPTimeout:        time.Duration(cfg.HTTPTimeoutSeconds) * time.Second,
 		RateLimitPerSecond: cfg.RateLimitPerSecond,

--- a/databricks/httpclient/api_client.go
+++ b/databricks/httpclient/api_client.go
@@ -57,7 +57,7 @@ type ApiClient struct {
 	httpClient  *http.Client
 }
 
-// IsAccountClient returns true if client is configured for Accounts API
+// IsAccountClient returns true if the client is configured for Accounts API.
 func (apic *ApiClient) IsAccountClient() bool {
 	if apic.config.AccountID == "" {
 		return false

--- a/databricks/httpclient/api_client.go
+++ b/databricks/httpclient/api_client.go
@@ -25,6 +25,9 @@ type ClientConfig struct {
 	AuthVisitor RequestVisitor
 	Visitors    []RequestVisitor
 
+	AccountID string
+	Host      string
+
 	RetryTimeout       time.Duration
 	HTTPTimeout        time.Duration
 	InsecureSkipVerify bool
@@ -52,6 +55,25 @@ type ApiClient struct {
 	config      ClientConfig
 	rateLimiter *rate.Limiter
 	httpClient  *http.Client
+}
+
+// IsAccountClient returns true if client is configured for Accounts API
+func (apic *ApiClient) IsAccountClient() bool {
+	if apic.config.AccountID == "" {
+		return false
+	}
+	if strings.HasPrefix(apic.config.Host, "https://accounts.") {
+		return true
+	}
+	if strings.HasPrefix(apic.config.Host, "https://accounts-dod.") {
+		return true
+	}
+	return false
+}
+
+// AccountID returns the account ID for the client.
+func (apic *ApiClient) AccountID() string {
+	return apic.config.AccountID
 }
 
 const (


### PR DESCRIPTION
## What changes are proposed in this pull request?

`ApiClient` provides always all the information needed to replace `DatabricksClient` in the service client. The only thing missing is access to the Host and Account ID. This PR add these to the `ApiClient` config. In preparation to the migration.

## How is this tested?

No test, the new function will be tested indirectly as soon as the migration is completed.

NO_CHANGELOG=true