### PR TITLE
Do not close all TCP connections on an HTTP error

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -305,8 +305,6 @@ func (c *ApiClient) attempt(
 			return &responseWrapper, nil
 		}
 
-		// proactively release the connections in HTTP connection pool
-		c.httpClient.CloseIdleConnections()
 		return c.handleError(ctx, err, requestBody)
 	}
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Closing the TCP pool on every error is unnecessary. The function was meant to be used for http clients that are short lived to avoid leaking resources (ref: https://github.com/golang/go/issues/26563). For the Go SDK, the HTTP client is long-lived, and thus, there's no reason to proactively close the TCP connection pool on errors. 

By default, the HTTP protocol maintains the health of its TCP connections (keep-alive messages) and the Go HTTP client automatically closes connections that have been idle for too long based on a timeout.

## How is this tested?
Manually used this in a Databricks CLI binary and verified that the commands still work.

NO_CHANGELOG=true