### PR TITLE
Use the same connection pool in all `ApiClient` by default. 

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -2,13 +2,10 @@ package httpclient
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
 	"time"
 
@@ -46,22 +43,7 @@ func (cfg ClientConfig) httpTransport() http.RoundTripper {
 	if cfg.Transport != nil {
 		return cfg.Transport
 	}
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
-		IdleConnTimeout:       180 * time.Second,
-		TLSHandshakeTimeout:   30 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: cfg.InsecureSkipVerify,
-		},
-	}
+	return http.DefaultTransport
 }
 
 func NewApiClient(cfg ClientConfig) *ApiClient {

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -29,7 +29,6 @@ type ClientConfig struct {
 
 	RetryTimeout       time.Duration
 	HTTPTimeout        time.Duration
-	InsecureSkipVerify bool
 	DebugHeaders       bool
 	DebugTruncateBytes int
 	RateLimitPerSecond int
@@ -39,6 +38,9 @@ type ClientConfig struct {
 	TransientErrors []string
 
 	Transport http.RoundTripper
+
+	// Deprecated: Use your own Transport implementation instead.
+	InsecureSkipVerify bool
 }
 
 var defaultTransport = &http.Transport{


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR changes `ApiClient` to use the same `RoundTripper` by default. This change should improve performance in context were users rely on different instances of the `ApiClient`. 

Note that this PR deprecates the `InsecureSkipVerify` option. Users who still need to enable it will be able to do so by 
specifying their own `RoundTripper` to the `ApiClient`.

## How is this tested?

Normal CI.