### PR TITLE
[Internal] Re-Enable tests that depends on Waiters.

### DIFF
--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -1,7 +1,16 @@
 package integration
 
-// TODO: Enable this test when LRO is implemented
-//
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/compute/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO:
+// Enable or Delete this test when we have a decision on Start mixin in CommandExecutionAPI
+// As this mixin have a cross dependency on the ClustersAPI.
 // func TestAccCommands(t *testing.T) {
 // 	ctx := workspaceTest(t)
 
@@ -27,45 +36,52 @@ package integration
 // 	assert.EqualError(t, res.Err(), "ZeroDivisionError: division by zero")
 // }
 
-// TODO: Enable this test when LRO is implemented
-//
-// func TestAccCommandsDirectUsage(t *testing.T) {
-// 	ctx, w := workspaceTest(t)
+func TestAccCommandsDirectUsage(t *testing.T) {
+	ctx := workspaceTest(t)
 
-// 	clusterId := GetEnvOrSkipTest(t, "TEST_DEFAULT_CLUSTER_ID")
-// 	err := w.Clusters.EnsureClusterIsRunning(ctx, clusterId)
-// 	require.NoError(t, err)
+	clusterId := GetEnvOrSkipTest(t, "TEST_DEFAULT_CLUSTER_ID")
+	ClustersAPI, err := compute.NewClustersClient(nil)
+	require.NoError(t, err)
+	err = ClustersAPI.EnsureClusterIsRunning(ctx, clusterId)
+	require.NoError(t, err)
 
-// 	context, err := CommandExecutionAPI.CreateAndWait(ctx, compute.CreateContext{
-// 		ClusterId: clusterId,
-// 		Language:  compute.LanguagePython,
-// 	})
-// 	require.NoError(t, err)
+	CommandExecutionAPI, err := compute.NewCommandExecutionClient(nil)
+	require.NoError(t, err)
+	createWaiter, err := CommandExecutionAPI.Create(ctx, compute.CreateContext{
+		ClusterId: clusterId,
+		Language:  compute.LanguagePython,
+	})
+	require.NoError(t, err)
+	context, err := createWaiter.WaitUntilDone(ctx, nil)
+	require.NoError(t, err)
 
-// 	t.Cleanup(func() {
-// 		err = CommandExecutionAPI.Destroy(ctx, compute.DestroyContext{
-// 			ClusterId: clusterId,
-// 			ContextId: context.Id,
-// 		})
-// 		require.NoError(t, err)
-// 	})
+	t.Cleanup(func() {
+		_, err = CommandExecutionAPI.Destroy(ctx, compute.DestroyContext{
+			ClusterId: clusterId,
+			ContextId: context.Id,
+		})
+		require.NoError(t, err)
+	})
 
-// 	textResults, err := CommandExecutionAPI.ExecuteAndWait(ctx, compute.Command{
-// 		ClusterId: clusterId,
-// 		ContextId: context.Id,
-// 		Language:  compute.LanguagePython,
-// 		Command:   "print(1)",
-// 	})
-// 	require.NoError(t, err)
+	executeWaiter, err := CommandExecutionAPI.Execute(ctx, compute.Command{
+		ClusterId: clusterId,
+		ContextId: context.Id,
+		Language:  compute.LanguagePython,
+		Command:   "print(1)",
+	})
+	require.NoError(t, err)
+	textResults, err := executeWaiter.WaitUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "1", textResults.Results.Text())
 
-// 	assert.Equal(t, "1", textResults.Results.Text())
-
-// 	failingCommand, err := CommandExecutionAPI.ExecuteAndWait(ctx, compute.Command{
-// 		ClusterId: clusterId,
-// 		ContextId: context.Id,
-// 		Language:  compute.LanguagePython,
-// 		Command:   "1/0",
-// 	})
-// 	require.NoError(t, err)
-// 	assert.EqualError(t, failingCommand.Results.Err(), "ZeroDivisionError: division by zero")
-// }
+	executeWaiter, err = CommandExecutionAPI.Execute(ctx, compute.Command{
+		ClusterId: clusterId,
+		ContextId: context.Id,
+		Language:  compute.LanguagePython,
+		Command:   "1/0",
+	})
+	require.NoError(t, err)
+	failingCommand, err := executeWaiter.WaitUntilDone(ctx, nil)
+	require.NoError(t, err)
+	assert.EqualError(t, failingCommand.Results.Err(), "ZeroDivisionError: division by zero")
+}

--- a/integration/instancepools_test.go
+++ b/integration/instancepools_test.go
@@ -1,43 +1,52 @@
 package integration
 
-// TODO: Enable this test when LRO is implemented
-//
-// func TestAccInstancePools(t *testing.T) {
-// 	ctx := workspaceTest(t)
+import (
+	"testing"
 
-// 	ClustersAPI, err := compute.NewClustersClient(nil)
-// 	smallest, err := ClustersAPI.SelectNodeType(ctx, compute.NodeTypeRequest{
-// 		LocalDisk: true,
-// 	})
-// 	require.NoError(t, err)
+	"github.com/databricks/databricks-sdk-go/compute/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
-// 	created, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
-// 		InstancePoolName: RandomName("go-sdk-"),
-// 		NodeTypeId:       smallest,
-// 	})
-// 	require.NoError(t, err)
+func TestAccInstancePools(t *testing.T) {
+	ctx := workspaceTest(t)
 
-// 	defer w.InstancePools.DeleteByInstancePoolId(ctx, created.InstancePoolId)
+	ClustersAPI, err := compute.NewClustersClient(nil)
+	require.NoError(t, err)
+	smallest, err := ClustersAPI.SelectNodeType(ctx, compute.NodeTypeRequest{
+		LocalDisk: true,
+	})
+	require.NoError(t, err)
 
-// 	err = w.InstancePools.Edit(ctx, compute.EditInstancePool{
-// 		InstancePoolId:   created.InstancePoolId,
-// 		InstancePoolName: RandomName("go-sdk-updated"),
-// 		NodeTypeId:       smallest,
-// 	})
-// 	require.NoError(t, err)
+	InstancePoolsAPI, err := compute.NewInstancePoolsClient(nil)
+	require.NoError(t, err)
+	created, err := InstancePoolsAPI.Create(ctx, compute.CreateInstancePool{
+		InstancePoolName: RandomName("go-sdk-"),
+		NodeTypeId:       smallest,
+	})
+	require.NoError(t, err)
 
-// 	byId, err := w.InstancePools.GetByInstancePoolId(ctx, created.InstancePoolId)
-// 	require.NoError(t, err)
+	defer InstancePoolsAPI.DeleteByInstancePoolId(ctx, created.InstancePoolId)
 
-// 	all, err := w.InstancePools.ListAll(ctx)
-// 	require.NoError(t, err)
+	_, err = InstancePoolsAPI.Edit(ctx, compute.EditInstancePool{
+		InstancePoolId:   created.InstancePoolId,
+		InstancePoolName: RandomName("go-sdk-updated"),
+		NodeTypeId:       smallest,
+	})
+	require.NoError(t, err)
 
-// 	names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, len(all), len(names))
-// 	assert.Equal(t, byId.InstancePoolId, names[byId.InstancePoolName])
+	byId, err := InstancePoolsAPI.GetByInstancePoolId(ctx, created.InstancePoolId)
+	require.NoError(t, err)
 
-// 	byName, err := w.InstancePools.GetByInstancePoolName(ctx, byId.InstancePoolName)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, byName.InstancePoolId, byId.InstancePoolId)
-// }
+	all, err := InstancePoolsAPI.ListAll(ctx)
+	require.NoError(t, err)
+
+	names, err := InstancePoolsAPI.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(all), len(names))
+	assert.Equal(t, byId.InstancePoolId, names[byId.InstancePoolName])
+
+	byName, err := InstancePoolsAPI.GetByInstancePoolName(ctx, byId.InstancePoolName)
+	require.NoError(t, err)
+	assert.Equal(t, byName.InstancePoolId, byId.InstancePoolId)
+}

--- a/integration/jobs_test.go
+++ b/integration/jobs_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/compute/v2"
 	"github.com/databricks/databricks-sdk-go/databricks/apierr"
 	"github.com/databricks/databricks-sdk-go/jobs/v2"
 	"github.com/stretchr/testify/assert"
@@ -17,57 +18,57 @@ func TestAccJobsGetCorrectErrorNoTranspile(t *testing.T) {
 	assert.ErrorIs(t, err, apierr.ErrResourceDoesNotExist)
 }
 
-// TODO: Enable this test when LRO is implemented
-//
-// func TestAccJobsListAllNoDuplicatesNoTranspile(t *testing.T) {
-// 	ctx := workspaceTest(t)
+func TestAccJobsListAllNoDuplicatesNoTranspile(t *testing.T) {
+	ctx := workspaceTest(t)
 
-// 	// Fetch list of spark runtime versions
-// 	ClustersAPI, err := compute.NewClustersClient(nil)
-// 	require.NoError(t, err)
-// 	sparkVersions, err := ClustersAPI.SparkVersions(ctx)
-// 	require.NoError(t, err)
+	// Fetch list of spark runtime versions
+	ClustersAPI, err := compute.NewClustersClient(nil)
+	require.NoError(t, err)
+	sparkVersions, err := ClustersAPI.SparkVersions(ctx)
+	require.NoError(t, err)
 
-// 	// Select the latest LTS version
-// 	latestLTS, err := sparkVersions.Select(compute.SparkVersionRequest{
-// 		Latest: true,
-// 	})
-// 	require.NoError(t, err)
+	// Select the latest LTS version
+	latestLTS, err := sparkVersions.Select(compute.SparkVersionRequest{
+		Latest: true,
+	})
+	require.NoError(t, err)
 
-// 	// Select the smallest node type id
-// 	smallestWithDisk, err := ClustersAPI.SelectNodeType(ctx, compute.NodeTypeRequest{
-// 		LocalDisk: true,
-// 	})
-// 	require.NoError(t, err)
+	// Select the smallest node type id
+	smallestWithDisk, err := ClustersAPI.SelectNodeType(ctx, compute.NodeTypeRequest{
+		LocalDisk: true,
+	})
+	require.NoError(t, err)
 
-// 	for i := 0; i < 34; i++ {
-// 		createdJob, err := w.Jobs.Create(ctx, jobs.CreateJob{
-// 			Name: RandomName(t.Name()),
-// 			Tasks: []jobs.Task{{
-// 				Description: "test",
-// 				NewCluster: &compute.ClusterSpec{
-// 					SparkVersion: latestLTS,
-// 					NodeTypeId:   smallestWithDisk,
-// 					NumWorkers:   1,
-// 				},
-// 				TaskKey:        "test",
-// 				TimeoutSeconds: 0,
-// 				NotebookTask: &jobs.NotebookTask{
-// 					NotebookPath: "/foo/bar",
-// 				},
-// 			}},
-// 		})
-// 		require.NoError(t, err)
-// 		t.Cleanup(func() {
-// 			err := w.Jobs.DeleteByJobId(ctx, createdJob.JobId)
-// 			require.NoError(t, err)
-// 		})
-// 	}
-// 	all, err := w.Jobs.ListAll(ctx, jobs.ListJobsRequest{})
-// 	require.NoError(t, err)
-// 	ids := map[int64]bool{}
-// 	for _, v := range all {
-// 		ids[v.JobId] = true
-// 	}
-// 	assert.Equal(t, len(all), len(ids), "Listing produced duplicate results")
-// }
+	JobsAPI, err := jobs.NewJobsClient(nil)
+	require.NoError(t, err)
+	for i := 0; i < 34; i++ {
+		createdJob, err := JobsAPI.Create(ctx, jobs.CreateJob{
+			Name: RandomName(t.Name()),
+			Tasks: []jobs.Task{{
+				Description: "test",
+				NewCluster: &jobs.JobsClusterSpec{
+					SparkVersion: latestLTS,
+					NodeTypeId:   smallestWithDisk,
+					NumWorkers:   1,
+				},
+				TaskKey:        "test",
+				TimeoutSeconds: 0,
+				NotebookTask: &jobs.NotebookTask{
+					NotebookPath: "/foo/bar",
+				},
+			}},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, err := JobsAPI.DeleteByJobId(ctx, createdJob.JobId)
+			require.NoError(t, err)
+		})
+	}
+	all, err := JobsAPI.ListAll(ctx, jobs.ListJobsRequest{})
+	require.NoError(t, err)
+	ids := map[int64]bool{}
+	for _, v := range all {
+		ids[v.JobId] = true
+	}
+	assert.Equal(t, len(all), len(ids), "Listing produced duplicate results")
+}

--- a/integration/libraries_test.go
+++ b/integration/libraries_test.go
@@ -1,32 +1,49 @@
 package integration
 
-// TODO: Enable this test when LRO is implemented
-//
-// func TestAccLibraries(t *testing.T) {
-// 	ctx, w := workspaceTest(t)
-// 	clusterId := sharedRunningCluster(t, ctx, w)
+import (
+	"context"
+	"testing"
 
-// 	err := w.Libraries.UpdateAndWait(ctx, compute.Update{
-// 		ClusterId: clusterId,
-// 		Install: []compute.Library{
-// 			{
-// 				Pypi: &compute.PythonPyPiLibrary{
-// 					Package: "dbl-tempo",
-// 				},
-// 			},
-// 		},
-// 	})
-// 	require.NoError(t, err)
+	"github.com/databricks/databricks-sdk-go/compute/v2"
+	"github.com/stretchr/testify/require"
+)
 
-// 	err = w.Libraries.UpdateAndWait(ctx, compute.Update{
-// 		ClusterId: clusterId,
-// 		Uninstall: []compute.Library{
-// 			{
-// 				Pypi: &compute.PythonPyPiLibrary{
-// 					Package: "dbl-tempo",
-// 				},
-// 			},
-// 		},
-// 	})
-// 	require.NoError(t, err)
-// }
+func sharedRunningCluster(t *testing.T, ctx context.Context, c *compute.ClustersClient) string {
+	clusterId := GetEnvOrSkipTest(t, "TEST_GO_SDK_CLUSTER_ID")
+	err := c.EnsureClusterIsRunning(ctx, clusterId)
+	require.NoError(t, err)
+	return clusterId
+}
+
+func TestAccLibraries(t *testing.T) {
+	ctx := workspaceTest(t)
+	lc, err := compute.NewLibrariesClient(nil)
+	require.NoError(t, err)
+	cc, err := compute.NewClustersClient(nil)
+	require.NoError(t, err)
+	clusterId := sharedRunningCluster(t, ctx, cc)
+
+	err = lc.UpdateAndWait(ctx, compute.Update{
+		ClusterId: clusterId,
+		Install: []compute.Library{
+			{
+				Pypi: &compute.PythonPyPiLibrary{
+					Package: "dbl-tempo",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	err = lc.UpdateAndWait(ctx, compute.Update{
+		ClusterId: clusterId,
+		Uninstall: []compute.Library{
+			{
+				Pypi: &compute.PythonPyPiLibrary{
+					Package: "dbl-tempo",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR re-enables tests that depend on waiters, which were previously disabled as we didn't have waiters.

## How is this tested?
This PR only tests.
NO_CHANGELOG=true