### PR TITLE
Fix : [ISSUE] databricks auth login - Invalid Databricks Account configuration when host does not specify scheme #1403

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -282,6 +282,8 @@ func (c *Config) IsAccountClient() bool {
 	accountsPrefixes := []string{
 		"https://accounts.",
 		"https://accounts-dod.",
+		// "accounts.",
+		// "accounts-dod.",
 	}
 	for _, prefix := range accountsPrefixes {
 		if strings.HasPrefix(c.Host, prefix) {

--- a/config/config.go
+++ b/config/config.go
@@ -282,8 +282,8 @@ func (c *Config) IsAccountClient() bool {
 	accountsPrefixes := []string{
 		"https://accounts.",
 		"https://accounts-dod.",
-		// "accounts.",
-		// "accounts-dod.",
+		"accounts.",
+		"accounts-dod.",
 	}
 	for _, prefix := range accountsPrefixes {
 		if strings.HasPrefix(c.Host, prefix) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,22 @@ func TestIsAccountClient_AwsAccount(t *testing.T) {
 	assert.True(t, c.IsAccountClient())
 }
 
+func TestIsAccountClient_WithoutHTTPSInHost_AWSAccount(t *testing.T) {
+	c := &Config{
+		Host:      "accounts.cloud.databricks.com",
+		AccountID: "123e4567-e89b-12d3-a456-426614174000",
+	}
+	assert.True(t, c.IsAccountClient())
+}
+
+func TestIsAccountClient_WithoutHTTPSInHost_AwsDodAccount(t *testing.T) {
+	c := &Config{
+		Host:      "accounts-dod.cloud.databricks.us",
+		AccountID: "123e4567-e89b-12d3-a456-426614174000",
+	}
+	assert.True(t, c.IsAccountClient())
+}
+
 func TestIsAccountClient_AwsDodAccount(t *testing.T) {
 	c := &Config{
 		Host:      "https://accounts-dod.cloud.databricks.us",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR addresses an issue where the Databricks authentication process fails when the host URL does not explicitly include the https:// scheme.

- **WHAT** 

  The following changes were made:
   1. Updated the logic in the `IsAccountClient` function in `[./config/config.go](config/config.go)` to account for host URLs without the `https://` scheme (e.g.,  `accounts.cloud.databricks.com`).
   2. Added more prefixes to the check to allow authentication with valid hosts that omit the `https://` scheme.
   3. Created test cases to validate the fix by checking for authentication with both aws and aws-dod host URLs without the `https://` scheme. 

- **WHY** 

   Previously, the authentication failed for users who did not specify https:// in their host URL, even though this should have been allowed. The change ensures that authentication works seamlessly even when the URL is missing the scheme, avoiding unnecessary errors. 

## How is this tested?

Added unit tests functions in `[./config/config_test.go](config/config_test.go)` to validate the changes:

- `TestIsAccountClient_WithoutHTTPSInHost_AWSAccount`: Validates that the IsAccountClient function works for AWS accounts without the https:// scheme.
- `TestIsAccountClient_WithoutHTTPSInHost_AwsDodAccount`: Tests the same functionality for AWS DOD accounts.
- Both tests were successful, confirming the issue has been resolved. A screenshot showing the test results before and after the fix has been included for reference.

After:

<img width="1283" alt="Screenshot 2025-03-30 at 7 57 36 PM" src="https://github.com/user-attachments/assets/e5dc7e9f-7de5-41bd-bcfd-227e2d5396d6" />

Before:

<img width="1401" alt="Screenshot 2025-03-30 at 7 57 53 PM" src="https://github.com/user-attachments/assets/94f2df37-3422-4115-8c23-4bc7e9dbf3eb" />

