### PR TITLE
API Client timeouts should be int64 (breaks linux_arm target)

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -73,10 +73,10 @@ func (cfg ClientConfig) httpTransport() http.RoundTripper {
 }
 
 func NewApiClient(cfg ClientConfig) *ApiClient {
-	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(30*time.Second)))
+	cfg.HTTPTimeout = time.Duration(orDefault(int64(cfg.HTTPTimeout), int64(30*time.Second)))
 	cfg.DebugTruncateBytes = orDefault(cfg.DebugTruncateBytes, 96)
-	cfg.RetryTimeout = time.Duration(orDefault(int(cfg.RetryTimeout), int(5*time.Minute)))
-	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(30*time.Second)))
+	cfg.RetryTimeout = time.Duration(orDefault(int64(cfg.RetryTimeout), int64(5*time.Minute)))
+	cfg.HTTPTimeout = time.Duration(orDefault(int64(cfg.HTTPTimeout), int64(30*time.Second)))
 	if cfg.ErrorMapper == nil {
 		// default generic error mapper
 		cfg.ErrorMapper = DefaultErrorMapper
@@ -392,7 +392,7 @@ func (c *ApiClient) perform(
 	return resp, nil
 }
 
-func orDefault(configured, _default int) int {
+func orDefault(configured, _default int64) int64 {
 	if configured == 0 {
 		return _default
 	}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Implementation uses int(...) for default handling which overflows on linux_arm architecture:

```
../../../../go/pkg/mod/github.com/databricks/databricks-sdk-go@v0.60.0/httpclient/api_client.go:68:70: constant 30000000000 overflows int
```

I've changed it to int64 which also matches `time.Duration` size.


## How is this tested?

PR test suite.