### PR TITLE
[Internal] Remove `TestAccDashboards` as legacy dashboard creation on has been discontinued

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,5 +9,6 @@
 ### Documentation
 
 ### Internal Changes
+* Skip legacy dashboard creation on GCP ([#1205](https://github.com/databricks/databricks-sdk-go/pull/1205)).
 
 ### API Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,6 @@
 ### Documentation
 
 ### Internal Changes
-* Skip legacy dashboard creation on GCP ([#1205](https://github.com/databricks/databricks-sdk-go/pull/1205)).
+* Remove `TestAccDashboards` as legacy dashboard creation on has been discontinued ([#1205](https://github.com/databricks/databricks-sdk-go/pull/1205)).
 
 ### API Changes

--- a/internal/dbsql_test.go
+++ b/internal/dbsql_test.go
@@ -122,37 +122,28 @@ func TestAccAlerts(t *testing.T) {
 // As of April 7, 2025: Official support for the legacy version of dashboards has ended. More context: https://docs.databricks.com/gcp/en/sql/user/dashboards
 // func TestAccDashboards(t *testing.T) {
 // 	ctx, w := workspaceTest(t)
-
 // 	// As of April 7, 2025: Official support for the legacy version of dashboards has ended.
 // 	if w.Config.IsGcp() {
 // 		t.Skip("Legacy dashboard creation is not supported on GCP")
 // 	}
-
 // 	created, err := w.Dashboards.Create(ctx, sql.DashboardPostContent{
 // 		Name: RandomName("go-sdk-"),
 // 	})
 // 	require.NoError(t, err)
-
 // 	defer w.Dashboards.DeleteByDashboardId(ctx, created.Id)
-
 // 	byId, err := w.Dashboards.GetByDashboardId(ctx, created.Id)
 // 	require.NoError(t, err)
-
 // 	byName, err := w.Dashboards.GetByName(ctx, byId.Name)
 // 	require.NoError(t, err)
 // 	assert.Equal(t, byId.Id, byName.Id)
-
 // 	all, err := w.Dashboards.ListAll(ctx, sql.ListDashboardsRequest{})
 // 	require.NoError(t, err)
-
 // 	names, err := w.Dashboards.DashboardNameToIdMap(ctx, sql.ListDashboardsRequest{})
 // 	require.NoError(t, err)
 // 	assert.Equal(t, created.Id, names[byId.Name])
 // 	assert.Equal(t, len(all), len(names))
-
 // 	err = w.Dashboards.DeleteByDashboardId(ctx, created.Id)
 // 	require.NoError(t, err)
-
 // 	err = w.Dashboards.Restore(ctx, sql.RestoreDashboardRequest{
 // 		DashboardId: created.Id,
 // 	})

--- a/internal/dbsql_test.go
+++ b/internal/dbsql_test.go
@@ -119,41 +119,42 @@ func TestAccAlerts(t *testing.T) {
 	assert.Equal(t, alert.Id, names[byId.DisplayName])
 }
 
-func TestAccDashboards(t *testing.T) {
-	ctx, w := workspaceTest(t)
+// As of April 7, 2025: Official support for the legacy version of dashboards has ended. More context: https://docs.databricks.com/gcp/en/sql/user/dashboards
+// func TestAccDashboards(t *testing.T) {
+// 	ctx, w := workspaceTest(t)
 
-	// As of April 7, 2025: Official support for the legacy version of dashboards has ended.
-	if w.Config.IsGcp() {
-		t.Skip("Legacy dashboard creation is not supported on GCP")
-	}
+// 	// As of April 7, 2025: Official support for the legacy version of dashboards has ended.
+// 	if w.Config.IsGcp() {
+// 		t.Skip("Legacy dashboard creation is not supported on GCP")
+// 	}
 
-	created, err := w.Dashboards.Create(ctx, sql.DashboardPostContent{
-		Name: RandomName("go-sdk-"),
-	})
-	require.NoError(t, err)
+// 	created, err := w.Dashboards.Create(ctx, sql.DashboardPostContent{
+// 		Name: RandomName("go-sdk-"),
+// 	})
+// 	require.NoError(t, err)
 
-	defer w.Dashboards.DeleteByDashboardId(ctx, created.Id)
+// 	defer w.Dashboards.DeleteByDashboardId(ctx, created.Id)
 
-	byId, err := w.Dashboards.GetByDashboardId(ctx, created.Id)
-	require.NoError(t, err)
+// 	byId, err := w.Dashboards.GetByDashboardId(ctx, created.Id)
+// 	require.NoError(t, err)
 
-	byName, err := w.Dashboards.GetByName(ctx, byId.Name)
-	require.NoError(t, err)
-	assert.Equal(t, byId.Id, byName.Id)
+// 	byName, err := w.Dashboards.GetByName(ctx, byId.Name)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, byId.Id, byName.Id)
 
-	all, err := w.Dashboards.ListAll(ctx, sql.ListDashboardsRequest{})
-	require.NoError(t, err)
+// 	all, err := w.Dashboards.ListAll(ctx, sql.ListDashboardsRequest{})
+// 	require.NoError(t, err)
 
-	names, err := w.Dashboards.DashboardNameToIdMap(ctx, sql.ListDashboardsRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, created.Id, names[byId.Name])
-	assert.Equal(t, len(all), len(names))
+// 	names, err := w.Dashboards.DashboardNameToIdMap(ctx, sql.ListDashboardsRequest{})
+// 	require.NoError(t, err)
+// 	assert.Equal(t, created.Id, names[byId.Name])
+// 	assert.Equal(t, len(all), len(names))
 
-	err = w.Dashboards.DeleteByDashboardId(ctx, created.Id)
-	require.NoError(t, err)
+// 	err = w.Dashboards.DeleteByDashboardId(ctx, created.Id)
+// 	require.NoError(t, err)
 
-	err = w.Dashboards.Restore(ctx, sql.RestoreDashboardRequest{
-		DashboardId: created.Id,
-	})
-	require.NoError(t, err)
-}
+// 	err = w.Dashboards.Restore(ctx, sql.RestoreDashboardRequest{
+// 		DashboardId: created.Id,
+// 	})
+// 	require.NoError(t, err)
+// }

--- a/internal/dbsql_test.go
+++ b/internal/dbsql_test.go
@@ -122,6 +122,11 @@ func TestAccAlerts(t *testing.T) {
 func TestAccDashboards(t *testing.T) {
 	ctx, w := workspaceTest(t)
 
+	// As of April 7, 2025: Official support for the legacy version of dashboards has ended.
+	if w.Config.IsGcp() {
+		t.Skip("Legacy dashboard creation is not supported on GCP")
+	}
+
 	created, err := w.Dashboards.Create(ctx, sql.DashboardPostContent{
 		Name: RandomName("go-sdk-"),
 	})


### PR DESCRIPTION
## What changes are proposed in this pull request?
As of April 7, 2025: Official support for the legacy version of dashboards has ended.
https://docs.databricks.com/gcp/en/sql/user/dashboards. Removing the test and keeping it commented out for context as discussed. 

## How is this tested?
N/A