### PR TITLE
Enabled asynchronous token refreshes by default

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release v0.64.0
 
 ### New Features and Improvements
+* Enabled asynchronous token refreshes by default ([#1208](https://github.com/databricks/databricks-sdk-go/pull/1208)).
 
 ### Bug Fixes
 

--- a/config/experimental/auth/dataplane/dataplane.go
+++ b/config/experimental/auth/dataplane/dataplane.go
@@ -28,7 +28,6 @@ func NewEndpointTokenSource(c OAuthClient, cpts auth.TokenSource) *dataPlaneToke
 		client: c,
 		cpts: auth.NewCachedTokenSource(
 			cpts,
-			auth.WithAsyncRefresh(false), // TODO: Enable async refreshes once the feature is stable.
 		),
 	}
 }
@@ -65,7 +64,6 @@ func (dpts *dataPlaneTokenSource) Token(ctx context.Context, endpoint string, au
 			cpts:        dpts.cpts,
 			authDetails: authDetails,
 		},
-		auth.WithAsyncRefresh(false), // TODO: Enable async refresh once the feature is stable.
 	)
 	dpts.sources.Store(key, ts)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Enabled asynchronous token refreshes by default

## How is this tested?
Integration tests will be run using the new default