### PR TITLE
Fix: Replace non-ASCII and non-printable characters with dots in logger

### DIFF
--- a/logger/httplog/body_logger.go
+++ b/logger/httplog/body_logger.go
@@ -126,7 +126,8 @@ func (b bodyLogger) redactedDump(prefix string, body []byte) string {
 			sb.WriteString(prefix)
 			for _, c := range line {
 				// Convert non-ASCII and non-printable characters to '.'
-				if c > unicode.MaxASCII || !unicode.IsPrint(c) {
+				// But preserve tabs and spaces for indentation
+				if c > unicode.MaxASCII || (!unicode.IsPrint(c) && c != '\t') {
 					c = '.'
 				}
 				sb.WriteRune(c)

--- a/logger/httplog/body_logger.go
+++ b/logger/httplog/body_logger.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 type bodyLogger struct {
@@ -122,7 +123,14 @@ func (b bodyLogger) redactedDump(prefix string, body []byte) string {
 				sb.WriteString("\n")
 			}
 			line = strings.Trim(line, "\r")
-			sb.WriteString(fmt.Sprintf("%s%s", prefix, line))
+			sb.WriteString(prefix)
+			for _, c := range line {
+				// Convert non-ASCII and non-printable characters to '.'
+				if c > unicode.MaxASCII || !unicode.IsPrint(c) {
+					c = '.'
+				}
+				sb.WriteRune(c)
+			}
 		}
 		return sb.String()
 	}

--- a/logger/httplog/body_logger_test.go
+++ b/logger/httplog/body_logger_test.go
@@ -69,6 +69,11 @@ func TestBodyLoggerNotJson(t *testing.T) {
 	assert.Equal(t, dump, "<html>")
 }
 
+func TestBodyLoggerNotAscii(t *testing.T) {
+	dump := bodyLogger{debugTruncateBytes: 20}.redactedDump("", []byte("\x01 🚀 🚀"))
+	assert.Equal(t, dump, ". . .")
+}
+
 func TestBodyLoggerNonJSONNewline(t *testing.T) {
 	dump := bodyLogger{debugTruncateBytes: 100}.redactedDump("< ", []byte(`<html>
 	<body>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Never log non-ASCII or non-printable characters in log output.

Request logs may include binary data if it isn't JSON. This can affect the terminal state.

Motivated by https://github.com/databricks/cli/pull/2804.

## How is this tested?

Unit test that confirms that non-printable ASCII and UTF-8 characters are replaced with a `.`.