### PR TITLE
Add support to authenticate with Account-wide token federation 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New Features and Improvements
 
+- Add support to authenticate with Account-wide token federation from the 
+  following auth methods: `env-oidc`, `file-oidc`, and `github-oidc`.  
+
 ### Bug Fixes
 
 ### Documentation

--- a/config/auth_azure_github_oidc.go
+++ b/config/auth_azure_github_oidc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/config/credentials"
+	"github.com/databricks/databricks-sdk-go/config/experimental/auth/oidc"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"golang.org/x/oauth2"
 )
@@ -26,10 +27,11 @@ func (c AzureGithubOIDCCredentials) Configure(ctx context.Context, cfg *Config) 
 	if !cfg.IsAzure() || cfg.AzureClientID == "" || cfg.Host == "" || cfg.AzureTenantID == "" || cfg.ActionsIDTokenRequestURL == "" || cfg.ActionsIDTokenRequestToken == "" {
 		return nil, nil
 	}
-	supplier := githubIDTokenSource{actionsIDTokenRequestURL: cfg.ActionsIDTokenRequestURL,
-		actionsIDTokenRequestToken: cfg.ActionsIDTokenRequestToken,
-		refreshClient:              cfg.refreshClient,
-	}
+	supplier := oidc.NewGithubIDTokenSource(
+		cfg.refreshClient,
+		cfg.ActionsIDTokenRequestURL,
+		cfg.ActionsIDTokenRequestToken,
+	)
 
 	idToken, err := supplier.IDToken(ctx, "api://AzureADTokenExchange")
 	if err != nil {

--- a/config/auth_default.go
+++ b/config/auth_default.go
@@ -35,28 +35,28 @@ func buildOidcTokenCredentialStrategies(cfg *Config) []CredentialsStrategy {
 		},
 		{
 			name: "github-oidc",
-			tokenSource: &githubIDTokenSource{
-				actionsIDTokenRequestURL:   cfg.ActionsIDTokenRequestURL,
-				actionsIDTokenRequestToken: cfg.ActionsIDTokenRequestToken,
-				refreshClient:              cfg.refreshClient,
-			},
+			tokenSource: oidc.NewGithubIDTokenSource(
+				cfg.refreshClient,
+				cfg.ActionsIDTokenRequestURL,
+				cfg.ActionsIDTokenRequestToken,
+			),
 		},
 		// Add new providers at the end of the list
 	}
 
 	strategies := []CredentialsStrategy{}
 	for _, idTokenSource := range idTokenSources {
-		oidcConfig := DatabricksOIDCTokenSourceConfig{
+		oidcConfig := oidc.DatabricksOIDCTokenSourceConfig{
 			ClientID:              cfg.ClientID,
 			Host:                  cfg.CanonicalHostName(),
 			TokenEndpointProvider: cfg.getOidcEndpoints,
 			Audience:              cfg.TokenAudience,
-			IdTokenSource:         idTokenSource.tokenSource,
+			IDTokenSource:         idTokenSource.tokenSource,
 		}
 		if cfg.IsAccountClient() {
 			oidcConfig.AccountID = cfg.AccountID
 		}
-		tokenSource := NewDatabricksOIDCTokenSource(oidcConfig)
+		tokenSource := oidc.NewDatabricksOIDCTokenSource(oidcConfig)
 		strategies = append(strategies, NewTokenSourceStrategy(idTokenSource.name, tokenSource))
 	}
 	return strategies

--- a/config/experimental/auth/oidc/github.go
+++ b/config/experimental/auth/oidc/github.go
@@ -1,14 +1,24 @@
-package config
+package oidc
 
 import (
 	"context"
 	"errors"
 	"fmt"
 
-	"github.com/databricks/databricks-sdk-go/config/experimental/auth/oidc"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/logger"
 )
+
+// NewGithubIDTokenSource returns a new IDTokenSource that retrieves an IDToken
+// from the Github Actions environment. This IDTokenSource is only valid when
+// running in Github Actions with OIDC enabled.
+func NewGithubIDTokenSource(client *httpclient.ApiClient, actionsIDTokenRequestURL, actionsIDTokenRequestToken string) IDTokenSource {
+	return &githubIDTokenSource{
+		actionsIDTokenRequestURL:   actionsIDTokenRequestURL,
+		actionsIDTokenRequestToken: actionsIDTokenRequestToken,
+		refreshClient:              client,
+	}
+}
 
 // githubIDTokenSource retrieves JWT Tokens from Github Actions.
 type githubIDTokenSource struct {
@@ -19,7 +29,7 @@ type githubIDTokenSource struct {
 
 // IDToken returns a JWT Token for the specified audience. It will return
 // an error if not running in GitHub Actions.
-func (g *githubIDTokenSource) IDToken(ctx context.Context, audience string) (*oidc.IDToken, error) {
+func (g *githubIDTokenSource) IDToken(ctx context.Context, audience string) (*IDToken, error) {
 	if g.actionsIDTokenRequestURL == "" {
 		logger.Debugf(ctx, "Missing ActionsIDTokenRequestURL, likely not calling from a Github action")
 		return nil, errors.New("missing ActionsIDTokenRequestURL")
@@ -29,7 +39,7 @@ func (g *githubIDTokenSource) IDToken(ctx context.Context, audience string) (*oi
 		return nil, errors.New("missing ActionsIDTokenRequestToken")
 	}
 
-	resp := &oidc.IDToken{}
+	resp := &IDToken{}
 	requestUrl := g.actionsIDTokenRequestURL
 	if audience != "" {
 		requestUrl = fmt.Sprintf("%s&audience=%s", requestUrl, audience)

--- a/config/experimental/auth/oidc/github_test.go
+++ b/config/experimental/auth/oidc/github_test.go
@@ -1,11 +1,10 @@
-package config
+package oidc
 
 import (
 	"context"
 	"net/http"
 	"testing"
 
-	"github.com/databricks/databricks-sdk-go/config/experimental/auth/oidc"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
 	"github.com/google/go-cmp/cmp"
@@ -18,7 +17,7 @@ func TestGithubIDTokenSource(t *testing.T) {
 		tokenRequestToken string
 		audience          string
 		httpTransport     http.RoundTripper
-		wantToken         *oidc.IDToken
+		wantToken         *IDToken
 		wantErrPrefix     *string
 	}{
 		{
@@ -60,7 +59,7 @@ func TestGithubIDTokenSource(t *testing.T) {
 					Response: `{"value": "id-token-42"}`,
 				},
 			},
-			wantToken: &oidc.IDToken{
+			wantToken: &IDToken{
 				Value: "id-token-42",
 			},
 		},


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support to authenticate with [Account-wide token federation](https://docs.databricks.com/aws/en/dev-tools/auth/oauth-federation#account-wide-token-federation) from the following auth methods: `env-oidc`, `file-oidc`, and `github-oidc`.  

The PR also slightly re-organize the code by moving the OIDC token source and Github IDTokenSource in the `oidc` package.

## How is this tested?

Unit test + local validation.