### PR TITLE
Return `ErrCannotConfigureDefault` when `DefaulCredentials` cannot determine the default auth type.

### DIFF
--- a/config/auth_default.go
+++ b/config/auth_default.go
@@ -11,6 +11,10 @@ import (
 
 const authDocURL = "https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication"
 
+// ErrCannotConfigureDefault indicates that the DefaultCredentials strategy was
+// unable to configure the default credentials.
+var ErrCannotConfigureDefault = fmt.Errorf("cannot configure default credentials, please check %s to configure credentials for your preferred authentication method", authDocURL)
+
 type DefaultCredentials struct {
 	name string
 }
@@ -83,7 +87,7 @@ func (c *DefaultCredentials) Configure(ctx context.Context, cfg *Config) (creden
 		return cp, nil
 	}
 
-	return nil, fmt.Errorf("cannot configure default credentials, please check %s to configure credentials for your preferred authentication method", authDocURL)
+	return nil, ErrCannotConfigureDefault
 }
 
 func githubOIDC(cfg *Config) CredentialsStrategy {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds changes `DefaultCredentials` to return `ErrCannotConfigureDefault` when it cannot determine the default auth type. The goal is to make it easier for clients (such as the Databricks CLI) to differentiate auth errors from config errors. 

## How is this tested?

N/A

NO_CHANGELOG=true