### PR TITLE
Pin make file dependency versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: vendor
 
 fmt:
 	@echo "✓ Formatting source code with goimports ..."
-	@go run golang.org/x/tools/cmd/goimports@latest -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+	@go run golang.org/x/tools/cmd/goimports@0.34.0 -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 	@echo "✓ Formatting source code with gofmt ..."
 	@gofmt -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
@@ -16,7 +16,7 @@ lint: vendor
 
 test: vendor
 	@echo "✓ Running tests ..."
-	@go run gotest.tools/gotestsum@latest --format pkgname-and-test-fails \
+	@go run gotest.tools/gotestsum@v1.12.2 --format pkgname-and-test-fails \
 		--no-summary=skipped --raw-command go test -v \
 		-json -short -coverprofile=coverage.txt ./...
 
@@ -34,6 +34,6 @@ download:
 
 doc:
 	@echo "Open http://localhost:6060"
-	@go run golang.org/x/tools/cmd/godoc@latest -http=localhost:6060
+	@go run golang.org/x/tools/cmd/godoc@v0.34.0 -http=localhost:6060
 
 .PHONY: fmt vendor fmt coverage test lint doc download


### PR DESCRIPTION
## What changes are proposed in this pull request?
Pin make file dependency versions. We should not use latest since it can break without notice.

## How is this tested?
```
make build
make test
make doc
```

NO_CHANGELOG=true