### PR TITLE
Fix version for the goimports in make fmt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: vendor
 
 fmt:
 	@echo "✓ Formatting source code with goimports ..."
-	@go run golang.org/x/tools/cmd/goimports@0.34.0 -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+	@go run golang.org/x/tools/cmd/goimports@v0.34.0 -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 	@echo "✓ Formatting source code with gofmt ..."
 	@gofmt -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix version for the goimports in make fmt. Currently, we are missing a v before 0.34.0 in the version, which gives the following error: `go: golang.org/x/tools/cmd/goimports@0.34.0: golang.org/x/tools/cmd/goimports@0.34.0: invalid version: unknown revision 0.34.0`

## How is this tested?
Tested Locally. 

NO_CHANGELOG=true