### PR TITLE
Start decoupling `ApiClient` and `DatabricksClient`.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Default values for `ApiClient` are now properly set in the type constructor rather than in the config constructor. 
+
 ### Documentation
 
 ### Internal Changes

--- a/client/client.go
+++ b/client/client.go
@@ -15,13 +15,12 @@ func New(cfg *config.Config) (*DatabricksClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := cfg.NewApiClient()
+	clientCfg, err := config.HTTPClientConfigFromConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &DatabricksClient{
-		Config: cfg,
-		client: client,
+		client: httpclient.NewApiClient(clientCfg),
 	}, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,7 @@ func New(cfg *config.Config) (*DatabricksClient, error) {
 		return nil, err
 	}
 	return &DatabricksClient{
+		Config: cfg,
 		client: httpclient.NewApiClient(clientCfg),
 	}, nil
 }

--- a/common/environment/environments.go
+++ b/common/environment/environments.go
@@ -8,10 +8,9 @@ import (
 type Cloud string
 
 const (
-	CloudUnknown Cloud = "Unknown"
-	CloudAWS     Cloud = "AWS"
-	CloudAzure   Cloud = "Azure"
-	CloudGCP     Cloud = "GCP"
+	CloudAWS   Cloud = "AWS"
+	CloudAzure Cloud = "Azure"
+	CloudGCP   Cloud = "GCP"
 )
 
 type DatabricksEnvironment struct {

--- a/common/environment/environments.go
+++ b/common/environment/environments.go
@@ -8,9 +8,10 @@ import (
 type Cloud string
 
 const (
-	CloudAWS   Cloud = "AWS"
-	CloudAzure Cloud = "Azure"
-	CloudGCP   Cloud = "GCP"
+	CloudUnknown Cloud = "Unknown"
+	CloudAWS     Cloud = "AWS"
+	CloudAzure   Cloud = "Azure"
+	CloudGCP     Cloud = "GCP"
 )
 
 type DatabricksEnvironment struct {

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/config/credentials"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/useragent"
@@ -31,7 +30,6 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 	return httpclient.ClientConfig{
 		AccountID:          cfg.AccountID,
 		Host:               cfg.Host,
-		Cloud:              cloudFromConfig(cfg),
 		RetryTimeout:       time.Duration(cfg.RetryTimeoutSeconds) * time.Second,
 		HTTPTimeout:        time.Duration(cfg.HTTPTimeoutSeconds) * time.Second,
 		RateLimitPerSecond: cfg.RateLimitPerSecond,
@@ -91,19 +89,6 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 			return false
 		},
 	}, nil
-}
-
-func cloudFromConfig(cfg *Config) environment.Cloud {
-	switch {
-	case cfg.IsAzure():
-		return environment.CloudAzure
-	case cfg.IsAws():
-		return environment.CloudAWS
-	case cfg.IsGcp():
-		return environment.CloudGCP
-	default:
-		return environment.CloudUnknown
-	}
 }
 
 // noopLoader skips configuration loading

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -28,15 +28,10 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 		return httpclient.ClientConfig{}, err
 	}
 
-	cloud := cloudFromConfig(cfg)
-	if cloud == environment.CloudUnknown {
-		return httpclient.ClientConfig{}, fmt.Errorf("unable to determine cloud from config")
-	}
-
 	return httpclient.ClientConfig{
 		AccountID:          cfg.AccountID,
 		Host:               cfg.Host,
-		Cloud:              cloud,
+		Cloud:              cloudFromConfig(cfg),
 		RetryTimeout:       time.Duration(cfg.RetryTimeoutSeconds) * time.Second,
 		HTTPTimeout:        time.Duration(cfg.HTTPTimeoutSeconds) * time.Second,
 		RateLimitPerSecond: cfg.RateLimitPerSecond,
@@ -99,18 +94,16 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 }
 
 func cloudFromConfig(cfg *Config) environment.Cloud {
-	var cloud environment.Cloud
 	switch {
 	case cfg.IsAzure():
-		cloud = environment.CloudAzure
+		return environment.CloudAzure
 	case cfg.IsAws():
-		cloud = environment.CloudAWS
+		return environment.CloudAWS
 	case cfg.IsGcp():
-		cloud = environment.CloudGCP
+		return environment.CloudGCP
 	default:
 		return environment.CloudUnknown
 	}
-	return cloud
 }
 
 // noopLoader skips configuration loading

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -9,39 +9,48 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/config/credentials"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/useragent"
 )
 
-func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
-	if skippable, ok := c.HTTPTransport.(interface {
+func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
+	if skippable, ok := cfg.HTTPTransport.(interface {
 		SkipRetryOnIO() bool
 	}); ok && skippable.SkipRetryOnIO() {
-		c.Loaders = []Loader{noopLoader{}}
-		c.Credentials = noopAuth{}
+		cfg.Loaders = []Loader{noopLoader{}}
+		cfg.Credentials = noopAuth{}
 	}
-	err := c.EnsureResolved()
+
+	err := cfg.EnsureResolved()
 	if err != nil {
-		return nil, err
+		return httpclient.ClientConfig{}, err
 	}
-	retryTimeout := time.Duration(orDefault(c.RetryTimeoutSeconds, 300)) * time.Second
-	httpTimeout := time.Duration(orDefault(c.HTTPTimeoutSeconds, 60)) * time.Second
-	return httpclient.NewApiClient(httpclient.ClientConfig{
-		RetryTimeout:       retryTimeout,
-		HTTPTimeout:        httpTimeout,
-		RateLimitPerSecond: orDefault(c.RateLimitPerSecond, 15),
-		DebugHeaders:       c.DebugHeaders,
-		DebugTruncateBytes: c.DebugTruncateBytes,
-		InsecureSkipVerify: c.InsecureSkipVerify,
-		Transport:          c.HTTPTransport,
-		AuthVisitor:        c.Authenticate,
+
+	cloud := cloudFromConfig(cfg)
+	if cloud == environment.CloudUnknown {
+		return httpclient.ClientConfig{}, fmt.Errorf("unable to determine cloud from config")
+	}
+
+	return httpclient.ClientConfig{
+		AccountID:          cfg.AccountID,
+		Host:               cfg.Host,
+		Cloud:              cloud,
+		RetryTimeout:       time.Duration(cfg.RetryTimeoutSeconds) * time.Second,
+		HTTPTimeout:        time.Duration(cfg.HTTPTimeoutSeconds) * time.Second,
+		RateLimitPerSecond: cfg.RateLimitPerSecond,
+		DebugHeaders:       cfg.DebugHeaders,
+		DebugTruncateBytes: cfg.DebugTruncateBytes,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		Transport:          cfg.HTTPTransport,
+		AuthVisitor:        cfg.Authenticate,
 		Visitors: []httpclient.RequestVisitor{
 			func(r *http.Request) error {
 				if r.URL == nil {
 					return fmt.Errorf("no URL found in request")
 				}
-				url, err := url.Parse(c.Host)
+				url, err := url.Parse(cfg.Host)
 				if err != nil {
 					return err
 				}
@@ -49,7 +58,7 @@ func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
 				r.URL.Scheme = url.Scheme
 				return nil
 			},
-			authInUserAgentVisitor(c),
+			authInUserAgentVisitor(cfg),
 			func(r *http.Request) error {
 				// Detect if we are running in a CI/CD environment
 				provider := useragent.CiCdProvider()
@@ -74,7 +83,9 @@ func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
 			},
 		},
 		TransientErrors: []string{
-			"REQUEST_LIMIT_EXCEEDED", // This is temporary workaround for SCIM API returning 500.  Remove when it's fixed
+			// This is temporary workaround for SCIM API returning 500.
+			// TODO: Remove when it's fixed.
+			"REQUEST_LIMIT_EXCEEDED",
 		},
 		ErrorMapper: apierr.GetAPIError,
 		ErrorRetriable: func(ctx context.Context, err error) bool {
@@ -84,14 +95,22 @@ func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
 			}
 			return false
 		},
-	}), nil
+	}, nil
 }
 
-func orDefault(configured, _default int) int {
-	if configured == 0 {
-		return _default
+func cloudFromConfig(cfg *Config) environment.Cloud {
+	var cloud environment.Cloud
+	switch {
+	case cfg.IsAzure():
+		cloud = environment.CloudAzure
+	case cfg.IsAws():
+		cloud = environment.CloudAWS
+	case cfg.IsGcp():
+		cloud = environment.CloudGCP
+	default:
+		return environment.CloudUnknown
 	}
-	return configured
+	return cloud
 }
 
 // noopLoader skips configuration loading
@@ -107,4 +126,13 @@ func (noopAuth) Name() string { return "noop" }
 func (noopAuth) Configure(context.Context, *Config) (credentials.CredentialsProvider, error) {
 	visitor := func(r *http.Request) error { return nil }
 	return credentials.CredentialsProviderFn(visitor), nil
+}
+
+// Deprecated: use [HTTPClientConfigFromConfig] with [httpclient.NewApiClient].
+func (c *Config) NewApiClient() (*httpclient.ApiClient, error) {
+	cfg, err := HTTPClientConfigFromConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	return httpclient.NewApiClient(cfg), nil
 }

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -33,7 +33,7 @@ type ClientConfig struct {
 	Host      string
 
 	// TODO: Ideally we should not have knowledge of the cloud in the client
-	// config. But `getOrCreateRunningCluster` in `compute/v2/ext_utilities.go`
+	// config. But `getOrCreateRunningCluster` in `compute/ext_utilities.go`
 	// uses this to determine the cloud. So, we are keeping it for now. But we
 	// should reconsider this in the future.
 	Cloud environment.Cloud

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/common"
-	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/httpclient/traceparent"
 	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/logger/httplog"
@@ -73,26 +72,6 @@ func (apic *ApiClient) IsAccountClient() bool {
 		return true
 	}
 	return false
-}
-
-// AccountID returns the account ID for the client.
-func (apic *ApiClient) AccountID() string {
-	return apic.config.AccountID
-}
-
-// IsAzure returns if the client is configured for Azure Databricks.
-func (apic *ApiClient) IsAzure() bool {
-	return apic.config.Cloud == environment.CloudAzure
-}
-
-// IsGcp returns if the client is configured for Databricks on Google Cloud.
-func (apic *ApiClient) IsGcp() bool {
-	return apic.config.Cloud == environment.CloudGCP
-}
-
-// IsAws returns if the client is configured for Databricks on AWS.
-func (apic *ApiClient) IsAws() bool {
-	return apic.config.Cloud == environment.CloudAWS
 }
 
 var defaultTransport = makeDefaultTransport()

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -32,12 +32,6 @@ type ClientConfig struct {
 	AccountID string
 	Host      string
 
-	// TODO: Ideally we should not have knowledge of the cloud in the client
-	// config. But `getOrCreateRunningCluster` in `compute/ext_utilities.go`
-	// uses this to determine the cloud. So, we are keeping it for now. But we
-	// should reconsider this in the future.
-	Cloud environment.Cloud
-
 	RetryTimeout       time.Duration
 	HTTPTimeout        time.Duration
 	InsecureSkipVerify bool

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -105,10 +105,13 @@ func (cfg ClientConfig) httpTransport() http.RoundTripper {
 }
 
 func NewApiClient(cfg ClientConfig) *ApiClient {
+	// Set defaults for config values that are not set.
 	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(30*time.Second)))
 	cfg.DebugTruncateBytes = orDefault(cfg.DebugTruncateBytes, 96)
 	cfg.RetryTimeout = time.Duration(orDefault(int(cfg.RetryTimeout), int(5*time.Minute)))
-	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(30*time.Second)))
+	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(60*time.Second)))
+	cfg.RateLimitPerSecond = orDefault(cfg.RateLimitPerSecond, 15)
+
 	if cfg.ErrorMapper == nil {
 		// default generic error mapper
 		cfg.ErrorMapper = DefaultErrorMapper


### PR DESCRIPTION
## What changes are proposed in this pull request?

The SDK has two clients which serve very similar purposes: `ApiClient` and `DatabricksClient`. This PR is a first step to pay to merge these two client into a single consistent client. Specifically, it brings some of the functionality from `DatabricksClient` in `ApiClient` in preparation for a change of code generation logic.

This PR also slightly changes the way the `ApiClient` default parameter values are set by moving the logic in its constructor. 

## How is this tested?

Unit and integration tests.