### PR TITLE
Return more details error message when OAuth endpoints cannot be resolved.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+- Return more detailed error messages when OAuth endpoints cannot be resolved.
+
 ### Bug Fixes
 
 ### Documentation

--- a/config/auth_u2m.go
+++ b/config/auth_u2m.go
@@ -82,7 +82,7 @@ func (u u2mCredentials) makeVisitor(auth oauth2.TokenSource) func(*http.Request)
 func (u u2mCredentials) errorHandler(ctx context.Context, cfg *Config, arg u2m.OAuthArgument, err error) error {
 	// If the current OAuth argument doesn't have a corresponding session
 	// token, fall back to the next credentials strategy.
-	if errors.Is(err, cache.ErrNotConfigured) {
+	if errors.Is(err, cache.ErrNotFound) {
 		return nil
 	}
 	// If there is an existing token but the refresh token is invalid,

--- a/config/auth_u2m_test.go
+++ b/config/auth_u2m_test.go
@@ -99,7 +99,7 @@ func TestDatabricksCli_ErrorHandler(t *testing.T) {
 		{
 			name: "not configured is ignored",
 			arg:  workspaceArg,
-			err:  cache.ErrNotConfigured,
+			err:  cache.ErrNotFound,
 			want: nil,
 		},
 		{

--- a/config/in_memory_test.go
+++ b/config/in_memory_test.go
@@ -13,7 +13,7 @@ type InMemoryTokenCache struct {
 func (i *InMemoryTokenCache) Lookup(key string) (*oauth2.Token, error) {
 	token, ok := i.Tokens[key]
 	if !ok {
-		return nil, cache.ErrNotConfigured
+		return nil, cache.ErrNotFound
 	}
 	return token, nil
 }

--- a/credentials/u2m/cache/cache.go
+++ b/credentials/u2m/cache/cache.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var ErrNotFound = errors.New("token not found")
+
 // TokenCache is an interface for storing and looking up OAuth tokens.
 type TokenCache interface {
 	// Store stores the token with the given key, replacing any existing token.
@@ -25,8 +27,6 @@ type TokenCache interface {
 	Store(key string, t *oauth2.Token) error
 
 	// Lookup looks up the token with the given key. If the token is not found, it
-	// returns ErrNotConfigured.
+	// returns ErrNotFound.
 	Lookup(key string) (*oauth2.Token, error)
 }
-
-var ErrNotConfigured = errors.New("databricks OAuth is not configured for this host")

--- a/credentials/u2m/cache/file.go
+++ b/credentials/u2m/cache/file.go
@@ -116,7 +116,7 @@ func (c *fileTokenCache) Lookup(key string) (*oauth2.Token, error) {
 	}
 	t, ok := f.Tokens[key]
 	if !ok {
-		return nil, ErrNotConfigured
+		return nil, ErrNotFound
 	}
 	return t, nil
 }

--- a/credentials/u2m/cache/file_test.go
+++ b/credentials/u2m/cache/file_test.go
@@ -33,14 +33,14 @@ func TestStoreAndLookup(t *testing.T) {
 	assert.Equal(t, "abc", tok.AccessToken)
 
 	_, err = c.Lookup("z")
-	assert.Equal(t, ErrNotConfigured, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestNoCacheFileReturnsErrNotConfigured(t *testing.T) {
 	l, err := NewFileTokenCache(WithFileLocation(setup(t)))
 	require.NoError(t, err)
 	_, err = l.Lookup("x")
-	assert.Equal(t, ErrNotConfigured, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestLoadCorruptFile(t *testing.T) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR slightly updates the endpoint resolution logic to return more details error message when OAuth endpoints cannot be resolved. It also update the TokenCache not found error to be more aligned with its semantic in the context of the token cache.

## How is this tested?

Updated relevant unit tests. 