### PR TITLE
Explicitly mark `APIError.ResponseWrapper` as experimental.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Release v0.80.0
 
 ### New Features and Improvements
-* Added `ResponseWrapper` field to `APIError` struct ([1261](https://github.com/databricks/databricks-sdk-go/pull/1261)).
 
 ### Bug Fixes
 

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -30,8 +30,8 @@ type APIError struct {
 
 	// ResponseWrapper contains request/response for the error.
 	//
-	// EXPERIMENTAL: This field is experimental and may be changed or removed
-	// in the future.
+	// EXPERIMENTAL INTERNAL: This field is experimental and meant for internal
+	// use only. It will change or be removed in the future.
 	ResponseWrapper *common.ResponseWrapper
 
 	errorDetails ErrorDetails

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -28,7 +28,10 @@ type APIError struct {
 	Message    string
 	StatusCode int
 
-	// ResponseWrapper contains request/response for the error
+	// ResponseWrapper contains request/response for the error.
+	//
+	// EXPERIMENTAL: This field is experimental and may be changed or removed
+	// in the future.
 	ResponseWrapper *common.ResponseWrapper
 
 	errorDetails ErrorDetails


### PR DESCRIPTION
## What changes are proposed in this pull request?

`APIError.ResponseWrapper` is an experimental internal feature meant to enable some functionality in the Databricks CLI. As such, users should refrain from having dependency on that field. This PR helps make that contract clear. 

## How is this tested?

N/A

NO_CHANGELOG=true