### PR TITLE
[DO NOT TOUCH] Revert "Use a free port in `u2m` authentication flows rather than 8020.  (#1239)"

### DIFF
--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -26,8 +26,7 @@ const (
 	appClientID = "databricks-cli"
 
 	// appRedirectAddr is the default address for the OAuth2 callback server.
-	// Using ":0" tells the system to pick a random available port.
-	appRedirectAddr = "localhost:0"
+	appRedirectAddr = "localhost:8020"
 
 	// listenerTimeout is the maximum amount of time to acquire listener on
 	// appRedirectAddr.
@@ -58,11 +57,6 @@ type PersistentAuth struct {
 	// ctx is the context to use for underlying operations. This is needed in
 	// order to implement the oauth2.TokenSource interface.
 	ctx context.Context
-	// redirectAddr is the redirect address for OAuth2 callbacks. The value is
-	// set to localhost:PORT by startListener which will dynamically assign a
-	// random port. If a value is already provided, it will be used instead
-	// (e.g. for testing).
-	redirectAddr string
 }
 
 type PersistentAuthOption func(*PersistentAuth)
@@ -134,6 +128,9 @@ func NewPersistentAuth(ctx context.Context, opts ...PersistentAuthOption) (*Pers
 			return nil, fmt.Errorf("cache: %w", err)
 		}
 	}
+	if p.oAuthArgument == nil {
+		return nil, errors.New("missing OAuthArgument")
+	}
 	if err := p.validateArg(); err != nil {
 		return nil, err
 	}
@@ -165,9 +162,7 @@ func (a *PersistentAuth) Token() (t *oauth2.Token, err error) {
 			return nil, fmt.Errorf("token refresh: %w", err)
 		}
 	}
-
-	// Do not include the refresh token for security reasons. Refresh tokens are
-	// long-lived credentials that we do not want to expose unnecessarily.
+	// do not print refresh token to end-user
 	t.RefreshToken = ""
 	return t, nil
 }
@@ -274,19 +269,12 @@ func (a *PersistentAuth) Challenge() error {
 // startListener starts a listener on appRedirectAddr, retrying if the address
 // is already in use.
 func (a *PersistentAuth) startListener(ctx context.Context) error {
-	// Use the value of redirectURL if it is already set. This is only expected
-	// in tests to set a fixed redirect URL.
-	addr := a.redirectAddr
-	if addr == "" {
-		addr = appRedirectAddr
-	}
-
 	listener, err := retries.Poll(ctx, listenerTimeout,
 		func() (*net.Listener, *retries.Err) {
 			var lc net.ListenConfig
-			l, err := lc.Listen(ctx, "tcp", addr)
+			l, err := lc.Listen(ctx, "tcp", appRedirectAddr)
 			if err != nil {
-				logger.Debugf(ctx, "failed to listen on %s: %v, retrying", addr, err)
+				logger.Debugf(ctx, "failed to listen on %s: %v, retrying", appRedirectAddr, err)
 				return nil, retries.Continue(err)
 			}
 			return &l, nil
@@ -295,10 +283,6 @@ func (a *PersistentAuth) startListener(ctx context.Context) error {
 		return fmt.Errorf("listener: %w", err)
 	}
 	a.ln = *listener
-
-	// Get the actual address that was assigned (including the port).
-	a.redirectAddr = a.ln.Addr().String()
-	logger.Debugf(ctx, "OAuth callback server listening on %s", a.redirectAddr)
 	return nil
 }
 
@@ -312,9 +296,6 @@ func (a *PersistentAuth) Close() error {
 // validateArg ensures that the OAuthArgument is either a WorkspaceOAuthArgument
 // or an AccountOAuthArgument.
 func (a *PersistentAuth) validateArg() error {
-	if a.oAuthArgument == nil {
-		return errors.New("missing OAuthArgument")
-	}
 	_, isWorkspaceArg := a.oAuthArgument.(WorkspaceOAuthArgument)
 	_, isAccountArg := a.oAuthArgument.(AccountOAuthArgument)
 	if !isWorkspaceArg && !isAccountArg {
@@ -350,7 +331,7 @@ func (a *PersistentAuth) oauth2Config() (*oauth2.Config, error) {
 			TokenURL:  endpoints.TokenEndpoint,
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
-		RedirectURL: fmt.Sprintf("http://%s", a.redirectAddr),
+		RedirectURL: fmt.Sprintf("http://%s", appRedirectAddr),
 		Scopes:      scopes,
 	}, nil
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This reverts commit 667c53b472be6ba8866a927fe2ef7e7e8e668cad.

The original change is causing an issue when users use `databricks auth login`. It fails with:
```
{"error_description":"redirect_uri 'http:\/\/127.0.0.1:63673' not registered for OAuth application 'databricks-cli'","error":"invalid_request"}
```

## How is this tested?

Manually, `auth login` succeeds after this PR is reverted.