### PR TITLE
Add LroOptions struct for Long Running Operations configuration

### DIFF
--- a/service/common/lro/options.go
+++ b/service/common/lro/options.go
@@ -1,0 +1,12 @@
+package lro
+
+import "time"
+
+// LroOptions is the options for the Long Running Operations.
+// DO NOT USE THIS OPTION. This option is still under development
+// and can be updated in the future without notice.
+type LroOptions struct {
+	// Timeout is the timeout for the Long Running Operations.
+	// If not set, the default timeout is 20 minutes.
+	Timeout time.Duration
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change introduces the LroOptions struct to allow configuration of Long Running Operations, specifically timeout settings. The struct is marked as experimental and subject to future changes.

## How is this tested?

N/A

NO_CHANGELOG=true