### PR TITLE
Increase burst for rate limiter

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release v0.84.0
 
 ### New Features and Improvements
+* Increased rate limiter burst setting from 1 to rate\_limit value.
 
 ### Bug Fixes
 

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -22,8 +22,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const maxAllowedBurst = 5
-
 type RequestVisitor func(*http.Request) error
 
 type ClientConfig struct {
@@ -133,9 +131,6 @@ func NewApiClient(cfg ClientConfig) *ApiClient {
 	}
 
 	burst := int(rateLimit)
-	if burst > maxAllowedBurst {
-		burst = maxAllowedBurst
-	}
 	if burst < 1 {
 		burst = 1
 	}

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -131,6 +131,7 @@ func NewApiClient(cfg ClientConfig) *ApiClient {
 	}
 
 	burst := int(rateLimit)
+	// Ensure that burst is never 0
 	if burst < 1 {
 		burst = 1
 	}

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const maxAllowedBurst = 10
+const maxAllowedBurst = 5
 
 type RequestVisitor func(*http.Request) error
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Increase burst in rate limiter to the value of RateLimitPerSecond.

The current value of 1 means that even CLI commands that do 2 requests can have a sleep between them. This will increase speed of short-lived commands that do a few requests only.

The burst=1 also means that effective RPS is lower than target 15 RPS because if there is a mix of requests that are longer than 1/15s (default rate limit) and shorter than 1/15s the tokens are wasted.

The burst=1 comes from the initial commit https://github.com/databricks/databricks-sdk-go/commit/027c878a1709de251365a2417ebedc4185a53a94#diff-99ba62d54caf56e573f16c036acfae28d76ddaace9a914740a10f4e1d50b1bd8R420

which comes from this terraform provider commit https://github.com/databricks/terraform-provider-databricks/commit/6669a942e348c2f36d1a21b4f778777d3734f894#diff-e24a91e4fac6650a021a72e8527d08f88b5775ee989f109f5c6ead0c3737c7a6R201

## How is this tested?

Existing tests.