### PR TITLE
Set default HTTPTimeout to 60s

### DIFF
--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -106,7 +106,6 @@ func (cfg ClientConfig) httpTransport() http.RoundTripper {
 
 func NewApiClient(cfg ClientConfig) *ApiClient {
 	// Set defaults for config values that are not set.
-	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(30*time.Second)))
 	cfg.DebugTruncateBytes = orDefault(cfg.DebugTruncateBytes, 96)
 	cfg.RetryTimeout = time.Duration(orDefault(int(cfg.RetryTimeout), int(5*time.Minute)))
 	cfg.HTTPTimeout = time.Duration(orDefault(int(cfg.HTTPTimeout), int(60*time.Second)))


### PR DESCRIPTION
As far as I can see the intention is to have 60s (README.md says 60s).

The code sets both 30s and 60s but 30s is set first so it takes priority as the default.