### PR TITLE
Improve authentication prompt message formatting

### DIFF
--- a/credentials/u2m/callback.go
+++ b/credentials/u2m/callback.go
@@ -122,7 +122,7 @@ func (cb *callbackServer) getHost() string {
 func (cb *callbackServer) Handler(authCodeURL string) (string, string, error) {
 	err := cb.browser(authCodeURL)
 	if err != nil {
-		fmt.Printf("Please open %s in the browser to continue authentication", authCodeURL)
+		fmt.Printf("Please continue the authentication process in your browser:\n%s\n", authCodeURL)
 	}
 	select {
 	case <-cb.ctx.Done():


### PR DESCRIPTION
## What changes are proposed in this pull request?

The error case missed a newline.

I took the opportunity to rephrase the message.

## How is this tested?

Before:
```
$ databricks auth login --profile myprofile
/usr/bin/xdg-open: 869: www-browser: not found
/usr/bin/xdg-open: 869: links2: not found
/usr/bin/xdg-open: 869: elinks: not found
/usr/bin/xdg-open: 869: links: not found
/usr/bin/xdg-open: 869: lynx: not found
/usr/bin/xdg-open: 869: w3m: not found
xdg-open: no method available for opening 'https://...'
Please open https://... in the browser to continue authenticationProfile myprofile was successfully saved
```

After (includes https://github.com/databricks/cli/pull/3991):
```
$ databricks auth login --profile myprofile
Please continue the authentication process in your browser:
https://...
Profile myprofile was successfully saved
```

<!--
NO_CHANGELOG=true
//-->