### PR TITLE
[Feature] Add support for custom HTTP headers and URL path prefix

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Add `HTTPHeaders` and `HTTPPathPrefix` configuration options to support HTTP proxies that require custom headers or URL path rewriting.
+
 ### Bug Fixes
 
 ### Documentation

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -38,6 +38,17 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 			}
 			r.URL.Host = url.Host
 			r.URL.Scheme = url.Scheme
+			// Prepend path prefix if configured
+			if cfg.HTTPPathPrefix != "" {
+				r.URL.Path = cfg.HTTPPathPrefix + r.URL.Path
+			}
+			return nil
+		},
+		// Add custom HTTP headers if configured
+		func(r *http.Request) error {
+			for key, value := range cfg.HTTPHeaders {
+				r.Header.Set(key, value)
+			}
 			return nil
 		},
 		authInUserAgentVisitor(cfg),

--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,14 @@ type Config struct {
 	// Number of seconds for HTTP timeout. Default is 60 (1 minute).
 	HTTPTimeoutSeconds int `name:"http_timeout_seconds" auth:"-"`
 
+	// Custom HTTP headers to be added to each API request.
+	// Format for environment variable: key1=value1;key2=value2
+	HTTPHeaders map[string]string `name:"http_headers" env:"DATABRICKS_HTTP_HEADERS" auth:"-"`
+
+	// Path prefix to be prepended to all API URLs. Useful for HTTP proxies
+	// that require URL path rewriting.
+	HTTPPathPrefix string `name:"http_path_prefix" env:"DATABRICKS_HTTP_PATH_PREFIX" auth:"-"`
+
 	// Truncate JSON fields in JSON above this limit. Default is 96.
 	DebugTruncateBytes int `name:"debug_truncate_bytes" env:"DATABRICKS_DEBUG_TRUNCATE_BYTES" auth:"-"`
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add two new configuration options to enable the SDK to work with HTTP proxies:

1. **HTTPHeaders** (`map[string]string`): Custom headers added to all API requests
2. **HTTPPathPrefix** (`string`): Path prefix prepended to all API URLs

These options can be configured via:
- Struct fields (programmatic)
- Environment variables: `DATABRICKS_HTTP_HEADERS` (format: `key1=value1;key2=value2`) and `DATABRICKS_HTTP_PATH_PREFIX`
- Config file attributes: `http_headers` and `http_path_prefix`

#### Files changed:
- `config/config.go`: Added new config fields with struct tags
- `config/config_attribute.go`: Added support for parsing `map[string]string` from environment variables
- `config/api_client.go`: Added request visitors for applying headers and path prefix

### How is this tested?
Existing CI.

Also added unit tests in `config/config_test.go`:
- `TestConfig_HTTPHeaders`: Verifies headers are applied to requests
- `TestConfig_HTTPPathPrefix`: Verifies path prefix is prepended
- `TestConfig_HTTPHeadersAndPathPrefix`: Verifies both work together
- `TestConfig_HTTPHeadersFromEnvVar`: Verifies env var parsing for headers
- `TestConfig_HTTPPathPrefixFromEnvVar`: Verifies env var parsing for path prefix
- `TestParseMapFromString`: Verifies map parsing edge cases

