### PR TITLE
Remove Billing API test

### DIFF
--- a/internal/billing_test.go
+++ b/internal/billing_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"io"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/billing"
@@ -9,21 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMwsAccUsageDownload(t *testing.T) {
-	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
-		t.SkipNow()
-	}
-	resp, err := a.BillableUsage.Download(ctx, billing.DownloadRequest{
-		StartMonth: "2024-08",
-		EndMonth:   "2024-09",
-	})
-	require.NoError(t, err)
-	out, err := io.ReadAll(resp.Contents)
-	require.NoError(t, err)
-	assert.NotEmpty(t, out)
-}
 
 func TestMwsAccLogDelivery(t *testing.T) {
 	ctx, a := accountTest(t)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Remove Billing API test. 

This test recently started to time-out after backend changes which caused the API to return slower.
Given that the test has very low benefit to the SDKs and it takes very long time to run, we can remove it.
What this test is testing is handling of APIs which return a raw text response, but this is also covered by Files tests.

## How is this tested?
N/A

NO_CHANGELOG=true