### PR TITLE
Increase async cache stale period from 3 to 5 minutes.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Increase async cache stale period from 3 to 5 minutes to cover the maximum monthly downtime of a 99.99% uptime SLA.
+
 ### Bug Fixes
 
 ### Documentation

--- a/config/experimental/auth/cache.go
+++ b/config/experimental/auth/cache.go
@@ -8,11 +8,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const (
-	// Default duration for the stale period. The number as been set arbitrarily
-	// and might be changed in the future.
-	defaultStaleDuration = 3 * time.Minute
-)
+// Default duration for the stale period. This value is chosen to cover the
+// maximum monthly downtime allowed by a 99.99% uptime SLA (~4.38 minutes).
+const defaultStaleDuration = 5 * time.Minute
 
 type Option func(*cachedTokenSource)
 


### PR DESCRIPTION
## Changes

Increases the default async cache stale period from 3 minutes to 5 minutes.

## Rationale

The 5-minute stale period covers the maximum monthly downtime allowed by a 99.99% uptime SLA (~4.38 minutes). This ensures that even during the worst-case downtime scenario, the cache can continue serving stale tokens while waiting for the auth service to recover (assuming continuous traffic).