### PR TITLE
Automate tagging (and release) workflows

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -3,9 +3,9 @@ name: tagging
 
 on:
   workflow_dispatch:
-  # Enable for automatic tagging
-  #schedule:
-  #  - cron: '0 0 * * TUE'
+  # Runs at 8:00 UTC on Tuesday, Wednesday, and Thursday
+  schedule:
+    - cron: '0 8 * * TUE,WED,THU'
 
 # Ensure that only a single instance of the workflow is running at a time.
 concurrency:


### PR DESCRIPTION
## What changes are proposed in this pull request?

As the update of the SDK with the latest API changes is automated, the next step is to automate the releases of the SDK. This PR adds a `schedule` trigger on tagging workflow to run on 8:00 UTC on Tuesdays, Wednesdays and Thursdays each week.

## How is this tested?

N/A