### PR TITLE
Use CLOUD_PROVIDER instead of host to determine which tests to run

### DIFF
--- a/internal/billing_test.go
+++ b/internal/billing_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/service/billing"
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 
 func TestMwsAccLogDelivery(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 	creds, err := a.Credentials.Create(ctx, provisioning.CreateCredentialRequest{
@@ -66,7 +67,7 @@ func TestMwsAccLogDelivery(t *testing.T) {
 
 func TestMwsAccBudgets(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 
@@ -83,7 +84,8 @@ func TestMwsAccBudgets(t *testing.T) {
 							Values:   []string{"all"},
 						},
 					},
-				}},
+				},
+			},
 			AlertConfigurations: []billing.CreateBudgetConfigurationBudgetAlertConfigurations{
 				{
 					TimePeriod:        billing.AlertConfigurationTimePeriodMonth,
@@ -104,7 +106,6 @@ func TestMwsAccBudgets(t *testing.T) {
 	defer a.Budgets.DeleteByBudgetId(ctx, created.Budget.BudgetConfigurationId)
 
 	_, err = a.Budgets.Update(ctx, billing.UpdateBudgetConfigurationRequest{
-
 		BudgetId: created.Budget.BudgetConfigurationId,
 		Budget: billing.UpdateBudgetConfigurationBudget{
 			BudgetConfigurationId: created.Budget.BudgetConfigurationId,
@@ -118,7 +119,8 @@ func TestMwsAccBudgets(t *testing.T) {
 							Values:   []string{"all"},
 						},
 					},
-				}},
+				},
+			},
 			AlertConfigurations: []billing.AlertConfiguration{
 				{
 					AlertConfigurationId: created.Budget.AlertConfigurations[0].AlertConfigurationId,

--- a/internal/catalog_test.go
+++ b/internal/catalog_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/sql"
@@ -16,7 +17,7 @@ import (
 
 func TestUcAccVolumes(t *testing.T) {
 	ctx, w := ucwsTest(t)
-	if !w.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		skipf(t)("not on aws")
 	}
 
@@ -101,7 +102,7 @@ func TestUcAccVolumes(t *testing.T) {
 
 func TestUcAccTables(t *testing.T) {
 	ctx, w := ucwsTest(t)
-	if w.Config.IsGcp() {
+	if IsCloud(environment.CloudGCP) {
 		skipf(t)("Statement Execution API not available on GCP, skipping")
 	}
 
@@ -185,8 +186,8 @@ func TestUcAccTables(t *testing.T) {
 
 func TestUcAccStorageCredentialsOnAws(t *testing.T) {
 	ctx, w := ucwsTest(t)
-	if !w.Config.IsAws() {
-		skipf(t)("not not aws")
+	if !IsCloud(environment.CloudAWS) {
+		skipf(t)("not on aws")
 	}
 
 	// TODO: OpenAPI: retry protocol on late validation for storage
@@ -223,8 +224,8 @@ func TestUcAccStorageCredentialsOnAws(t *testing.T) {
 
 func TestUcAccExternalLocationsOnAws(t *testing.T) {
 	ctx, w := ucwsTest(t)
-	if !w.Config.IsAws() {
-		skipf(t)("not not aws")
+	if !IsCloud(environment.CloudAWS) {
+		skipf(t)("not on aws")
 	}
 
 	credential, err := w.StorageCredentials.Create(ctx, catalog.CreateStorageCredential{

--- a/internal/clusters_test.go
+++ b/internal/clusters_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,8 @@ import (
 )
 
 func sharedRunningCluster(t *testing.T, ctx context.Context,
-	w *databricks.WorkspaceClient) string {
+	w *databricks.WorkspaceClient,
+) string {
 	clusterId := GetEnvOrSkipTest(t, "TEST_GO_SDK_CLUSTER_ID")
 	err := w.Clusters.EnsureClusterIsRunning(ctx, clusterId)
 	require.NoError(t, err)
@@ -64,7 +66,7 @@ func TestAccClustersGetCorrectErrorMessageNoTranspile(t *testing.T) {
 
 func TestAccAwsInstanceProfiles(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if !w.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.Skipf("runs only on AWS")
 	}
 

--- a/internal/deployment_test.go
+++ b/internal/deployment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ import (
 
 func TestMwsAccStorage(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 
@@ -44,7 +45,7 @@ func TestMwsAccStorage(t *testing.T) {
 
 func TestMwsAccNetworks(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 	netw, err := a.Networks.Create(ctx, provisioning.CreateNetworkRequest{
@@ -73,7 +74,7 @@ func TestMwsAccNetworks(t *testing.T) {
 
 func TestMwsAccCredentials(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 	role, err := a.Credentials.Create(ctx, provisioning.CreateCredentialRequest{
@@ -105,7 +106,7 @@ func TestMwsAccCredentials(t *testing.T) {
 
 func TestMwsAccEncryptionKeys(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 
@@ -134,7 +135,7 @@ func TestMwsAccEncryptionKeys(t *testing.T) {
 
 func TestMwsAccPrivateAccess(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 
@@ -175,7 +176,7 @@ func TestMwsAccPrivateAccess(t *testing.T) {
 
 func TestMwsAccVpcEndpoints(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 
@@ -202,7 +203,7 @@ func TestMwsAccVpcEndpoints(t *testing.T) {
 
 func TestMwsAccWorkspaces(t *testing.T) {
 	ctx, a := accountTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 

--- a/internal/files_test.go
+++ b/internal/files_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/files"
@@ -124,7 +125,7 @@ func TestUcAccFilesGetDirectoryMetadata(t *testing.T) {
 
 func TestAccDbfsOpen(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if w.Config.IsGcp() {
+	if IsCloud(environment.CloudGCP) {
 		t.Skip("dbfs not available on gcp")
 	}
 
@@ -202,7 +203,7 @@ func TestAccDbfsOpen(t *testing.T) {
 
 func TestAccDbfsOpenDirectory(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if w.Config.IsGcp() {
+	if IsCloud(environment.CloudGCP) {
 		t.Skip("dbfs not available on gcp")
 	}
 
@@ -231,7 +232,7 @@ func TestAccDbfsOpenDirectory(t *testing.T) {
 
 func TestAccDbfsReadFileWriteFile(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if w.Config.IsGcp() {
+	if IsCloud(environment.CloudGCP) {
 		t.Skip("dbfs not available on gcp")
 	}
 
@@ -267,7 +268,7 @@ func TestAccDbfsReadFileWriteFile(t *testing.T) {
 
 func TestAccListDbfsIntegration(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if w.Config.IsGcp() {
+	if IsCloud(environment.CloudGCP) {
 		t.Skip("dbfs not available on gcp")
 	}
 

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -13,13 +13,16 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databricks/databricks-sdk-go/qa"
 )
 
-const fullCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-const hexCharset = "0123456789abcdef"
+const (
+	fullCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	hexCharset  = "0123456789abcdef"
+)
 
 func init() {
 	databricks.WithProduct("integration-tests", databricks.Version())
@@ -103,6 +106,13 @@ func GetEnvOrSkipTest(t *testing.T, name string) string {
 		skipf(t)("Environment variable %s is missing", name)
 	}
 	return value
+}
+
+// IsCloud checks if the CLOUD_PROVIDER environment variable matches the specified cloud provider
+func IsCloud(cloud environment.Cloud) bool {
+	cloudProvider := strings.ToUpper(os.Getenv("CLOUD_PROVIDER"))
+	cloudUpper := strings.ToUpper(string(cloud))
+	return cloudProvider == cloudUpper
 }
 
 func MustParseInt64(v string) int64 {

--- a/internal/permissions_test.go
+++ b/internal/permissions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestAccGenericPermissions(t *testing.T) {
 
 func TestUcAccWorkspaceAssignmentOnAws(t *testing.T) {
 	ctx, a := ucacctTest(t)
-	if !a.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.SkipNow()
 	}
 	workspaceId := MustParseInt64(GetEnvOrSkipTest(t, "DUMMY_WORKSPACE_ID"))

--- a/internal/scim_test.go
+++ b/internal/scim_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -168,7 +169,7 @@ func TestAccGroups(t *testing.T) {
 
 func TestAccServicePrincipalsOnAWS(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if !w.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.Skip("test only for aws")
 	}
 

--- a/internal/sharing_test.go
+++ b/internal/sharing_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/sharing"
 	"github.com/databricks/databricks-sdk-go/service/sql"
@@ -55,7 +56,7 @@ func TestUcAccProviders(t *testing.T) {
 // TODO: remove NoTranspile
 func TestUcAccRecipientActivationNoTranspile(t *testing.T) {
 	ctx, w := ucwsTest(t)
-	if w.Config.IsAzure() {
+	if IsCloud(environment.CloudAzure) {
 		skipf(t)("temporarily skipping this test on Azure until RetrieveToken uses the same host as specified in the activation URL")
 	}
 
@@ -131,7 +132,7 @@ func TestUcAccRecipients(t *testing.T) {
 
 func TestUcAccShares(t *testing.T) {
 	ctx, w := ucwsTest(t)
-	if w.Config.IsGcp() {
+	if IsCloud(environment.CloudGCP) {
 		skipf(t)("Statement Execution API not available on GCP, skipping")
 	}
 

--- a/internal/tokenmanagement_test.go
+++ b/internal/tokenmanagement_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/settings"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 
 func TestAccCreateOboTokenOnAws(t *testing.T) {
 	ctx, w := workspaceTest(t)
-	if !w.Config.IsAws() {
+	if !IsCloud(environment.CloudAWS) {
 		t.Skip("works only on aws")
 	}
 	groups, err := w.Groups.GroupDisplayNameToIdMap(ctx, iam.ListGroupsRequest{})


### PR DESCRIPTION
## What changes are proposed in this pull request?
Use CLOUD_PROVIDER instead of host to determine which tests to run. 

This decouples test run from host parsing and allows testing Cloud specific features on cloud agnostic hosts.

## How is this tested?
Check test run and validate that the test runs only when expected

<img width="1522" height="153" alt="Screenshot 2026-01-28 at 10 31 31" src="https://github.com/user-attachments/assets/5c4aff87-c38c-44f0-b6c1-0750ae9691f8" />

<img width="1508" height="260" alt="Screenshot 2026-01-28 at 10 32 42" src="https://github.com/user-attachments/assets/ec7d9197-3409-47cd-a04e-a171e8c191ef" />



NO_CHANGELOG=true