### PR TITLE
Add always-on Cursor CLAUDE context rule

### DIFF
--- a/.cursor/rules/00-claude-context.mdc
+++ b/.cursor/rules/00-claude-context.mdc
@@ -1,0 +1,13 @@
+---
+description: Always load CLAUDE.md context first
+alwaysApply: true
+globs:
+  - "**/*"
+---
+
+Always apply CLAUDE context before taking actions.
+
+1. If `/CLAUDE.md` exists, read and follow it for every task in this workspace.
+2. When working in a subdirectory, check for a closer `CLAUDE.md` in that path and follow it as an override.
+3. If multiple `CLAUDE.md` files apply and conflict, the most specific (closest) one wins.
+4. Keep these instructions active even for small or routine requests.


### PR DESCRIPTION
NO_CHANGELOG=true

## Summary
- add `.cursor/rules/00-claude-context.mdc` as an always-applied Cursor rule
- instruct agents to load `/CLAUDE.md` when present and use nearest `CLAUDE.md` as override
- keep CLAUDE context active for routine and larger tasks

## Test plan
- [x] Confirmed the new file is tracked by git
- [x] Reviewed rule front matter for `alwaysApply: true` and `globs: ["**/*"]`

Made with [Cursor](https://cursor.com)