### PR TITLE
Add hostMetadata type and getHostMetadata helper

### DIFF
--- a/config/host_metadata.go
+++ b/config/host_metadata.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go/httpclient"
+)
+
+// hostMetadata holds the parsed response from the /.well-known/databricks-config discovery endpoint.
+type hostMetadata struct {
+	// OIDCEndpoint is the OIDC discovery URL for this host. For account hosts,
+	// this may contain an {account_id} placeholder that callers must substitute.
+	OIDCEndpoint string `json:"oidc_endpoint"`
+
+	// AccountID is the Databricks account ID associated with this host, if available.
+	AccountID string `json:"account_id"`
+
+	// WorkspaceID is the Databricks workspace ID associated with this host, if available.
+	WorkspaceID string `json:"workspace_id"`
+}
+
+// getHostMetadata fetches the raw Databricks well-known configuration from
+// {host}/.well-known/databricks-config. The returned hostMetadata contains
+// raw values with no substitution (e.g., {account_id} placeholders are left
+// as-is). Callers are responsible for interpreting the result.
+func getHostMetadata(ctx context.Context, host string, client *httpclient.ApiClient) (*hostMetadata, error) {
+	discoveryURL := host + "/.well-known/databricks-config"
+	var meta hostMetadata
+	if err := client.Do(ctx, "GET", discoveryURL, httpclient.WithResponseUnmarshal(&meta)); err != nil {
+		return nil, fmt.Errorf("fetching host metadata from %q: %w", discoveryURL, err)
+	}
+	return &meta, nil
+}

--- a/config/host_metadata_test.go
+++ b/config/host_metadata_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/databricks/databricks-sdk-go/httpclient"
+	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
+)
+
+const (
+	testHMHost        = "https://dummy-workspace.databricks.com"
+	testHMAccHost     = "https://dummy-accounts.databricks.com"
+	testHMAccountID   = "00000000-0000-0000-0000-000000000001"
+	testHMWorkspaceID = "111111111111111"
+)
+
+func newTestAPIClient(transport fixtures.MappingTransport) *httpclient.ApiClient {
+	return httpclient.NewApiClient(httpclient.ClientConfig{Transport: transport})
+}
+
+func TestGetHostMetadata_WorkspaceStaticOIDCEndpoint(t *testing.T) {
+	client := newTestAPIClient(fixtures.MappingTransport{
+		"GET /.well-known/databricks-config": {
+			Status: 200,
+			Response: map[string]string{
+				"oidc_endpoint": testHMHost + "/oidc",
+				"account_id":    testHMAccountID,
+				"workspace_id":  testHMWorkspaceID,
+			},
+		},
+	})
+	meta, err := getHostMetadata(context.Background(), testHMHost, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &hostMetadata{
+		OIDCEndpoint: testHMHost + "/oidc",
+		AccountID:    testHMAccountID,
+		WorkspaceID:  testHMWorkspaceID,
+	}
+	if diff := cmp.Diff(want, meta); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetHostMetadata_AccountHostRawOIDCTemplate(t *testing.T) {
+	client := newTestAPIClient(fixtures.MappingTransport{
+		"GET /.well-known/databricks-config": {
+			Status: 200,
+			Response: map[string]string{
+				"oidc_endpoint": testHMAccHost + "/oidc/accounts/{account_id}",
+			},
+		},
+	})
+	meta, err := getHostMetadata(context.Background(), testHMAccHost, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &hostMetadata{
+		OIDCEndpoint: testHMAccHost + "/oidc/accounts/{account_id}",
+	}
+	if diff := cmp.Diff(want, meta); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetHostMetadata_HTTPError(t *testing.T) {
+	client := newTestAPIClient(fixtures.MappingTransport{
+		"GET /.well-known/databricks-config": {
+			Status: 404,
+		},
+	})
+	_, err := getHostMetadata(context.Background(), testHMHost, client)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetching host metadata from") {
+		t.Errorf("expected error containing %q, got %q", "fetching host metadata from", err.Error())
+	}
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-go/pull/1499/files) to review incremental changes.
- [**stack/config-auto-complete-1**](https://github.com/databricks/databricks-sdk-go/pull/1499) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1499/files)]
  - [stack/config-auto-complete-2](https://github.com/databricks/databricks-sdk-go/pull/1500) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1500/files/f6fe7e3aa25bce0135cf1cff721dff5b8d168979..830aa0f0455f66c632103f0406b3e5a9d8c9f3dd)]
    - [stack/config-auto-complete-3](https://github.com/databricks/databricks-sdk-go/pull/1501) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1501/files/830aa0f0455f66c632103f0406b3e5a9d8c9f3dd..9fe9f749a221f2d52f4aabaaa26728643e10e2a9)]

---------
## Changes

Ported from [databricks-sdk-py#1288](https://github.com/databricks/databricks-sdk-py/pull/1288).

Add `hostMetadata` type and `getHostMetadata` helper to `config/`.

The `getHostMetadata` function fetches the `/.well-known/databricks-config`
discovery endpoint and returns a `hostMetadata` struct containing:
- `OIDCEndpoint` — raw OIDC endpoint (may contain `{account_id}` template)
- `AccountID` — account ID (if present)
- `WorkspaceID` — workspace ID (if present)

This is the foundation for auto-completing config fields from the host's
well-known metadata.

## Tests

Unit tests in `config/host_metadata_test.go` cover:
- Workspace host returning a static OIDC endpoint with account/workspace IDs
- Account host returning an OIDC endpoint template with `{account_id}` placeholder
- HTTP error returns a descriptive error message