### PR TITLE
Add GetEndpointsFromURL to OAuthEndpointSupplier

### DIFF
--- a/credentials/u2m/endpoint_supplier_test.go
+++ b/credentials/u2m/endpoint_supplier_test.go
@@ -2,8 +2,11 @@ package u2m
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/common"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +37,62 @@ func TestGetWorkspaceOAuthEndpoints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "a", endpoints.AuthorizationEndpoint)
 	assert.Equal(t, "b", endpoints.TokenEndpoint)
+}
+
+func TestGetEndpointsFromURL(t *testing.T) {
+	p := httpclient.NewApiClient(httpclient.ClientConfig{
+		Transport: fixtures.MappingTransport{
+			"GET /oidc/v1/authorize-server": {
+				Status: 200,
+				Response: map[string]string{
+					"authorization_endpoint": "https://abc/oidc/v1/authorize",
+					"token_endpoint":         "https://abc/oidc/v1/token",
+				},
+			},
+		},
+	})
+	c := &BasicOAuthEndpointSupplier{Client: p}
+	endpoints, err := c.GetEndpointsFromURL(context.Background(), "https://abc/oidc/v1/authorize-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endpoints.AuthorizationEndpoint != "https://abc/oidc/v1/authorize" {
+		t.Errorf("unexpected AuthorizationEndpoint: %q", endpoints.AuthorizationEndpoint)
+	}
+	if endpoints.TokenEndpoint != "https://abc/oidc/v1/token" {
+		t.Errorf("unexpected TokenEndpoint: %q", endpoints.TokenEndpoint)
+	}
+}
+
+func TestGetEndpointsFromURL_NotFound(t *testing.T) {
+	p := httpclient.NewApiClient(httpclient.ClientConfig{
+		Transport: fixtures.MappingTransport{
+			"GET /oidc/v1/authorize-server": {
+				Status: 404,
+			},
+		},
+		// Mirror the error mapping done by Config.refreshTokenErrorMapper: map
+		// HTTP 404 to apierr.ErrNotFound so that errors.Is(err, apierr.ErrNotFound)
+		// returns true, matching the production code path.
+		ErrorMapper: func(ctx context.Context, resp common.ResponseWrapper) error {
+			err := httpclient.DefaultErrorMapper(ctx, resp)
+			if err == nil {
+				return nil
+			}
+			var httpErr *httpclient.HttpError
+			if errors.As(err, &httpErr) {
+				if sdkErr, ok := apierr.ByStatusCode(httpErr.StatusCode); ok {
+					return sdkErr
+				}
+			}
+			return err
+		},
+	})
+	c := &BasicOAuthEndpointSupplier{Client: p}
+	_, err := c.GetEndpointsFromURL(context.Background(), "https://abc/oidc/v1/authorize-server")
+	if !errors.Is(err, ErrOAuthNotSupported) {
+		t.Errorf("expected ErrOAuthNotSupported, got %v", err)
+	}
 }
 
 func TestGetUnifiedOAuthEndpoints(t *testing.T) {

--- a/credentials/u2m/persistent_auth_test.go
+++ b/credentials/u2m/persistent_auth_test.go
@@ -476,6 +476,10 @@ func (m MockOAuthEndpointSupplier) GetUnifiedOAuthEndpoints(ctx context.Context,
 	}, nil
 }
 
+func (m MockOAuthEndpointSupplier) GetEndpointsFromURL(_ context.Context, _ string) (*OAuthAuthorizationServer, error) {
+	return nil, ErrOAuthNotSupported
+}
+
 func TestToken_RefreshesExpiredAccessToken(t *testing.T) {
 	ctx := context.Background()
 	expectedKey := "https://accounts.cloud.databricks.com/oidc/accounts/xyz"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-go/pull/1500/files) to review incremental changes.
- [**stack/config-auto-complete-2**](https://github.com/databricks/databricks-sdk-go/pull/1500) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1500/files)]
  - [stack/config-auto-complete-3](https://github.com/databricks/databricks-sdk-go/pull/1501) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1501/files/392ea12ef0f489f74b5c6c64fc8a549945d46ed9..caa6cdb4bbf84e293772a7352a0436c40a3d7f5a)]

---------
## Changes

Ported from [databricks-sdk-py#1289](https://github.com/databricks/databricks-sdk-py/pull/1289).

Add `GetEndpointsFromURL` to the `OAuthEndpointSupplier` interface and
`BasicOAuthEndpointSupplier` implementation.

- Promotes the private `getOAuthEndpointsByDiscoveryUrl` to a public
  `GetEndpointsFromURL` method (fixing `Url`→`URL` acronym casing).
- `GetWorkspaceOAuthEndpoints` and `GetUnifiedOAuthEndpoints` now delegate
  to `GetEndpointsFromURL`.
- `MockOAuthEndpointSupplier` updated to implement the new interface method.

This allows callers (e.g., `Config`) to bypass host-type detection and fetch
OAuth endpoints directly from an arbitrary authorization server metadata URL.

## Tests

- `TestGetEndpointsFromURL`: verifies successful endpoint fetch from an arbitrary URL
- `TestGetEndpointsFromURL_NotFound`: verifies `ErrOAuthNotSupported` is returned on 404
- `TestGetUnifiedOAuthEndpoints`: verifies unified host endpoint fetch
- Existing tests for `GetWorkspaceOAuthEndpoints` and `GetAccountOAuthEndpoints` continue to pass

NO_CHANGELOG=true