### PR TITLE
Add Cloud to HostMetadata

### DIFF
--- a/common/environment/environments.go
+++ b/common/environment/environments.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -8,10 +9,39 @@ import (
 type Cloud string
 
 const (
-	CloudAWS   Cloud = "AWS"
-	CloudAzure Cloud = "Azure"
-	CloudGCP   Cloud = "GCP"
+	CloudAWS     Cloud = "AWS"
+	CloudAzure   Cloud = "Azure"
+	CloudGCP     Cloud = "GCP"
+	CloudUnknown Cloud = ""
 )
+
+// UnmarshalJSON automatically normalizes the cloud string when parsing JSON
+func (c *Cloud) UnmarshalJSON(data []byte) error {
+	var rawString string
+
+	if err := json.Unmarshal(data, &rawString); err != nil {
+		return err
+	}
+
+	*c = normalizeCloud(rawString)
+	return nil
+}
+
+func normalizeCloud(cloud string) Cloud {
+	switch strings.ToUpper(cloud) {
+	case "AWS":
+		return CloudAWS
+	case "AZURE":
+		return CloudAzure
+	case "GCP":
+		return CloudGCP
+	case "":
+		return CloudUnknown
+	// For forward compatibility with new cloud providers that are not yet supported by the SDK.
+	default:
+		return Cloud(cloud)
+	}
+}
 
 type DatabricksEnvironment struct {
 	Cloud              Cloud
@@ -51,7 +81,6 @@ func DefaultEnvironment() DatabricksEnvironment {
 		Cloud:   CloudAWS,
 		DnsZone: ".cloud.databricks.com",
 	}
-
 }
 
 var envs = []DatabricksEnvironment{

--- a/config/config.go
+++ b/config/config.go
@@ -210,7 +210,11 @@ type Config struct {
 	// HTTPTransport can be overriden for unit testing and together with tooling like https://github.com/google/go-replayers
 	HTTPTransport http.RoundTripper
 
-	// Environment override to return when resolving the current environment.
+	// Cloud is the cloud provider for this Databricks deployment (AWS, Azure, GCP, or CloudUnknown).
+	//
+	// Experimental: subject to change.
+	Cloud environment.Cloud `name:"cloud" env:"DATABRICKS_CLOUD" auth:"-"`
+
 	DatabricksEnvironment *environment.DatabricksEnvironment
 
 	// When using Workload Identity Federation, the audience to specify when fetching an ID token from the ID token supplier.
@@ -352,16 +356,25 @@ func (c *Config) IsAzure() bool {
 	if c.AzureResourceID != "" {
 		return true
 	}
+	if c.Cloud != environment.CloudUnknown {
+		return c.Cloud == environment.CloudAzure
+	}
 	return c.Environment().Cloud == environment.CloudAzure
 }
 
 // IsGcp returns if the client is configured for Databricks on Google Cloud.
 func (c *Config) IsGcp() bool {
+	if c.Cloud != environment.CloudUnknown {
+		return c.Cloud == environment.CloudGCP
+	}
 	return c.Environment().Cloud == environment.CloudGCP
 }
 
 // IsAws returns if the client is configured for Databricks on AWS.
 func (c *Config) IsAws() bool {
+	if c.Cloud != environment.CloudUnknown {
+		return c.Cloud == environment.CloudAWS
+	}
 	return c.Host != "" && !c.IsAzure() && !c.IsGcp()
 }
 
@@ -643,7 +656,7 @@ func (c *Config) getOidcEndpoints(ctx context.Context) (*u2m.OAuthAuthorizationS
 
 // resolveHostMetadata populates missing config fields from the host's
 // /.well-known/databricks-config discovery endpoint. It back-fills AccountID,
-// WorkspaceID, and DiscoveryURL (with any {account_id} placeholder substituted)
+// WorkspaceID, Cloud, and DiscoveryURL (with any {account_id} placeholder substituted)
 // if those fields are not already set. Returns an error if AccountID cannot be
 // resolved or no oidc_endpoint is present in the metadata.
 //
@@ -657,6 +670,7 @@ func (c *Config) resolveHostMetadata(ctx context.Context) error {
 	}
 	meta, err := getHostMetadata(ctx, c.CanonicalHostName(), c.refreshClient)
 	if err != nil {
+		logger.Debugf(ctx, "Failed to fetch host metadata: %v", err)
 		return err
 	}
 	if c.AccountID == "" && meta.AccountID != "" {
@@ -669,6 +683,14 @@ func (c *Config) resolveHostMetadata(ctx context.Context) error {
 	if c.WorkspaceID == "" && meta.WorkspaceID != "" {
 		logger.Debugf(ctx, "Resolved workspace_id from host metadata: %q", meta.WorkspaceID)
 		c.WorkspaceID = meta.WorkspaceID
+	}
+	if c.Cloud == "" && meta.Cloud != environment.CloudUnknown {
+		logger.Debugf(ctx, "Resolved cloud from host metadata: %q", meta.Cloud)
+		c.Cloud = meta.Cloud
+	}
+	if c.Cloud == "" {
+		c.Cloud = c.Environment().Cloud
+		logger.Debugf(ctx, "Resolved cloud from hostname: %q", c.Cloud)
 	}
 	if c.DiscoveryURL == "" {
 		if meta.OIDCEndpoint == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -666,3 +666,158 @@ func TestConfig_ResolveHostMetadata_NoHost(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestConfig_ResolveHostMetadata_PopulatesCloudFromAPI(t *testing.T) {
+	cfg := &Config{
+		Host:  testHMHost,
+		Token: "t",
+		HTTPTransport: fixtures.SliceTransport{
+			{
+				Method:   "GET",
+				Resource: "/.well-known/databricks-config",
+				Status:   200,
+				Response: `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "Azure"}`,
+			},
+		},
+	}
+	if err := cfg.resolveHostMetadata(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cloud != "Azure" {
+		t.Errorf("unexpected Cloud: %q", cfg.Cloud)
+	}
+}
+
+func TestConfig_ResolveHostMetadata_CloudFallbackToDNS(t *testing.T) {
+	cfg := &Config{
+		Host:  "https://my-workspace.azuredatabricks.net",
+		Token: "t",
+		HTTPTransport: fixtures.SliceTransport{
+			{
+				Method:   "GET",
+				Resource: "/.well-known/databricks-config",
+				Status:   200,
+				Response: `{"oidc_endpoint": "https://my-workspace.azuredatabricks.net/oidc", "account_id": "` + testHMAccountID + `"}`,
+			},
+		},
+	}
+	if err := cfg.resolveHostMetadata(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cloud != "Azure" {
+		t.Errorf("unexpected Cloud from DNS fallback: %q", cfg.Cloud)
+	}
+}
+
+func TestConfig_ResolveHostMetadata_DoesNotOverwriteExistingCloud(t *testing.T) {
+	cfg := &Config{
+		Host:  testHMHost,
+		Token: "t",
+		Cloud: "GCP",
+		HTTPTransport: fixtures.SliceTransport{
+			{
+				Method:   "GET",
+				Resource: "/.well-known/databricks-config",
+				Status:   200,
+				Response: `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "AWS"}`,
+			},
+		},
+	}
+	if err := cfg.resolveHostMetadata(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cloud != "GCP" {
+		t.Errorf("Cloud was overwritten: got %q, want %q", cfg.Cloud, "GCP")
+	}
+}
+
+func TestConfig_ResolveHostMetadata_Clouds(t *testing.T) {
+	tests := []struct {
+		name      string
+		cloudJSON string
+		wantCloud string
+	}{
+		{
+			name:      "AWS",
+			cloudJSON: "AWS",
+			wantCloud: "AWS",
+		},
+		{
+			name:      "Azure",
+			cloudJSON: "Azure",
+			wantCloud: "Azure",
+		},
+		{
+			name:      "GCP",
+			cloudJSON: "GCP",
+			wantCloud: "GCP",
+		},
+		{
+			name:      "aws lowercase",
+			cloudJSON: "aws",
+			wantCloud: "AWS",
+		},
+		{
+			name:      "AWS uppercase",
+			cloudJSON: "AWS",
+			wantCloud: "AWS",
+		},
+		{
+			name:      "azure lowercase",
+			cloudJSON: "azure",
+			wantCloud: "Azure",
+		},
+		{
+			name:      "AZURE uppercase",
+			cloudJSON: "AZURE",
+			wantCloud: "Azure",
+		},
+		{
+			name:      "Azure title case",
+			cloudJSON: "Azure",
+			wantCloud: "Azure",
+		},
+		{
+			name:      "gcp lowercase",
+			cloudJSON: "gcp",
+			wantCloud: "GCP",
+		},
+		{
+			name:      "GCP uppercase",
+			cloudJSON: "GCP",
+			wantCloud: "GCP",
+		},
+		{
+			name:      "Another cloud is supported",
+			cloudJSON: "Another",
+			wantCloud: "Another",
+		},
+		{
+			name:      "Unknown cloud falls back to DNS",
+			cloudJSON: "",
+			wantCloud: "AWS", // Falls back to DNS-based detection for testHMHost
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Host:  testHMHost,
+				Token: "t",
+				HTTPTransport: fixtures.SliceTransport{
+					{
+						Method:   "GET",
+						Resource: "/.well-known/databricks-config",
+						Status:   200,
+						Response: `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "` + tc.cloudJSON + `"}`,
+					},
+				},
+			}
+			if err := cfg.resolveHostMetadata(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if string(cfg.Cloud) != tc.wantCloud {
+				t.Errorf("unexpected Cloud: got %q, want %q", cfg.Cloud, tc.wantCloud)
+			}
+		})
+	}
+}

--- a/config/environments.go
+++ b/config/environments.go
@@ -6,6 +6,9 @@ import (
 	"github.com/databricks/databricks-sdk-go/common/environment"
 )
 
+// Deprecated: Use the Cloud field and cloud-specific helper methods (IsAws, IsAzure, IsGcp)
+// instead. Environment() returns environment metadata including cloud type and Azure-specific
+// endpoints.
 func (c *Config) Environment() environment.DatabricksEnvironment {
 	// Use the provided environment if specified. Tests may configure the client with different hostnames,
 	// like localhost, which are not resolvable to a known environment, while needing to mock a specific environment.

--- a/config/environments_test.go
+++ b/config/environments_test.go
@@ -22,3 +22,59 @@ func TestOverriddenEnvironmentIsReturned(t *testing.T) {
 	}
 	assert.Equal(t, "holla", c.Environment().DnsZone)
 }
+
+func TestCloudField_AWS(t *testing.T) {
+	c := &Config{
+		Host:  "https://my-workspace.cloud.databricks.com",
+		Cloud: environment.CloudAWS,
+	}
+	assert.True(t, c.IsAws())
+	assert.False(t, c.IsAzure())
+	assert.False(t, c.IsGcp())
+}
+
+func TestCloudField_Azure(t *testing.T) {
+	c := &Config{
+		Host:  "https://my-workspace.azuredatabricks.net",
+		Cloud: environment.CloudAzure,
+	}
+	assert.True(t, c.IsAzure())
+	assert.False(t, c.IsAws())
+	assert.False(t, c.IsGcp())
+}
+
+func TestCloudField_GCP(t *testing.T) {
+	c := &Config{
+		Host:  "https://my-workspace.gcp.databricks.com",
+		Cloud: environment.CloudGCP,
+	}
+	assert.True(t, c.IsGcp())
+	assert.False(t, c.IsAws())
+	assert.False(t, c.IsAzure())
+}
+
+func TestCloudField_FallsBackToEnvironment(t *testing.T) {
+	c := &Config{
+		Host: "https://my-workspace.azuredatabricks.net",
+	}
+	assert.True(t, c.IsAzure())
+	assert.False(t, c.IsAws())
+	assert.False(t, c.IsGcp())
+}
+
+func TestCloudField_PrefersCloudOverEnvironment(t *testing.T) {
+	c := &Config{
+		Host:  "https://my-workspace.cloud.databricks.com",
+		Cloud: environment.CloudAzure,
+	}
+	assert.True(t, c.IsAzure())
+	assert.False(t, c.IsAws())
+}
+
+func TestCloudField_EmptyStringIsCloudUnknown(t *testing.T) {
+	c := &Config{
+		Host:  "https://localhost:8080",
+		Cloud: "",
+	}
+	assert.Equal(t, environment.CloudUnknown, c.Cloud)
+}

--- a/config/host_metadata.go
+++ b/config/host_metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 )
 
@@ -18,6 +19,9 @@ type hostMetadata struct {
 
 	// WorkspaceID is the Databricks workspace ID associated with this host, if available.
 	WorkspaceID string `json:"workspace_id"`
+
+	// Cloud is the cloud provider for this Databricks deployment (AWS, Azure, or GCP).
+	Cloud environment.Cloud `json:"cloud"`
 }
 
 // getHostMetadata fetches the raw Databricks well-known configuration from

--- a/config/host_metadata_test.go
+++ b/config/host_metadata_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/databricks/databricks-sdk-go/common/environment"
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
 )
@@ -30,6 +31,7 @@ func TestGetHostMetadata_WorkspaceStaticOIDCEndpoint(t *testing.T) {
 				"oidc_endpoint": testHMHost + "/oidc",
 				"account_id":    testHMAccountID,
 				"workspace_id":  testHMWorkspaceID,
+				"cloud":         "AWS",
 			},
 		},
 	})
@@ -41,6 +43,7 @@ func TestGetHostMetadata_WorkspaceStaticOIDCEndpoint(t *testing.T) {
 		OIDCEndpoint: testHMHost + "/oidc",
 		AccountID:    testHMAccountID,
 		WorkspaceID:  testHMWorkspaceID,
+		Cloud:        "AWS",
 	}
 	if diff := cmp.Diff(want, meta); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -80,5 +83,58 @@ func TestGetHostMetadata_HTTPError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "fetching host metadata from") {
 		t.Errorf("expected error containing %q, got %q", "fetching host metadata from", err.Error())
+	}
+}
+
+func TestGetHostMetadata_WithCloudField(t *testing.T) {
+	tests := []struct {
+		name      string
+		cloud     string
+		wantCloud environment.Cloud
+	}{
+		{
+			name:      "AWS",
+			cloud:     "AWS",
+			wantCloud: environment.CloudAWS,
+		},
+		{
+			name:      "Azure",
+			cloud:     "Azure",
+			wantCloud: environment.CloudAzure,
+		},
+		{
+			name:      "GCP",
+			cloud:     "GCP",
+			wantCloud: environment.CloudGCP,
+		},
+		{
+			name:      "missing cloud field",
+			cloud:     "",
+			wantCloud: environment.CloudUnknown,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			response := map[string]string{
+				"oidc_endpoint": testHMHost + "/oidc",
+				"account_id":    testHMAccountID,
+			}
+			if tc.cloud != "" {
+				response["cloud"] = tc.cloud
+			}
+			client := newTestAPIClient(fixtures.MappingTransport{
+				"GET /.well-known/databricks-config": {
+					Status:   200,
+					Response: response,
+				},
+			})
+			meta, err := getHostMetadata(context.Background(), testHMHost, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.Cloud != tc.wantCloud {
+				t.Errorf("Cloud field mismatch: got %q, want %q", meta.Cloud, tc.wantCloud)
+			}
+		})
 	}
 }


### PR DESCRIPTION
---                                                                          
## Summary                                                                      
   
  Adds an explicit Cloud field to Config that is populated from the            
  /.well-known/databricks-config discovery endpoint (or overridden via config
  file / DATABRICKS_CLOUD env var).
 
## Why

  Today, IsAws(), IsAzure(), and IsGcp() all delegate to c.Environment().Cloud,
   which infers cloud type by suffix-matching the workspace hostname against a
  hardcoded list of known DNS zones. This works for standard deployments but
  fails silently for non-standard hostnames — for example, custom vanity
  domains, unified hosts, or any future topology where the hostname doesn't
  encode the cloud provider. In those cases the SDK falls back to
  DefaultEnvironment() (AWS), potentially misclassifying the deployment.

  The /.well-known/databricks-config discovery endpoint is the authoritative
  source for host metadata. It already returns a cloud field, but the SDK was
  discarding it. This PR threads that value through: the metadata response is
  parsed into hostMetadata.Cloud, then back-filled into Config.Cloud if not
  already set. DNS-based detection is retained as a fallback when the endpoint
  doesn't return a cloud field.

  The Cloud field can also be set directly in configuration or via
  DATABRICKS_CLOUD, which is useful for testing and for environments where the
  discovery endpoint is unreachable.

NOTE: Auto discovery is not yet enabled, since the new endpoint has not been rolled out to all hosts.

##  What changed

### Interface changes

  - Config.Cloud environment.Cloud — new experimental field (name:"cloud",
  env:"DATABRICKS_CLOUD"). Takes precedence over DNS-based detection in IsAws,
  IsAzure, IsGcp.
  - environment.CloudUnknown Cloud = "" — new sentinel for an unset/empty cloud
   value.
  - Cloud.UnmarshalJSON — case-insensitive JSON deserialization ("aws", "AWS",
  "Azure", "AZURE" all normalize). Unknown values are passed through as-is for
  forward compatibility.
  - hostMetadata.Cloud environment.Cloud — new field parsed from the cloud key
  in the /.well-known/databricks-config response.
  - Config.Environment() — marked deprecated; use Config.Cloud + cloud-specific
   helpers instead.

### Behavioral changes

  - IsAzure(), IsGcp(), IsAws() now check Config.Cloud first; DNS-based
  inference is used only when Cloud is unset.
  - resolveHostMetadata now populates Config.Cloud from the discovery endpoint,
   with a DNS-based fallback. Previously the cloud field in the response was
  silently ignored.



##  How is this tested?

  Unit tests cover:
  - TestConfig_ResolveHostMetadata_PopulatesCloudFromAPI — Cloud is set from
  the API response.
  - TestConfig_ResolveHostMetadata_CloudFallbackToDNS — falls back to DNS when
  the response omits cloud.
  - TestConfig_ResolveHostMetadata_DoesNotOverwriteExistingCloud — explicit
  Config.Cloud is not overwritten.
  - TestConfig_ResolveHostMetadata_Clouds — table-driven tests covering all
  case variants ("aws", "AZURE", "gcp", forward-compat unknown, empty).
  - TestCloudField_* — IsAws/IsAzure/IsGcp respect the explicit Cloud field and
   fall back correctly when unset.
  - TestGetHostMetadata_WithCloudField — hostMetadata deserialization for all
  three cloud providers and missing field.

NO_CHANGELOG=true