### PR TITLE
Fix debug logs showing empty Host for API requests

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+ - Fix debug logs showing empty `Host` for API requests.
+
 ### Documentation
 
 ### Internal Changes

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -44,7 +44,9 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 			// r.Host empty makes debug logs misleadingly show an empty host.
 			r.URL.Host = url.Host
 			r.URL.Scheme = url.Scheme
-			r.Host = url.Host
+			if r.Host == "" {
+				r.Host = url.Host
+			}
 			return nil
 		},
 		authInUserAgentVisitor(cfg),

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -36,8 +36,15 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 			if err != nil {
 				return err
 			}
+			// API requests are made with relative paths (e.g. /api/2.0/...).
+			// r.URL.Host and r.URL.Scheme direct the HTTP client to the right
+			// server. r.Host sets the Host header explicitly; if r.Host is
+			// empty, Go copies r.URL.Host into the Host header automatically
+			// before sending, so both reach the same server — but leaving
+			// r.Host empty makes debug logs misleadingly show an empty host.
 			r.URL.Host = url.Host
 			r.URL.Scheme = url.Scheme
+			r.Host = url.Host
 			return nil
 		},
 		authInUserAgentVisitor(cfg),


### PR DESCRIPTION
## Changes

Fixes empty `Host` in debug logs for all API requests (workspace and account level).

API requests use relative paths (e.g. `/api/2.0/...`), so `http.NewRequestWithContext` leaves `r.Host` empty — only requests built from full URLs (like auth token fetches) had it populated. Go silently falls back to `r.URL.Host` for the wire Host header, so requests always reached the correct server. But `RoundTripStringer` reads `r.Host` directly, making the host appear empty in debug logs.

```
2026/03/09 07:27:52 [DEBUG] GET /api/2.0/preview/scim/v2/Me
> * Host:  <---- no host?
> * Accept: application/json
```

Fix: set `r.Host = url.Host` in the request visitor alongside the existing `r.URL.Host` assignment.

## Tests

Manually verified with `go run ./test/` using the UNIFIED profile — `Host:` now shows correctly in debug logs for all API calls.

NO_CHANGELOG=false