### PR TITLE
Use pure-Go DNS resolver to fix Private Link/PSC connectivity on macOS

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Use pure-Go DNS resolver to fix Private Link/PSC connectivity on macOS ([#1589](https://github.com/databricks/databricks-sdk-go/pull/1589)).
+
 ### Documentation
 
 ### Internal Changes

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -82,6 +82,7 @@ func makeDefaultTransport() *http.Transport {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
+			Resolver:  &net.Resolver{PreferGo: true},
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,


### PR DESCRIPTION
## Summary

- Set `PreferGo: true` on the `net.Resolver` used by the SDK's default HTTP transport dialer
- Fixes DNS resolution issues on macOS when using Private Link / Private Service Connect

## Problem

On macOS, Go's default cgo DNS resolver can bypass split-horizon DNS configurations. When a Databricks workspace is configured with Private Link or Private Service Connect, the workspace URL should resolve to a private IP via a private DNS zone. However, the cgo resolver may resolve to the public IP instead, causing requests to be blocked by IP ACLs with a confusing error:

```
Error: cannot update permissions: Source IP address: x.x.x.x is blocked by 
Databricks IP ACL for workspace: xxxxx
```

The workaround today is setting `GODEBUG=netdns=go` globally, but users have no way to know this from the error message alone.

## Solution

Set `PreferGo: true` on the `net.Resolver` in the SDK's default HTTP transport dialer. This:

- Ensures the pure-Go DNS resolver is used, which correctly respects system DNS settings including private DNS zones
- Is scoped to the SDK's HTTP client only — does not affect other libraries or providers in the same process
- Falls back to the cgo resolver automatically if the Go resolver fails (it's a *preference*, not a hard requirement)
- Matches what `GODEBUG=netdns=go` does, but without requiring a global environment variable

## Test plan

- [x] Verified the change compiles
- [ ] Test on macOS with a Private Service Connect workspace — workspace URL should resolve to private IP
- [ ] Test on Linux — no behavioral change expected (Go resolver is already the default on Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)