### PR TITLE
Improve default auth error message to suggest setting auth_type

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+ * Improved the default authentication error message to guide users toward setting `auth_type` for more specific error reporting ([#1064](https://github.com/databricks/databricks-sdk-go/issues/1064)).
  * Fix double-caching of OAuth tokens in Azure client secret credentials ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Disable async token refresh for GCP credential providers to avoid wasted refresh attempts caused by double-caching with Google's internal `oauth2.ReuseTokenSource` ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Fixed double-caching in M2M OAuth that prevented the proactive async token refresh from reaching the HTTP endpoint until ~10s before expiry, causing bursts of 401 errors at token rotation boundaries ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).

--- a/config/auth_default.go
+++ b/config/auth_default.go
@@ -13,7 +13,7 @@ const authDocURL = "https://docs.databricks.com/en/dev-tools/auth.html#databrick
 
 // ErrCannotConfigureDefault indicates that no credentials strategy in the
 // chain was able to provide valid credentials.
-var ErrCannotConfigureDefault = fmt.Errorf("cannot configure default credentials, please check %s to configure credentials for your preferred authentication method", authDocURL)
+var ErrCannotConfigureDefault = fmt.Errorf("cannot configure default credentials, set auth_type for a specific error message. See %s", authDocURL)
 
 // NewCredentialsChain returns a new CredentialsStrategy that tries the given
 // strategies in order and returns the first one that succeeds. If

--- a/config/auth_permutations_test.go
+++ b/config/auth_permutations_test.go
@@ -45,8 +45,8 @@ var dumpTo string = ""
 var dumpToMu sync.Mutex
 
 var defaultAuthBaseErrorMessage = "default auth: cannot configure default credentials, " +
-	"please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication " +
-	"to configure credentials for your preferred authentication method"
+	"set auth_type for a specific error message. See " +
+	"https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication"
 
 func (cf configFixture) dump(t *testing.T) error {
 	if dumpTo == "" {


### PR DESCRIPTION
## Summary

- When no credentials strategy succeeds, the SDK returns a generic error that
  points users at the full authentication documentation page. This is unhelpful
  because it does not tell users what is actually misconfigured.
- This change updates the error message to suggest setting `auth_type`, which
  causes the SDK to try a single strategy and return a specific error explaining
  exactly what is missing (e.g. "missing host" or "missing token").
- Fixes [#1064](https://github.com/databricks/databricks-sdk-go/issues/1064).

## Test plan

- [x] Updated `config/auth_permutations_test.go` to match the new error string
- [x] Verified `config/auth_default_test.go` still passes (it uses a substring match)
- [x] `go test ./config/...` passes
- [x] `go vet ./config/...` passes
- [x] `gofmt` reports no formatting issues