### PR TITLE
fix(config): safe concurrent lazy credentials init (#1310)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,7 @@
  * Fix double-caching of OAuth tokens in Azure client secret credentials ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Disable async token refresh for GCP credential providers to avoid wasted refresh attempts caused by double-caching with Google's internal `oauth2.ReuseTokenSource` ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Fixed double-caching in M2M OAuth that prevented the proactive async token refresh from reaching the HTTP endpoint until ~10s before expiry, causing bursts of 401 errors at token rotation boundaries ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
+ * Fix data race when lazily initializing `credentialsProvider`: always take `Config.mu` before reading the field so concurrent `Authenticate` / `GetTokenSource` calls are safe ([#1310](https://github.com/databricks/databricks-sdk-go/issues/1310)).
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,7 +18,7 @@
  * Fix double-caching of OAuth tokens in Azure client secret credentials ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Disable async token refresh for GCP credential providers to avoid wasted refresh attempts caused by double-caching with Google's internal `oauth2.ReuseTokenSource` ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Fixed double-caching in M2M OAuth that prevented the proactive async token refresh from reaching the HTTP endpoint until ~10s before expiry, causing bursts of 401 errors at token rotation boundaries ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
- * Fix data race when lazily initializing `credentialsProvider`: always take `Config.mu` before reading the field so concurrent `Authenticate` / `GetTokenSource` calls are safe ([#1310](https://github.com/databricks/databricks-sdk-go/issues/1310)).
+ * Fix data race when lazily initializing `credentialsProvider`: always take `Config.mu` before reading the field so concurrent `Authenticate` / `GetTokenSource` calls are safe ([#1310](https://github.com/databricks/databricks-sdk-go/issues/1310), [#1613](https://github.com/databricks/databricks-sdk-go/pull/1613)).
 
 ### Documentation
 

--- a/config/config.go
+++ b/config/config.go
@@ -590,9 +590,6 @@ func (c *Config) wrapDebug(err error) error {
 
 // authenticateIfNeeded lazily authenticates across authorizers or returns error
 func (c *Config) authenticateIfNeeded() error {
-	if c.credentialsProvider != nil {
-		return nil
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.credentialsProvider != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/common/environment"
@@ -194,6 +195,34 @@ func TestAuthenticate_InvalidHostSet(t *testing.T) {
 	require.NoError(t, err)
 	err = c.Authenticate(req)
 	assert.ErrorIs(t, err, ErrNoHostConfigured)
+}
+
+// TestAuthenticate_concurrentLazyInit verifies that concurrent first-time
+// authentication does not race on credentialsProvider (see issue #1310).
+func TestAuthenticate_concurrentLazyInit(t *testing.T) {
+	noopLoader := mockLoader(func(*Config) error { return nil })
+	cfg := &Config{
+		Host:          "https://accounts.cloud.databricks.com",
+		AccountID:     "123e4567-e89b-12d3-a456-426614174000",
+		Token:         "dapi_test_token",
+		Loaders:       []Loader{noopLoader},
+		HTTPTransport: metadataNotFoundTransport,
+	}
+	require.NoError(t, cfg.EnsureResolved())
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://accounts.cloud.databricks.com/api/2.0/preview/scim/v2/Me", nil)
+			require.NoError(t, err)
+			err = cfg.Authenticate(req)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestConfig_getOidcEndpoints_account(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes a data race in [`authenticateIfNeeded`](https://github.com/databricks/databricks-sdk-go/blob/main/config/config.go): the lock-free read of `credentialsProvider` before acquiring `Config.mu` was not synchronized with writers, so concurrent first-time `Authenticate` / `GetTokenSource` could race (see [#1310](https://github.com/databricks/databricks-sdk-go/issues/1310)).

## Changes
- Always take `Config.mu` before reading `credentialsProvider` (single check inside the critical section).
- Add `TestAuthenticate_concurrentLazyInit`; verified with `go test ./config -race -run TestAuthenticate_concurrentLazyInit`.
- `NEXT_CHANGELOG.md` entry.

## Testing
- `go test ./config/...`
- `go test ./config -race -run TestAuthenticate_concurrentLazyInit -count=3`

Fixes #1310