### PR TITLE
[Feature] Add GetResolvedHostType() getter to Config for downstream host type access

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features and Improvements
 
+* Added `GetResolvedHostType()` getter on `Config` to expose the host type resolved from host metadata discovery, without URL pattern matching fallback.
 * Added `HostMetadataResolver` hook to allow callers to customize host metadata resolution, e.g. with caching ([#1572](https://github.com/databricks/databricks-sdk-go/pull/1572)).
 * Added `NewLimitIterator` to `listing` package for lazy iteration with a cap on output items ([#1555](https://github.com/databricks/databricks-sdk-go/pull/1555)).
 * Resolve `TokenAudience` from `default_oidc_audience` in host metadata discovery endpoint.

--- a/config/config.go
+++ b/config/config.go
@@ -487,6 +487,13 @@ func (c *Config) HostType() HostType {
 	return WorkspaceHost
 }
 
+// GetResolvedHostType returns the host type resolved from the host's
+// /.well-known/databricks-config discovery endpoint. Unlike HostType(),
+// this method does not fall back to URL pattern matching or other heuristics.
+func (c *Config) GetResolvedHostType() HostType {
+	return c.resolvedHostType
+}
+
 // ConfigType returns the type of config that the client is configured for.
 // Returns InvalidConfig if the config is invalid.
 // Use of this function should be avoided where possible, because we plan

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -134,6 +134,25 @@ func TestHostType_MetadataOverridesExperimentalFlag(t *testing.T) {
 	assert.Equal(t, AccountHost, c.HostType())
 }
 
+func TestGetResolvedHostType_ReturnsUnknownByDefault(t *testing.T) {
+	c := &Config{}
+	assert.Equal(t, HostTypeUnknown, c.GetResolvedHostType())
+}
+
+func TestGetResolvedHostType_ReturnsResolvedValue(t *testing.T) {
+	c := &Config{
+		resolvedHostType: WorkspaceHost,
+	}
+	assert.Equal(t, WorkspaceHost, c.GetResolvedHostType())
+}
+
+func TestGetResolvedHostType_AccountHost(t *testing.T) {
+	c := &Config{
+		resolvedHostType: AccountHost,
+	}
+	assert.Equal(t, AccountHost, c.GetResolvedHostType())
+}
+
 func TestHostType_EndToEnd_MetadataResolvesHostType(t *testing.T) {
 	noopLoader := mockLoader(func(cfg *Config) error { return nil })
 	cfg := &Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,13 @@ func TestGetResolvedHostType_AccountHost(t *testing.T) {
 	assert.Equal(t, AccountHost, c.GetResolvedHostType())
 }
 
+func TestGetResolvedHostType_UnifiedHost(t *testing.T) {
+	c := &Config{
+		resolvedHostType: UnifiedHost,
+	}
+	assert.Equal(t, UnifiedHost, c.GetResolvedHostType())
+}
+
 func TestHostType_EndToEnd_MetadataResolvesHostType(t *testing.T) {
 	noopLoader := mockLoader(func(cfg *Config) error { return nil })
 	cfg := &Config{


### PR DESCRIPTION
  ## Summary

  Adds a `GetResolvedHostType()` public getter on `Config` that exposes the host type resolved from the `/.well-known/databricks-config` discovery endpoint, without falling back to URL pattern matching heuristics.

  ## Why

  The existing `HostType()` method combines two behaviors: it checks the resolved host metadata first, then falls back to URL pattern matching.  Downstream consumers like the Terraform provider need access to _only_ the metadata-resolved host type to make decisions about host-agnostic behavior — without the URL-based fallback polluting the result. 

Today, `resolvedHostType` is a private field with no public accessor, so downstream packages cannot distinguish between "metadata says this is a workspace host" and "we guessed from the URL pattern."

  This getter provides a clean, minimal API for that use case.

  ## What changed

  ### Interface changes

  - **`(*Config).GetResolvedHostType() HostType`** — Returns the host type resolved from host metadata discovery. Returns `HostTypeUnknown` if
  metadata has not been resolved or did not include a host type. Unlike `HostType()`, this method does not fall back to URL pattern matching.

  ### Behavioral changes

  None. This is a new accessor for an existing internal field.

  ### Internal changes

  None.

  ## How is this tested?

  4 unit tests added in `config/config_test.go`:
  - `TestGetResolvedHostType_ReturnsUnknownByDefault` — fresh `Config` returns `HostTypeUnknown`
  - `TestGetResolvedHostType_ReturnsResolvedValue` — returns `WorkspaceHost` when set
  - `TestGetResolvedHostType_AccountHost` — returns `AccountHost` when set
  - `TestGetResolvedHostType_UnifiedHost` — returns `UnifiedHost` when set

  All pass locally via `go test -run TestGetResolvedHostType ./config/`.