### PR TITLE
Fix data race in concurrent credentials initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: vendor
 	@echo "✓ Running tests ..."
 	@go run gotest.tools/gotestsum@v1.13.0 --format pkgname-and-test-fails \
 		--no-summary=skipped --raw-command go test -v \
-		-json -short -coverprofile=coverage.txt ./...
+		-json -short -race -coverprofile=coverage.txt ./...
 
 coverage: test
 	@echo "✓ Opening coverage for unit tests ..."

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -19,6 +19,7 @@
  * Fix double-caching of OAuth tokens in Azure client secret credentials ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Disable async token refresh for GCP credential providers to avoid wasted refresh attempts caused by double-caching with Google's internal `oauth2.ReuseTokenSource` ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Fixed double-caching in M2M OAuth that prevented the proactive async token refresh from reaching the HTTP endpoint until ~10s before expiry, causing bursts of 401 errors at token rotation boundaries ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
+ * Fix data race in `authenticateIfNeeded` when lazily initializing `credentialsProvider` ([#1310](https://github.com/databricks/databricks-sdk-go/issues/1310)).
 
 ### Documentation
 

--- a/config/config.go
+++ b/config/config.go
@@ -590,9 +590,6 @@ func (c *Config) wrapDebug(err error) error {
 
 // authenticateIfNeeded lazily authenticates across authorizers or returns error
 func (c *Config) authenticateIfNeeded() error {
-	if c.credentialsProvider != nil {
-		return nil
-	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.credentialsProvider != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/common/environment"
@@ -194,6 +195,39 @@ func TestAuthenticate_InvalidHostSet(t *testing.T) {
 	require.NoError(t, err)
 	err = c.Authenticate(req)
 	assert.ErrorIs(t, err, ErrNoHostConfigured)
+}
+
+// TestAuthenticate_concurrentLazyInit verifies that concurrent first-time
+// authentication does not race on credentialsProvider (see #1310).
+// This test requires -race to detect regressions.
+func TestAuthenticate_concurrentLazyInit(t *testing.T) {
+	noopLoader := mockLoader(func(*Config) error { return nil })
+	cfg := &Config{
+		Host:          "https://accounts.cloud.databricks.com",
+		AccountID:     "123e4567-e89b-12d3-a456-426614174000",
+		Token:         "dapi_test_token",
+		Loaders:       []Loader{noopLoader},
+		HTTPTransport: metadataNotFoundTransport,
+	}
+	require.NoError(t, cfg.EnsureResolved())
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost", nil)
+			errs[i] = cfg.Authenticate(req)
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
 }
 
 func TestConfig_getOidcEndpoints_account(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -209,7 +209,9 @@ func TestAuthenticate_concurrentLazyInit(t *testing.T) {
 		Loaders:       []Loader{noopLoader},
 		HTTPTransport: metadataNotFoundTransport,
 	}
-	require.NoError(t, cfg.EnsureResolved())
+	if err := cfg.EnsureResolved(); err != nil {
+		t.Fatal(err)
+	}
 
 	const goroutines = 32
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Changes

Fixes #1310.

This PR is based on #1613 by @d-padmanabhan. It aims to merge the fix while complying with recent security hardening of the repository which prevents us from merging fork PRs.

`authenticateIfNeeded` used a double-checked locking pattern that read `credentialsProvider` outside the mutex before acquiring `Config.mu`. This unsynchronized read raced with the write inside the critical section when multiple goroutines called `Authenticate` or `GetTokenSource` concurrently on first use.

The fix removes the outer unsynchronized check, keeping only the check inside the lock.

This PR also enables `-race` in `make test` so the race detector runs in CI across all Go versions.

## Tests

- Added `TestAuthenticate_concurrentLazyInit`: spawns 32 goroutines calling `Authenticate` concurrently on a shared `Config` to exercise the lazy init path.
- Verified the test catches the regression: reverting the fix and running with `-race` produces `WARNING: DATA RACE`.
- `go test -race -short ./config/...` passes.