### PR TITLE
[Internal] Rename default_oidc_audience to token_federation_default_oidc_audiences

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Added `HostMetadataResolver` hook to allow callers to customize host metadata resolution, e.g. with caching ([#1572](https://github.com/databricks/databricks-sdk-go/pull/1572)).
 * Added `NewLimitIterator` to `listing` package for lazy iteration with a cap on output items ([#1555](https://github.com/databricks/databricks-sdk-go/pull/1555)).
-* Resolve `TokenAudience` from `default_oidc_audience` in host metadata discovery endpoint.
+* Resolve `TokenAudience` from `token_federation_default_oidc_audiences` in host metadata discovery endpoint.
 
 ### Bug Fixes
 

--- a/config/config.go
+++ b/config/config.go
@@ -746,9 +746,9 @@ func (c *Config) resolveHostMetadata(ctx context.Context) {
 		logger.Debugf(ctx, "Resolved host_type from host metadata: %q", meta.HostType)
 		c.resolvedHostType = meta.HostType
 	}
-	if c.TokenAudience == "" && meta.DefaultOIDCAudience != "" {
-		logger.Debugf(ctx, "Resolved token_audience from host metadata default_oidc_audience: %q", meta.DefaultOIDCAudience)
-		c.TokenAudience = meta.DefaultOIDCAudience
+	if c.TokenAudience == "" && len(meta.TokenFederationDefaultOIDCAudiences) > 0 {
+		logger.Debugf(ctx, "Resolved token_audience from host metadata token_federation_default_oidc_audiences: %q", meta.TokenFederationDefaultOIDCAudiences[0])
+		c.TokenAudience = meta.TokenFederationDefaultOIDCAudiences[0]
 	}
 	if c.TokenAudience == "" && meta.WorkspaceID == "" && c.AccountID != "" {
 		logger.Debugf(ctx, "Setting token_audience to account_id for account host: %q", c.AccountID)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -814,7 +814,7 @@ func TestApplyHostMetadata_DoesNotOverrideExistingTokenAudience(t *testing.T) {
 	assert.Equal(t, "custom-audience", cfg.TokenAudience)
 }
 
-func TestApplyHostMetadata_SetsTokenAudienceFromDefaultOIDCAudience(t *testing.T) {
+func TestApplyHostMetadata_SetsTokenAudienceFromTokenFederationDefaultOIDCAudiences(t *testing.T) {
 	noopLoader := mockLoader(func(cfg *Config) error { return nil })
 	cfg := &Config{
 		Host:    testHMHost,
@@ -825,7 +825,7 @@ func TestApplyHostMetadata_SetsTokenAudienceFromDefaultOIDCAudience(t *testing.T
 				Resource:     "/.well-known/databricks-config",
 				ReuseRequest: true,
 				Status:       200,
-				Response:     `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "workspace_id": "` + testHMWorkspaceID + `", "cloud": "AWS", "default_oidc_audience": "` + testHMHost + `/oidc/v1/token"}`,
+				Response:     `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "workspace_id": "` + testHMWorkspaceID + `", "cloud": "AWS", "token_federation_default_oidc_audiences": ["` + testHMHost + `/oidc/v1/token"]}`,
 			},
 		},
 	}
@@ -834,7 +834,7 @@ func TestApplyHostMetadata_SetsTokenAudienceFromDefaultOIDCAudience(t *testing.T
 	assert.Equal(t, testHMHost+"/oidc/v1/token", cfg.TokenAudience)
 }
 
-func TestApplyHostMetadata_DefaultOIDCAudienceTakesPriorityOverAccountIDFallback(t *testing.T) {
+func TestApplyHostMetadata_TokenFederationDefaultOIDCAudiencesTakesPriorityOverAccountIDFallback(t *testing.T) {
 	noopLoader := mockLoader(func(cfg *Config) error { return nil })
 	cfg := &Config{
 		Host:    testHMHost,
@@ -845,17 +845,17 @@ func TestApplyHostMetadata_DefaultOIDCAudienceTakesPriorityOverAccountIDFallback
 				Resource:     "/.well-known/databricks-config",
 				ReuseRequest: true,
 				Status:       200,
-				Response:     `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "AWS", "default_oidc_audience": "custom-audience-from-server"}`,
+				Response:     `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "AWS", "token_federation_default_oidc_audiences": ["custom-audience-from-server"]}`,
 			},
 		},
 	}
 	err := cfg.EnsureResolved()
 	require.NoError(t, err)
-	// default_oidc_audience should take priority over the account_id fallback
+	// token_federation_default_oidc_audiences should take priority over the account_id fallback
 	assert.Equal(t, "custom-audience-from-server", cfg.TokenAudience)
 }
 
-func TestApplyHostMetadata_DefaultOIDCAudienceDoesNotOverrideExisting(t *testing.T) {
+func TestApplyHostMetadata_TokenFederationDefaultOIDCAudiencesDoesNotOverrideExisting(t *testing.T) {
 	noopLoader := mockLoader(func(cfg *Config) error { return nil })
 	cfg := &Config{
 		Host:          testHMHost,
@@ -867,7 +867,7 @@ func TestApplyHostMetadata_DefaultOIDCAudienceDoesNotOverrideExisting(t *testing
 				Resource:     "/.well-known/databricks-config",
 				ReuseRequest: true,
 				Status:       200,
-				Response:     `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "AWS", "default_oidc_audience": "` + testHMHost + `/oidc/v1/token"}`,
+				Response:     `{"oidc_endpoint": "` + testHMHost + `/oidc", "account_id": "` + testHMAccountID + `", "cloud": "AWS", "token_federation_default_oidc_audiences": ["` + testHMHost + `/oidc/v1/token"]}`,
 			},
 		},
 	}
@@ -876,7 +876,7 @@ func TestApplyHostMetadata_DefaultOIDCAudienceDoesNotOverrideExisting(t *testing
 	assert.Equal(t, "user-set-audience", cfg.TokenAudience)
 }
 
-func TestApplyHostMetadata_FallsBackToAccountIDWhenNoDefaultOIDCAudience(t *testing.T) {
+func TestApplyHostMetadata_FallsBackToAccountIDWhenNoTokenFederationDefaultOIDCAudiences(t *testing.T) {
 	noopLoader := mockLoader(func(cfg *Config) error { return nil })
 	cfg := &Config{
 		Host:    testHMHost,
@@ -893,7 +893,7 @@ func TestApplyHostMetadata_FallsBackToAccountIDWhenNoDefaultOIDCAudience(t *test
 	}
 	err := cfg.EnsureResolved()
 	require.NoError(t, err)
-	// No default_oidc_audience and no workspace_id → falls back to account_id
+	// No token_federation_default_oidc_audiences and no workspace_id → falls back to account_id
 	assert.Equal(t, testHMAccountID, cfg.TokenAudience)
 }
 

--- a/config/host_metadata.go
+++ b/config/host_metadata.go
@@ -26,10 +26,10 @@ type HostMetadata struct {
 	// HostType is the type of host (WORKSPACE_HOST, ACCOUNT_HOST, or UNIFIED_HOST).
 	HostType HostType `json:"host_type"`
 
-	// DefaultOIDCAudience is the default OIDC audience for token requests.
+	// TokenFederationDefaultOIDCAudiences is the default OIDC audience for token requests.
 	// For workspace hosts: "https://<workspace_host>/oidc/v1/token"
 	// For account/unified hosts: the resolved account ID.
-	DefaultOIDCAudience string `json:"default_oidc_audience"`
+	TokenFederationDefaultOIDCAudiences []string `json:"token_federation_default_oidc_audiences"`
 }
 
 // HostMetadataResolver, when set on [Config], overrides the default HTTP fetch

--- a/config/host_metadata_test.go
+++ b/config/host_metadata_test.go
@@ -146,36 +146,36 @@ func TestGetHostMetadata_WithHostTypeField(t *testing.T) {
 	}
 }
 
-func TestGetHostMetadata_WithDefaultOIDCAudience(t *testing.T) {
+func TestGetHostMetadata_WithTokenFederationDefaultOIDCAudiences(t *testing.T) {
 	tests := []struct {
-		name         string
-		audience     string
-		wantAudience string
+		name          string
+		audiences     []string
+		wantAudiences []string
 	}{
 		{
-			name:         "workspace audience",
-			audience:     testHMHost + "/oidc/v1/token",
-			wantAudience: testHMHost + "/oidc/v1/token",
+			name:          "workspace audience",
+			audiences:     []string{testHMHost + "/oidc/v1/token"},
+			wantAudiences: []string{testHMHost + "/oidc/v1/token"},
 		},
 		{
-			name:         "account audience",
-			audience:     testHMAccountID,
-			wantAudience: testHMAccountID,
+			name:          "account audience",
+			audiences:     []string{testHMAccountID},
+			wantAudiences: []string{testHMAccountID},
 		},
 		{
-			name:         "missing field",
-			audience:     "",
-			wantAudience: "",
+			name:          "missing field",
+			audiences:     nil,
+			wantAudiences: nil,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			response := map[string]string{
+			response := map[string]any{
 				"oidc_endpoint": testHMHost + "/oidc",
 				"account_id":    testHMAccountID,
 			}
-			if tc.audience != "" {
-				response["default_oidc_audience"] = tc.audience
+			if tc.audiences != nil {
+				response["token_federation_default_oidc_audiences"] = tc.audiences
 			}
 			client := newTestAPIClient(fixtures.MappingTransport{
 				"GET /.well-known/databricks-config": {
@@ -187,8 +187,8 @@ func TestGetHostMetadata_WithDefaultOIDCAudience(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if meta.DefaultOIDCAudience != tc.wantAudience {
-				t.Errorf("DefaultOIDCAudience mismatch: got %q, want %q", meta.DefaultOIDCAudience, tc.wantAudience)
+			if diff := cmp.Diff(tc.wantAudiences, meta.TokenFederationDefaultOIDCAudiences); diff != "" {
+				t.Errorf("TokenFederationDefaultOIDCAudiences mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
  ## Summary

  Renames the `default_oidc_audience` field in `HostMetadata` to
  `token_federation_default_oidc_audiences` and changes its type from
  `string` to `[]string` to match the updated well-known config endpoint
  response.

  ## Why

  The `/.well-known/databricks-config` discovery endpoint has been updated
  to return the default OIDC audience as a JSON array under the key
  `token_federation_default_oidc_audiences` instead of a single string
  under `default_oidc_audience`. The SDK must match the actual API response
  shape to correctly deserialize and use the field.

  ## What changed

  ### Interface changes

  - **`HostMetadata.TokenFederationDefaultOIDCAudiences []string`** —
    Renamed from `DefaultOIDCAudience string`. JSON tag changed from
    `default_oidc_audience` to `token_federation_default_oidc_audiences`.

  ### Behavioral changes

  The first element of the `token_federation_default_oidc_audiences` array
  is used to populate `Config.TokenAudience`. The fallback chain is
  unchanged:
  1. User-set `TokenAudience` (kept as-is)
  2. First entry from `token_federation_default_oidc_audiences`
  3. `AccountID` fallback for account hosts with no workspace ID

  ### Internal changes

  - Updated all tests to use the new field name and array type.
  - Updated `NEXT_CHANGELOG.md` entry.

  ## How is this tested?

  Existing unit tests updated and passing:
  - `TestGetHostMetadata_WithTokenFederationDefaultOIDCAudiences`
  - `TestApplyHostMetadata_SetsTokenAudienceFromTokenFederationDefaultOIDCAudiences`
  - `TestApplyHostMetadata_TokenFederationDefaultOIDCAudiencesTakesPriorityOverAccountIDFallback`
  - `TestApplyHostMetadata_TokenFederationDefaultOIDCAudiencesDoesNotOverrideExisting`
  - `TestApplyHostMetadata_FallsBackToAccountIDWhenNoTokenFederationDefaultOIDCAudiences`

Manually triggered integration tests, also passed.