### PR TITLE
Pass --force-refresh to CLI auth token command

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -20,6 +20,7 @@
  * Disable async token refresh for GCP credential providers to avoid wasted refresh attempts caused by double-caching with Google's internal `oauth2.ReuseTokenSource` ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Fixed double-caching in M2M OAuth that prevented the proactive async token refresh from reaching the HTTP endpoint until ~10s before expiry, causing bursts of 401 errors at token rotation boundaries ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).
  * Fix data race in `authenticateIfNeeded` when lazily initializing `credentialsProvider` ([#1310](https://github.com/databricks/databricks-sdk-go/issues/1310)).
+ * Fix CLI token source `--profile` fallback: `--profile` is a global Cobra flag that old CLIs accept silently instead of reporting "unknown flag", making the previous error-based detection dead code. Now uses `databricks version` to detect CLI capabilities at init time.
 
 ### Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Internal Changes
 
+ * Pass `--force-refresh` to Databricks CLI `auth token` command to bypass the CLI's internal token cache.
  * Use resolved host type from host metadata in `HostType()` method, falling back to URL pattern matching when metadata is unavailable.
  * Normalize internal token sources on `auth.TokenSource` for proper context propagation ([#1577](https://github.com/databricks/databricks-sdk-go/pull/1577)).
  * Fix `TestAzureGithubOIDCCredentials` hang caused by missing `HTTPTransport` stub: `EnsureResolved` now calls `resolveHostMetadata`, which makes a real network request when no transport is set ([#1550](https://github.com/databricks/databricks-sdk-go/pull/1550)).

--- a/config/auth_u2m.go
+++ b/config/auth_u2m.go
@@ -32,7 +32,7 @@ func (u u2mCredentials) Configure(ctx context.Context, cfg *Config) (credentials
 		return nil, err
 	}
 
-	ts, err := NewCliTokenSource(cfg)
+	ts, err := NewCliTokenSource(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/config/cli_token_source.go
+++ b/config/cli_token_source.go
@@ -31,62 +31,111 @@ type cliTokenResponse struct {
 	Expiry      string `json:"expiry"`
 }
 
-type CliTokenSource struct {
-	// cmd is the primary command to execute (--profile when available, --host otherwise).
-	cmd []string
-
-	// hostCmd is a fallback command using --host, used when the primary --profile
-	// command fails because the CLI is too old to support --profile.
-	hostCmd []string
+// cliVersion represents a parsed Databricks CLI semver version.
+type cliVersion struct {
+	Major, Minor, Patch int
 }
 
-func NewCliTokenSource(cfg *Config) (*CliTokenSource, error) {
+// AtLeast returns true if v is greater than or equal to other.
+func (v cliVersion) AtLeast(other cliVersion) bool {
+	if v.Major != other.Major {
+		return v.Major > other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor > other.Minor
+	}
+	return v.Patch >= other.Patch
+}
+
+func (v cliVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// Minimum CLI versions for flags that require version-based detection.
+// --profile is a global Cobra flag — old CLIs accept it silently but fail
+// with "cannot fetch credentials" instead of "unknown flag", so we cannot
+// use error-based detection.
+var cliVersionForProfile = cliVersion{0, 207, 1}
+
+// getCliVersion runs "databricks version" and parses the output.
+func getCliVersion(ctx context.Context, cliPath string) (cliVersion, error) {
+	cmd := exec.CommandContext(ctx, cliPath, "version")
+	out, err := cmd.Output()
+	if err != nil {
+		return cliVersion{}, fmt.Errorf("cannot get CLI version: %w", err)
+	}
+	return parseCliVersion(strings.TrimSpace(string(out)))
+}
+
+// parseCliVersion parses a version string like "Databricks CLI v0.207.1".
+func parseCliVersion(s string) (cliVersion, error) {
+	s = strings.TrimPrefix(s, "Databricks CLI v")
+	var v cliVersion
+	_, err := fmt.Sscanf(s, "%d.%d.%d", &v.Major, &v.Minor, &v.Patch)
+	if err != nil {
+		return cliVersion{}, fmt.Errorf("cannot parse CLI version %q: %w", s, err)
+	}
+	return v, nil
+}
+
+// CliTokenSource fetches OAuth tokens by shelling out to the Databricks CLI.
+type CliTokenSource struct {
+	cmd []string
+}
+
+// NewCliTokenSource creates a [CliTokenSource] by detecting the installed CLI
+// version and building the appropriate auth token command.
+func NewCliTokenSource(ctx context.Context, cfg *Config) (*CliTokenSource, error) {
 	cliPath, err := findDatabricksCli(cfg.DatabricksCliPath)
 	if err != nil {
 		return nil, err
 	}
-	profileCmd, hostCmd := buildCliCommands(cliPath, cfg)
-	return &CliTokenSource{cmd: profileCmd, hostCmd: hostCmd}, nil
+	cmd, err := resolveCliCommand(ctx, cliPath, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &CliTokenSource{cmd: cmd}, nil
 }
 
-// buildCliCommands constructs the CLI commands for fetching an auth token.
-// When cfg.Profile is set, the primary command uses --profile and a fallback
-// --host command is also returned for compatibility with older CLIs.
-// When cfg.Profile is empty, the primary command uses --host and no fallback
-// is needed.
-func buildCliCommands(cliPath string, cfg *Config) (primaryCmd []string, hostCmd []string) {
-	if cfg.Profile != "" {
-		primary := []string{cliPath, "auth", "token", "--profile", cfg.Profile}
-		if cfg.Host != "" {
-			// Build a --host fallback for old CLIs that don't support --profile.
-			return primary, buildHostCommand(cliPath, cfg)
+// resolveCliCommand detects the CLI version and builds the command to execute.
+func resolveCliCommand(ctx context.Context, cliPath string, cfg *Config) ([]string, error) {
+	ver, err := getCliVersion(ctx, cliPath)
+	if err != nil {
+		ver = cliVersion{}
+	}
+	cmd := buildCliCommand(ctx, cliPath, cfg, ver)
+	if cmd == nil {
+		return nil, fmt.Errorf("cannot configure CLI token source: neither profile nor host is set")
+	}
+	return cmd, nil
+}
+
+// buildCliCommand constructs the CLI command for fetching an auth token.
+// The CLI version determines which flags are used.
+func buildCliCommand(ctx context.Context, cliPath string, cfg *Config, ver cliVersion) []string {
+	// --profile is a global Cobra flag — old CLIs accept it silently but
+	// fail with "cannot fetch credentials" instead of "unknown flag".
+	// We use version detection to decide --profile vs --host.
+	if cfg.Profile != "" && ver.AtLeast(cliVersionForProfile) {
+		return []string{cliPath, "auth", "token", "--profile", cfg.Profile}
+	}
+	if cfg.Host != "" {
+		cmd := []string{cliPath, "auth", "token", "--host", cfg.Host}
+		switch cfg.HostType() {
+		case AccountHost:
+			cmd = append(cmd, "--account-id", cfg.AccountID)
 		}
-		return primary, nil
+		if cfg.Profile != "" && !ver.AtLeast(cliVersionForProfile) {
+			logger.Warnf(ctx, "Databricks CLI v%s does not support --profile flag. Falling back to --host. Please upgrade your CLI to the latest version.", ver)
+		}
+		return cmd
 	}
-	return buildHostCommand(cliPath, cfg), nil
-}
-
-// buildHostCommand constructs the legacy --host based CLI command.
-func buildHostCommand(cliPath string, cfg *Config) []string {
-	cmd := []string{cliPath, "auth", "token", "--host", cfg.Host}
-	switch cfg.HostType() {
-	case AccountHost:
-		cmd = append(cmd, "--account-id", cfg.AccountID)
-	}
-	return cmd
+	return nil
 }
 
 // Token fetches an OAuth token by shelling out to the Databricks CLI.
-// When a --profile command is configured, it is tried first. If the CLI
-// returns "unknown flag: --profile" (indicating an older CLI version),
-// the fallback --host command is used instead.
 func (c *CliTokenSource) Token(ctx context.Context) (*oauth2.Token, error) {
-	tok, err := c.execCliCommand(ctx, c.cmd)
-	if err != nil && c.hostCmd != nil && isUnknownFlagError(err) {
-		logger.Warnf(ctx, "Databricks CLI does not support --profile flag. Falling back to --host. Please upgrade your CLI to the latest version.")
-		return c.execCliCommand(ctx, c.hostCmd)
-	}
-	return tok, err
+	return c.execCliCommand(ctx, c.cmd)
 }
 
 func (c *CliTokenSource) execCliCommand(ctx context.Context, args []string) (*oauth2.Token, error) {
@@ -95,6 +144,8 @@ func (c *CliTokenSource) execCliCommand(ctx context.Context, args []string) (*oa
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
+			// We intentionally discard exec.ExitError — the stderr text is the
+			// CLI's error contract; exit codes and process state are not useful.
 			return nil, fmt.Errorf("cannot get access token: %s", strings.TrimSpace(string(exitErr.Stderr)))
 		}
 		return nil, fmt.Errorf("cannot get access token: %w", err)
@@ -112,13 +163,6 @@ func (c *CliTokenSource) execCliCommand(ctx context.Context, args []string) (*oa
 		TokenType:   resp.TokenType,
 		Expiry:      expiry,
 	}, nil
-}
-
-// isUnknownFlagError returns true if the error indicates the CLI does not
-// recognize the --profile flag. This happens with older CLI versions that
-// predate profile-based token lookup.
-func isUnknownFlagError(err error) bool {
-	return strings.Contains(err.Error(), "unknown flag: --profile")
 }
 
 // parseExpiry parses an expiry time string in multiple formats for cross-SDK compatibility.

--- a/config/cli_token_source.go
+++ b/config/cli_token_source.go
@@ -51,11 +51,11 @@ func (v cliVersion) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
-// Minimum CLI versions for flags that require version-based detection.
-// --profile is a global Cobra flag — old CLIs accept it silently but fail
-// with "cannot fetch credentials" instead of "unknown flag", so we cannot
-// use error-based detection.
-var cliVersionForProfile = cliVersion{0, 207, 1}
+// Minimum CLI versions for flag support.
+var (
+	cliVersionForProfile      = cliVersion{0, 207, 1} // databricks/cli#855
+	cliVersionForForceRefresh = cliVersion{0, 296, 0} // databricks/cli#4767
+)
 
 // getCliVersion runs "databricks version" and parses the output.
 func getCliVersion(ctx context.Context, cliPath string) (cliVersion, error) {
@@ -113,14 +113,15 @@ func resolveCliCommand(ctx context.Context, cliPath string, cfg *Config) ([]stri
 // buildCliCommand constructs the CLI command for fetching an auth token.
 // The CLI version determines which flags are used.
 func buildCliCommand(ctx context.Context, cliPath string, cfg *Config, ver cliVersion) []string {
+	var cmd []string
+
 	// --profile is a global Cobra flag — old CLIs accept it silently but
 	// fail with "cannot fetch credentials" instead of "unknown flag".
 	// We use version detection to decide --profile vs --host.
 	if cfg.Profile != "" && ver.AtLeast(cliVersionForProfile) {
-		return []string{cliPath, "auth", "token", "--profile", cfg.Profile}
-	}
-	if cfg.Host != "" {
-		cmd := []string{cliPath, "auth", "token", "--host", cfg.Host}
+		cmd = []string{cliPath, "auth", "token", "--profile", cfg.Profile}
+	} else if cfg.Host != "" {
+		cmd = []string{cliPath, "auth", "token", "--host", cfg.Host}
 		switch cfg.HostType() {
 		case AccountHost:
 			cmd = append(cmd, "--account-id", cfg.AccountID)
@@ -128,9 +129,19 @@ func buildCliCommand(ctx context.Context, cliPath string, cfg *Config, ver cliVe
 		if cfg.Profile != "" && !ver.AtLeast(cliVersionForProfile) {
 			logger.Warnf(ctx, "Databricks CLI v%s does not support --profile flag. Falling back to --host. Please upgrade your CLI to the latest version.", ver)
 		}
-		return cmd
 	}
-	return nil
+
+	if cmd == nil {
+		return nil
+	}
+
+	if ver.AtLeast(cliVersionForForceRefresh) {
+		cmd = append(cmd, "--force-refresh")
+	} else {
+		logger.Warnf(ctx, "Databricks CLI does not support --force-refresh flag. The CLI's token cache may provide stale tokens. Please upgrade your CLI to the latest version.")
+	}
+
+	return cmd
 }
 
 // Token fetches an OAuth token by shelling out to the Databricks CLI.

--- a/config/cli_token_source_test.go
+++ b/config/cli_token_source_test.go
@@ -226,13 +226,25 @@ func TestBuildCliCommand(t *testing.T) {
 		wantCmd []string
 	}{
 		{
-			name:    "host only — any version",
+			name:    "host only — old CLI, no force-refresh",
 			cfg:     &Config{Host: host},
 			ver:     cliVersion{0, 200, 0},
 			wantCmd: []string{cliPath, "auth", "token", "--host", host},
 		},
 		{
-			name:    "account host",
+			name:    "host only — new CLI, with force-refresh",
+			cfg:     &Config{Host: host},
+			ver:     cliVersion{0, 296, 0},
+			wantCmd: []string{cliPath, "auth", "token", "--host", host, "--force-refresh"},
+		},
+		{
+			name:    "account host — with force-refresh",
+			cfg:     &Config{Host: accountHost, AccountID: accountID},
+			ver:     cliVersion{0, 296, 0},
+			wantCmd: []string{cliPath, "auth", "token", "--host", accountHost, "--account-id", accountID, "--force-refresh"},
+		},
+		{
+			name:    "account host — without force-refresh",
 			cfg:     &Config{Host: accountHost, AccountID: accountID},
 			ver:     cliVersion{0, 200, 0},
 			wantCmd: []string{cliPath, "auth", "token", "--host", accountHost, "--account-id", accountID},
@@ -248,13 +260,19 @@ func TestBuildCliCommand(t *testing.T) {
 			wantCmd: []string{cliPath, "auth", "token", "--host", unifiedHost},
 		},
 		{
-			name:    "profile with new CLI — uses --profile",
+			name:    "profile with new CLI — uses --profile, no force-refresh",
 			cfg:     &Config{Profile: "my-profile", Host: host},
 			ver:     cliVersion{0, 207, 1},
 			wantCmd: []string{cliPath, "auth", "token", "--profile", "my-profile"},
 		},
 		{
-			name:    "profile with old CLI — falls back to --host",
+			name:    "profile with newest CLI — uses --profile and --force-refresh",
+			cfg:     &Config{Profile: "my-profile", Host: host},
+			ver:     cliVersion{0, 296, 0},
+			wantCmd: []string{cliPath, "auth", "token", "--profile", "my-profile", "--force-refresh"},
+		},
+		{
+			name:    "profile with old CLI — falls back to --host, no force-refresh",
 			cfg:     &Config{Profile: "my-profile", Host: host},
 			ver:     cliVersion{0, 207, 0},
 			wantCmd: []string{cliPath, "auth", "token", "--host", host},
@@ -272,7 +290,13 @@ func TestBuildCliCommand(t *testing.T) {
 			wantCmd: []string{cliPath, "auth", "token", "--profile", "my-profile"},
 		},
 		{
-			name:    "zero version (detection failed) — falls back to --host",
+			name:    "profile without host and newest CLI — --profile and --force-refresh",
+			cfg:     &Config{Profile: "my-profile"},
+			ver:     cliVersion{0, 296, 0},
+			wantCmd: []string{cliPath, "auth", "token", "--profile", "my-profile", "--force-refresh"},
+		},
+		{
+			name:    "zero version (detection failed) — falls back to --host, no force-refresh",
 			cfg:     &Config{Profile: "my-profile", Host: host},
 			ver:     cliVersion{},
 			wantCmd: []string{cliPath, "auth", "token", "--host", host},
@@ -280,7 +304,7 @@ func TestBuildCliCommand(t *testing.T) {
 		{
 			name:    "neither profile nor host — nil",
 			cfg:     &Config{},
-			ver:     cliVersion{0, 295, 0},
+			ver:     cliVersion{0, 296, 0},
 			wantCmd: nil,
 		},
 	}

--- a/config/cli_token_source_test.go
+++ b/config/cli_token_source_test.go
@@ -125,7 +125,91 @@ func TestFindDatabricksCli(t *testing.T) {
 	}
 }
 
-func TestBuildCliCommands(t *testing.T) {
+func TestParseCliVersion(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    cliVersion
+		wantErr bool
+	}{
+		{
+			name:  "standard version",
+			input: "Databricks CLI v0.295.0",
+			want:  cliVersion{0, 295, 0},
+		},
+		{
+			name:  "patch version",
+			input: "Databricks CLI v0.207.1",
+			want:  cliVersion{0, 207, 1},
+		},
+		{
+			name:  "major version",
+			input: "Databricks CLI v1.0.0",
+			want:  cliVersion{1, 0, 0},
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "malformed",
+			input:   "not a version",
+			wantErr: true,
+		},
+		{
+			name:    "missing prefix",
+			input:   "v0.207.1",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseCliVersion(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseCliVersion(%q) = %v, want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCliVersion(%q) error = %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseCliVersion(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCliVersion_AtLeast(t *testing.T) {
+	testCases := []struct {
+		name  string
+		v     cliVersion
+		other cliVersion
+		want  bool
+	}{
+		{"equal", cliVersion{0, 207, 1}, cliVersion{0, 207, 1}, true},
+		{"higher patch", cliVersion{0, 207, 2}, cliVersion{0, 207, 1}, true},
+		{"lower patch", cliVersion{0, 207, 0}, cliVersion{0, 207, 1}, false},
+		{"higher minor", cliVersion{0, 208, 0}, cliVersion{0, 207, 1}, true},
+		{"lower minor", cliVersion{0, 206, 9}, cliVersion{0, 207, 1}, false},
+		{"higher major", cliVersion{1, 0, 0}, cliVersion{0, 207, 1}, true},
+		{"zero vs zero", cliVersion{0, 0, 0}, cliVersion{0, 0, 0}, true},
+		{"zero vs nonzero", cliVersion{0, 0, 0}, cliVersion{0, 207, 1}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.v.AtLeast(tc.other); got != tc.want {
+				t.Errorf("%v.AtLeast(%v) = %v, want %v", tc.v, tc.other, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildCliCommand(t *testing.T) {
 	const (
 		cliPath     = "/path/to/databricks"
 		host        = "https://workspace.cloud.databricks.com"
@@ -136,19 +220,21 @@ func TestBuildCliCommands(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name        string
-		cfg         *Config
-		wantCmd     []string
-		wantHostCmd []string
+		name    string
+		cfg     *Config
+		ver     cliVersion
+		wantCmd []string
 	}{
 		{
-			name:    "workspace host",
+			name:    "host only — any version",
 			cfg:     &Config{Host: host},
+			ver:     cliVersion{0, 200, 0},
 			wantCmd: []string{cliPath, "auth", "token", "--host", host},
 		},
 		{
 			name:    "account host",
 			cfg:     &Config{Host: accountHost, AccountID: accountID},
+			ver:     cliVersion{0, 200, 0},
 			wantCmd: []string{cliPath, "auth", "token", "--host", accountHost, "--account-id", accountID},
 		},
 		{
@@ -158,63 +244,104 @@ func TestBuildCliCommands(t *testing.T) {
 				AccountID:   accountID,
 				WorkspaceID: workspaceID,
 			},
+			ver:     cliVersion{0, 295, 0},
 			wantCmd: []string{cliPath, "auth", "token", "--host", unifiedHost},
 		},
 		{
-			name:        "profile uses --profile with --host fallback",
-			cfg:         &Config{Profile: "my-profile", Host: host},
-			wantCmd:     []string{cliPath, "auth", "token", "--profile", "my-profile"},
-			wantHostCmd: []string{cliPath, "auth", "token", "--host", host},
+			name:    "profile with new CLI — uses --profile",
+			cfg:     &Config{Profile: "my-profile", Host: host},
+			ver:     cliVersion{0, 207, 1},
+			wantCmd: []string{cliPath, "auth", "token", "--profile", "my-profile"},
 		},
 		{
-			name:    "profile without host — no fallback",
+			name:    "profile with old CLI — falls back to --host",
+			cfg:     &Config{Profile: "my-profile", Host: host},
+			ver:     cliVersion{0, 207, 0},
+			wantCmd: []string{cliPath, "auth", "token", "--host", host},
+		},
+		{
+			name:    "profile without host and old CLI — nil",
 			cfg:     &Config{Profile: "my-profile"},
+			ver:     cliVersion{0, 207, 0},
+			wantCmd: nil,
+		},
+		{
+			name:    "profile without host and new CLI — uses --profile",
+			cfg:     &Config{Profile: "my-profile"},
+			ver:     cliVersion{0, 207, 1},
 			wantCmd: []string{cliPath, "auth", "token", "--profile", "my-profile"},
+		},
+		{
+			name:    "zero version (detection failed) — falls back to --host",
+			cfg:     &Config{Profile: "my-profile", Host: host},
+			ver:     cliVersion{},
+			wantCmd: []string{cliPath, "auth", "token", "--host", host},
+		},
+		{
+			name:    "neither profile nor host — nil",
+			cfg:     &Config{},
+			ver:     cliVersion{0, 295, 0},
+			wantCmd: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotCmd, gotHostCmd := buildCliCommands(cliPath, tc.cfg)
-			if !slices.Equal(gotCmd, tc.wantCmd) {
-				t.Errorf("primary cmd = %v, want %v", gotCmd, tc.wantCmd)
-			}
-			if !slices.Equal(gotHostCmd, tc.wantHostCmd) {
-				t.Errorf("host cmd = %v, want %v", gotHostCmd, tc.wantHostCmd)
+			got := buildCliCommand(context.Background(), cliPath, tc.cfg, tc.ver)
+			if !slices.Equal(got, tc.wantCmd) {
+				t.Errorf("buildCliCommand() = %v, want %v", got, tc.wantCmd)
 			}
 		})
 	}
 }
 
-func TestNewCliTokenSource(t *testing.T) {
-	tempDir := t.TempDir()
-
-	cliName := "databricks"
-	if runtime.GOOS == "windows" {
-		cliName = "databricks.exe"
-	}
-	validCliPath := filepath.Join(tempDir, cliName)
-	if err := os.WriteFile(validCliPath, make([]byte, databricksCliMinSize+1), 0755); err != nil {
+// writeMockCli creates a shell script that passes the file-size check in
+// findDatabricksCli and executes body when run.
+func writeMockCli(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "databricks")
+	content := append([]byte(body), make([]byte, databricksCliMinSize)...)
+	if err := os.WriteFile(path, content, 0755); err != nil {
 		t.Fatalf("failed to create mock CLI: %v", err)
 	}
+	return path
+}
 
-	t.Run("success", func(t *testing.T) {
-		cfg := &Config{DatabricksCliPath: validCliPath, Host: "https://example.databricks.com"}
-		ts, err := NewCliTokenSource(cfg)
+func TestNewCliTokenSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping shell script test on Windows")
+	}
+
+	tempDir := t.TempDir()
+	cliScript := writeMockCli(t, tempDir, "#!/bin/sh\necho 'Databricks CLI v0.295.0'")
+
+	t.Run("success with host", func(t *testing.T) {
+		cfg := &Config{DatabricksCliPath: cliScript, Host: "https://example.databricks.com"}
+		ts, err := NewCliTokenSource(context.Background(), cfg)
 		if err != nil {
 			t.Fatalf("NewCliTokenSource() unexpected error: %v", err)
 		}
-		// Verify CLI path was resolved and used
-		if ts.cmd[0] != validCliPath {
-			t.Errorf("cmd[0] = %q, want %q", ts.cmd[0], validCliPath)
+		if ts.cmd[0] != cliScript {
+			t.Errorf("cmd[0] = %q, want %q", ts.cmd[0], cliScript)
 		}
 	})
 
 	t.Run("CLI not found", func(t *testing.T) {
 		cfg := &Config{DatabricksCliPath: filepath.Join(tempDir, "nonexistent"), Host: "https://example.databricks.com"}
-		_, err := NewCliTokenSource(cfg)
+		_, err := NewCliTokenSource(context.Background(), cfg)
 		if !errors.Is(err, ErrCliNotFound) {
 			t.Errorf("NewCliTokenSource() error = %v, want %v", err, ErrCliNotFound)
+		}
+	})
+
+	t.Run("neither profile nor host", func(t *testing.T) {
+		cfg := &Config{DatabricksCliPath: cliScript}
+		_, err := NewCliTokenSource(context.Background(), cfg)
+		if err == nil {
+			t.Fatal("NewCliTokenSource() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "neither profile nor host") {
+			t.Errorf("NewCliTokenSource() error = %v, want error containing %q", err, "neither profile nor host")
 		}
 	})
 }
@@ -278,76 +405,5 @@ func TestCliTokenSource_Token(t *testing.T) {
 				t.Errorf("AccessToken = %q, want %q", token.AccessToken, tc.wantToken)
 			}
 		})
-	}
-}
-
-func TestCliTokenSource_Token_FallbackOnUnknownFlag(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping shell script test on Windows")
-	}
-
-	expiry := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
-	validResponse, _ := json.Marshal(cliTokenResponse{
-		AccessToken: "fallback-token",
-		TokenType:   "Bearer",
-		Expiry:      expiry,
-	})
-
-	tempDir := t.TempDir()
-
-	// Primary script simulates an old CLI that doesn't know --profile.
-	profileScript := filepath.Join(tempDir, "profile_cli.sh")
-	if err := os.WriteFile(profileScript, []byte("#!/bin/sh\necho 'Error: unknown flag: --profile' >&2\nexit 1"), 0755); err != nil {
-		t.Fatalf("failed to create profile script: %v", err)
-	}
-
-	// Fallback script succeeds with --host.
-	hostScript := filepath.Join(tempDir, "host_cli.sh")
-	if err := os.WriteFile(hostScript, []byte("#!/bin/sh\necho '"+string(validResponse)+"'"), 0755); err != nil {
-		t.Fatalf("failed to create host script: %v", err)
-	}
-
-	ts := &CliTokenSource{
-		cmd:     []string{profileScript},
-		hostCmd: []string{hostScript},
-	}
-	token, err := ts.Token(context.Background())
-	if err != nil {
-		t.Fatalf("Token() error = %v, want fallback to succeed", err)
-	}
-	if token.AccessToken != "fallback-token" {
-		t.Errorf("AccessToken = %q, want %q", token.AccessToken, "fallback-token")
-	}
-}
-
-func TestCliTokenSource_Token_NoFallbackOnRealError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping shell script test on Windows")
-	}
-
-	tempDir := t.TempDir()
-
-	// Primary script fails with a real auth error (not unknown flag).
-	profileScript := filepath.Join(tempDir, "profile_cli.sh")
-	if err := os.WriteFile(profileScript, []byte("#!/bin/sh\necho 'cache: databricks OAuth is not configured for this host' >&2\nexit 1"), 0755); err != nil {
-		t.Fatalf("failed to create profile script: %v", err)
-	}
-
-	// Fallback script would succeed, but should not be called.
-	hostScript := filepath.Join(tempDir, "host_cli.sh")
-	if err := os.WriteFile(hostScript, []byte("#!/bin/sh\necho 'should not reach here' >&2\nexit 1"), 0755); err != nil {
-		t.Fatalf("failed to create host script: %v", err)
-	}
-
-	ts := &CliTokenSource{
-		cmd:     []string{profileScript},
-		hostCmd: []string{hostScript},
-	}
-	_, err := ts.Token(context.Background())
-	if err == nil {
-		t.Fatal("Token() error = nil, want error")
-	}
-	if !strings.Contains(err.Error(), "databricks OAuth is not configured") {
-		t.Errorf("Token() error = %v, want error containing original auth failure", err)
 	}
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-go/pull/1625/files/c360a6dd6fd9ea39432b912f1605981d7a9b79ce..cd4d00d2f87075e26bea6e82f5271f582be737dd) to review incremental changes.
- [stack/cli-version-detection](https://github.com/databricks/databricks-sdk-go/pull/1624) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1624/files)]
  - [**stack/cli-force-refresh**](https://github.com/databricks/databricks-sdk-go/pull/1625) [[Files changed](https://github.com/databricks/databricks-sdk-go/pull/1625/files/c360a6dd6fd9ea39432b912f1605981d7a9b79ce..cd4d00d2f87075e26bea6e82f5271f582be737dd)]

---------
## Summary

Pass `--force-refresh` to the Databricks CLI `auth token` command when the CLI supports it (>= v0.296.0), bypassing the CLI's internal token cache.

## Why

The SDK manages its own token caching via `CachedTokenSource`. When the SDK decides it needs a new token and shells out to `databricks auth token`, the CLI may return a cached token that is about to expire (or has already expired from the SDK's perspective). This creates unnecessary refresh failures and retry loops.

The CLI added a `--force-refresh` flag ([databricks/cli#4767](https://github.com/databricks/cli/pull/4767), motivated by [databricks/cli#4564](https://github.com/databricks/cli/issues/4564)) that bypasses its internal cache. By using this flag, the SDK is guaranteed a freshly minted token every time it asks for one.

With the version detection infrastructure from the parent PR (#1624), adding `--force-refresh` is a one-constant, one-`if` change.

## What changed

### Interface changes

None. `CliTokenSource` is not part of the public API surface.

### Behavioral changes

- The SDK now appends `--force-refresh` when invoking `databricks auth token` if the CLI version is >= v0.296.0.
- A warning is logged when the CLI is too old for `--force-refresh`: `"Databricks CLI does not support --force-refresh flag. The CLI's token cache may provide stale tokens."`

### Internal changes

- **`cliVersionForForceRefresh`**: new version constant `{0, 296, 0}`.
- **`buildCliCommand`**: Layer 1 used early returns; this PR changes them to assignments so `--force-refresh` can be appended after the base command is resolved. One new `if` block at the end.

## How is this tested?

Additional test cases in `TestBuildCliCommand`:
- host + v0.296.0 → appends `--force-refresh`
- host + v0.200.0 → no `--force-refresh`
- account host + v0.296.0 → appends `--force-refresh`
- profile + v0.296.0 → `--profile` + `--force-refresh`
- profile + v0.207.1 → `--profile` only (no `--force-refresh`)
- profile-only + v0.296.0 → `--profile` + `--force-refresh`
- zero version → `--host` only, no `--force-refresh`