### PR TITLE
marshal: handle NaN/Inf string values when unmarshaling float fields

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+ * Handle `NaN`, `Inf`, and `-Inf` string values when deserializing float fields; fixes deserialization failures for MLflow metric responses that encode special float values as JSON strings ([#1498](https://github.com/databricks/databricks-sdk-go/issues/1498)).
  * Add `X-Databricks-Org-Id` header to deprecated workspace SCIM APIs (Groups, ServicePrincipals, Users) for SPOG host compatibility.
  * Add retry logic to token acquisition for OIDC, M2M, and Azure client secret credentials ([#1398](https://github.com/databricks/databricks-sdk-go/issues/1398), [#1072](https://github.com/databricks/databricks-sdk-go/issues/1072)).
  * Fix double-caching of OAuth tokens in Azure client secret credentials ([#1549](https://github.com/databricks/databricks-sdk-go/issues/1549)).

--- a/marshal/types_float_test.go
+++ b/marshal/types_float_test.go
@@ -1,6 +1,7 @@
 package marshal
 
 import (
+	"math"
 	"testing"
 )
 
@@ -41,4 +42,29 @@ func TestFloatForce(t *testing.T) {
 			unmarshalForceSendField: []string{"Float"},
 		},
 	)
+}
+
+// TestFloatNaN verifies that fields whose API value is the JSON string "NaN"
+// are correctly decoded to math.NaN().  MLflow and other Databricks APIs
+// encode special float values as quoted strings (see issue #1498).
+func TestFloatNaN(t *testing.T) {
+	var s customStruct
+	err := Unmarshal([]byte(`{"float":"NaN"}`), &s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !math.IsNaN(s.Float) {
+		t.Errorf("expected NaN, got %v", s.Float)
+	}
+}
+
+func TestFloatInf(t *testing.T) {
+	var s customStruct
+	err := Unmarshal([]byte(`{"float":"Inf"}`), &s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !math.IsInf(s.Float, 1) {
+		t.Errorf("expected +Inf, got %v", s.Float)
+	}
 }

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -3,7 +3,10 @@ package marshal
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"reflect"
+	"strconv"
+	"strings"
 )
 
 // Unmarshals a JSON element and fills in the ForceSendFields field if
@@ -71,6 +74,32 @@ func setField(field reflect.Value, value []byte) error {
 	if err == nil {
 		return nil
 	}
+
+	// MLflow and some other Databricks APIs encode special float values
+	// (NaN, Inf) as JSON strings rather than numbers.  Handle these before
+	// falling through to the YAML-string heuristic below.
+	k := field.Kind()
+	if k == reflect.Float32 || k == reflect.Float64 {
+		// Strip surrounding quotes if present ("NaN" → NaN).
+		unquoted := strings.Trim(string(value), `"`)
+		switch strings.ToLower(unquoted) {
+		case "nan":
+			field.SetFloat(math.NaN())
+			return nil
+		case "inf", "+inf", "infinity", "+infinity":
+			field.SetFloat(math.Inf(1))
+			return nil
+		case "-inf", "-infinity":
+			field.SetFloat(math.Inf(-1))
+			return nil
+		default:
+			if f, parseErr := strconv.ParseFloat(unquoted, 64); parseErr == nil {
+				field.SetFloat(f)
+				return nil
+			}
+		}
+	}
+
 	// We use godss/yaml to convert YAML into JSON.
 	// This library stops converting when it finds a custom Marshaller,
 	// Since strings in YAML may not have quotes, they won't be added.


### PR DESCRIPTION
Fixes #1498. MLflow returns `"NaN"` as a JSON string for float fields. The existing unmarshaler failed because `json.Unmarshal` correctly rejects strings for float64. Added handling in `setField` to recognise NaN/Inf/+Inf/-Inf strings and set the float value directly.