### PR TITLE
Add .jfrog/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ out/**
 *.log
 .databricks/
 .DS_Store
+.jfrog/


### PR DESCRIPTION
## Changes

The JFrog CLI (added in #1631) creates a `.jfrog/` configuration directory at
runtime. GoReleaser requires a clean working tree and fails with a "dirty git
state" error when this directory is present. Adding it to `.gitignore` fixes the
release workflow.

## Tests

- [ ] Verify release workflow snapshot build passes in merge queue

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.