### PR TITLE
Expand AI agent detection in user-agent header

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,4 +18,6 @@
 
 ### Internal Changes
 
+ * Expanded AI agent detection: added Goose, Amp, Augment, Copilot (VS Code), Kiro, Windsurf. Honors the `AGENT=<name>` standard and falls back to `unknown` for unrecognized values.
+
 ### API Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,6 @@
 
 ### Internal Changes
 
- * Expanded AI agent detection: added Goose, Amp, Augment, Copilot (VS Code), Kiro, Windsurf. Honors the `AGENT=<name>` standard and falls back to `unknown` for unrecognized values.
+ * Expanded AI agent detection: added Goose, Amp, Augment, Copilot (VS Code), Kiro, Windsurf. Honors the `AGENT=<name>` standard and falls back to `unknown` for unrecognized values. When multiple agent env vars are present (e.g. a Cursor CLI subagent invoked from Claude Code), the user-agent reports `agent/multiple`.
 
 ### API Changes

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -578,8 +578,10 @@ func TestUserAgentForMultipleAgents(t *testing.T) {
 
 	userAgent := captureUserAgent(t)
 
-	// When multiple agent env vars are set, no agent/ entry should appear.
-	assert.NotContains(t, userAgent, "agent/")
+	// Nested agents (e.g. Claude Code spawning a Cursor CLI subagent) set
+	// multiple explicit matchers on the same process. Report "multiple" so
+	// the stacked case is visible in telemetry.
+	assert.Contains(t, userAgent, "agent/multiple")
 }
 
 func TestUserAgentForAgentNotSet(t *testing.T) {

--- a/useragent/agent.go
+++ b/useragent/agent.go
@@ -49,14 +49,13 @@ func listKnownAgents() []knownAgent {
 //
 // The function counts how many distinct agents matched via explicit env vars:
 //   - Exactly one agent matched: return its product name.
-//   - More than one agent matched: return "" (ambiguity).
+//   - More than one agent matched: return "multiple". Agent env vars can be
+//     stacked when one agent invokes another as a subagent (e.g. Claude Code
+//     spawning a Cursor CLI subprocess), so the child process inherits env
+//     vars from multiple layers.
 //   - Zero agents matched: if the agents.md standard AGENT env var is set to
 //     a non-empty value, return that value if it matches a known product name,
 //     or "unknown" otherwise. If AGENT is not set, return "".
-//
-// Unlike CI/CD detection (which returns the first match), agent detection
-// uses an ambiguity guard because agent env vars can be stacked (e.g., running
-// Cline inside Cursor).
 func lookupAgentProvider() string {
 	agents := listKnownAgents()
 
@@ -67,14 +66,42 @@ func lookupAgentProvider() string {
 		}
 	}
 
+	// Known BYOK false positive: Copilot CLI users often set COPILOT_MODEL
+	// alongside COPILOT_CLI. That is a single copilot-cli signal, not a
+	// stacked multi-agent setup, so drop the copilot-vscode match.
+	matches = collapseCopilotBYOK(matches)
+
 	switch len(matches) {
 	case 1:
 		return matches[0]
 	case 0:
 		return agentEnvFallback(agents)
 	default:
-		return "" // ambiguity: multiple distinct agents matched
+		return "multiple"
 	}
+}
+
+func collapseCopilotBYOK(matches []string) []string {
+	hasCLI, hasVSCode := false, false
+	for _, m := range matches {
+		if m == "copilot-cli" {
+			hasCLI = true
+		}
+		if m == "copilot-vscode" {
+			hasVSCode = true
+		}
+	}
+	if !hasCLI || !hasVSCode {
+		return matches
+	}
+	filtered := make([]string, 0, len(matches)-1)
+	for _, m := range matches {
+		if m == "copilot-vscode" {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
 }
 
 // agentEnvFallback honors the agents.md AGENT=<name> standard.
@@ -103,10 +130,12 @@ var (
 //   - the known product name when exactly one agent is detected via explicit
 //     env matchers, or when AGENT is set to a known product name and no
 //     explicit matcher fired;
+//   - "multiple" when multiple explicit matchers fire for different agents
+//     (typically nested agents, e.g. Cursor CLI running as a Claude Code
+//     subagent);
 //   - "unknown" when no explicit matcher fired and AGENT is set to a value
 //     that is not a known product name;
-//   - "" when no agent is detected, or when multiple explicit matchers fire
-//     for different agents (ambiguity).
+//   - "" when no agent is detected.
 func AgentProvider() string {
 	agentOnce.Do(func() {
 		agentName = lookupAgentProvider()

--- a/useragent/agent.go
+++ b/useragent/agent.go
@@ -32,6 +32,7 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "amp",
 			matchAny: []envMatcher{
+				// https://ampcode.com/ (sets AMP_CURRENT_THREAD_ID and AGENT=amp)
 				{envVar: "AMP_CURRENT_THREAD_ID"},
 				{envVar: agentEnvVar, value: "amp"},
 			},
@@ -45,7 +46,7 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "augment",
 			matchAny: []envMatcher{
-				{envVar: "AUGMENT_AGENT"},
+				{envVar: "AUGMENT_AGENT"}, // https://www.augmentcode.com/
 			},
 		},
 		{
@@ -75,7 +76,8 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "copilot-vscode",
 			matchAny: []envMatcher{
-				{envVar: "COPILOT_MODEL"}, // VS Code Copilot
+				// VS Code Copilot terminal, best-effort heuristic, not officially identified
+				{envVar: "COPILOT_MODEL"},
 			},
 		},
 		{
@@ -93,6 +95,7 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "goose",
 			matchAny: []envMatcher{
+				// https://block.github.io/goose/ (sets GOOSE_TERMINAL and AGENT=goose)
 				{envVar: "GOOSE_TERMINAL"},
 				{envVar: agentEnvVar, value: "goose"},
 			},
@@ -100,13 +103,7 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "kiro",
 			matchAny: []envMatcher{
-				{envVar: "KIRO"},
-			},
-		},
-		{
-			product: "opencode",
-			matchAny: []envMatcher{
-				{envVar: "OPENCODE"}, // https://github.com/opencode-ai/opencode
+				{envVar: "KIRO"}, // https://kiro.dev/ (Amazon)
 			},
 		},
 		{
@@ -116,9 +113,15 @@ func listKnownAgents() []knownAgent {
 			},
 		},
 		{
+			product: "opencode",
+			matchAny: []envMatcher{
+				{envVar: "OPENCODE"}, // https://github.com/opencode-ai/opencode
+			},
+		},
+		{
 			product: "windsurf",
 			matchAny: []envMatcher{
-				{envVar: "WINDSURF_AGENT"},
+				{envVar: "WINDSURF_AGENT"}, // https://codeium.com/windsurf (Codeium)
 			},
 		},
 	}
@@ -144,15 +147,17 @@ func matcherFires(m envMatcher) bool {
 //   - Exactly one agent matched: return its product name.
 //   - More than one agent matched: return "" (ambiguity).
 //   - Zero agents matched: if the agents.md standard AGENT env var is set to
-//     any non-empty value, return "unknown". Otherwise return "".
+//     a non-empty value, return that value if it matches a known product name,
+//     or "unknown" otherwise. If AGENT is not set, return "".
 //
 // Unlike CI/CD detection (which returns the first match), agent detection
 // uses an ambiguity guard because agent env vars can be stacked (e.g., running
 // Cline inside Cursor).
 func lookupAgentProvider() string {
+	agents := listKnownAgents()
 	var detected string
 	count := 0
-	for _, a := range listKnownAgents() {
+	for _, a := range agents {
 		fired := false
 		for _, m := range a.matchAny {
 			if matcherFires(m) {
@@ -173,6 +178,13 @@ func lookupAgentProvider() string {
 	}
 	if count == 0 {
 		if v, ok := os.LookupEnv(agentEnvVar); ok && v != "" {
+			// Honor the agents.md standard: if AGENT is set to a known product
+			// name that wasn't caught by any explicit matcher, report it directly.
+			for _, a := range agents {
+				if a.product == v {
+					return v
+				}
+			}
 			return "unknown"
 		}
 	}

--- a/useragent/agent.go
+++ b/useragent/agent.go
@@ -5,41 +5,162 @@ import (
 	"sync"
 )
 
-// knownAgent maps an environment variable to an agent product name.
-type knownAgent struct {
-	envVar  string
-	product string
+// envMatcher matches an environment variable. If value is empty, matching is
+// presence-only (any value, including empty string, counts as a match). If
+// value is non-empty, the env var must be set to exactly that value.
+type envMatcher struct {
+	envVar string
+	value  string
 }
+
+// knownAgent describes a single AI coding agent and the environment matchers
+// that identify it. The agent is detected if ANY matcher in matchAny fires.
+type knownAgent struct {
+	product  string
+	matchAny []envMatcher
+}
+
+// agentEnvVar is the agents.md standard env var. When set to a value we
+// don't specifically recognize, detection falls back to "unknown".
+const agentEnvVar = "AGENT"
 
 // listKnownAgents returns the canonical list of AI coding agents.
 // Keep this list in sync with databricks-sdk-py and databricks-sdk-java.
+// Agents are listed alphabetically by product name.
 func listKnownAgents() []knownAgent {
 	return []knownAgent{
-		{"ANTIGRAVITY_AGENT", "antigravity"}, // Closed source (Google)
-		{"CLAUDECODE", "claude-code"},        // https://github.com/anthropics/claude-code
-		{"CLINE_ACTIVE", "cline"},            // https://github.com/cline/cline (v3.24.0+)
-		{"CODEX_CI", "codex"},                // https://github.com/openai/codex
-		{"COPILOT_CLI", "copilot-cli"},       // https://github.com/features/copilot
-		{"CURSOR_AGENT", "cursor"},           // Closed source
-		{"GEMINI_CLI", "gemini-cli"},         // https://google-gemini.github.io/gemini-cli
-		{"OPENCODE", "opencode"},             // https://github.com/opencode-ai/opencode
-		{"OPENCLAW_SHELL", "openclaw"},       // https://github.com/anthropics/openclaw
+		{
+			product: "amp",
+			matchAny: []envMatcher{
+				{envVar: "AMP_CURRENT_THREAD_ID"},
+				{envVar: agentEnvVar, value: "amp"},
+			},
+		},
+		{
+			product: "antigravity",
+			matchAny: []envMatcher{
+				{envVar: "ANTIGRAVITY_AGENT"}, // Closed source (Google)
+			},
+		},
+		{
+			product: "augment",
+			matchAny: []envMatcher{
+				{envVar: "AUGMENT_AGENT"},
+			},
+		},
+		{
+			product: "claude-code",
+			matchAny: []envMatcher{
+				{envVar: "CLAUDECODE"}, // https://github.com/anthropics/claude-code
+			},
+		},
+		{
+			product: "cline",
+			matchAny: []envMatcher{
+				{envVar: "CLINE_ACTIVE"}, // https://github.com/cline/cline (v3.24.0+)
+			},
+		},
+		{
+			product: "codex",
+			matchAny: []envMatcher{
+				{envVar: "CODEX_CI"}, // https://github.com/openai/codex
+			},
+		},
+		{
+			product: "copilot-cli",
+			matchAny: []envMatcher{
+				{envVar: "COPILOT_CLI"}, // https://github.com/features/copilot
+			},
+		},
+		{
+			product: "copilot-vscode",
+			matchAny: []envMatcher{
+				{envVar: "COPILOT_MODEL"}, // VS Code Copilot
+			},
+		},
+		{
+			product: "cursor",
+			matchAny: []envMatcher{
+				{envVar: "CURSOR_AGENT"}, // Closed source
+			},
+		},
+		{
+			product: "gemini-cli",
+			matchAny: []envMatcher{
+				{envVar: "GEMINI_CLI"}, // https://google-gemini.github.io/gemini-cli
+			},
+		},
+		{
+			product: "goose",
+			matchAny: []envMatcher{
+				{envVar: "GOOSE_TERMINAL"},
+				{envVar: agentEnvVar, value: "goose"},
+			},
+		},
+		{
+			product: "kiro",
+			matchAny: []envMatcher{
+				{envVar: "KIRO"},
+			},
+		},
+		{
+			product: "opencode",
+			matchAny: []envMatcher{
+				{envVar: "OPENCODE"}, // https://github.com/opencode-ai/opencode
+			},
+		},
+		{
+			product: "openclaw",
+			matchAny: []envMatcher{
+				{envVar: "OPENCLAW_SHELL"}, // https://github.com/anthropics/openclaw
+			},
+		},
+		{
+			product: "windsurf",
+			matchAny: []envMatcher{
+				{envVar: "WINDSURF_AGENT"},
+			},
+		},
 	}
 }
 
-// lookupAgentProvider checks environment for known agent env vars.
-// Returns the product name if exactly one is set.
-// Returns empty string if zero or multiple are set.
+// matcherFires returns true if the matcher's env var is set (for presence
+// checks) or set to the exact expected value (for value checks).
+func matcherFires(m envMatcher) bool {
+	v, ok := os.LookupEnv(m.envVar)
+	if !ok {
+		return false
+	}
+	if m.value == "" {
+		return true
+	}
+	return v == m.value
+}
+
+// lookupAgentProvider checks environment variables for known AI agents.
+//
+// For each agent, it fires if ANY of its matchers fires. The function counts
+// how many distinct agents matched:
+//   - Exactly one agent matched: return its product name.
+//   - More than one agent matched: return "" (ambiguity).
+//   - Zero agents matched: if the agents.md standard AGENT env var is set to
+//     any non-empty value, return "unknown". Otherwise return "".
 //
 // Unlike CI/CD detection (which returns the first match), agent detection
-// uses an ambiguity guard: multiple matches return empty. This is because
-// CI/CD providers are mutually exclusive in practice, but agent env vars
-// can be stacked (e.g., running Cline inside Cursor).
+// uses an ambiguity guard because agent env vars can be stacked (e.g., running
+// Cline inside Cursor).
 func lookupAgentProvider() string {
 	var detected string
 	count := 0
 	for _, a := range listKnownAgents() {
-		if _, ok := os.LookupEnv(a.envVar); ok {
+		fired := false
+		for _, m := range a.matchAny {
+			if matcherFires(m) {
+				fired = true
+				break
+			}
+		}
+		if fired {
 			detected = a.product
 			count++
 			if count > 1 {
@@ -49,6 +170,11 @@ func lookupAgentProvider() string {
 	}
 	if count == 1 {
 		return detected
+	}
+	if count == 0 {
+		if v, ok := os.LookupEnv(agentEnvVar); ok && v != "" {
+			return "unknown"
+		}
 	}
 	return ""
 }

--- a/useragent/agent.go
+++ b/useragent/agent.go
@@ -32,9 +32,9 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "amp",
 			matchAny: []envMatcher{
-				// https://ampcode.com/ (sets AMP_CURRENT_THREAD_ID and AGENT=amp)
+				// https://ampcode.com/ (also sets AGENT=amp, handled by the
+				// central fallback in lookupAgentProvider).
 				{envVar: "AMP_CURRENT_THREAD_ID"},
-				{envVar: agentEnvVar, value: "amp"},
 			},
 		},
 		{
@@ -95,9 +95,9 @@ func listKnownAgents() []knownAgent {
 		{
 			product: "goose",
 			matchAny: []envMatcher{
-				// https://block.github.io/goose/ (sets GOOSE_TERMINAL and AGENT=goose)
+				// https://block.github.io/goose/ (also sets AGENT=goose, handled
+				// by the central fallback in lookupAgentProvider).
 				{envVar: "GOOSE_TERMINAL"},
-				{envVar: agentEnvVar, value: "goose"},
 			},
 		},
 		{
@@ -142,8 +142,13 @@ func matcherFires(m envMatcher) bool {
 
 // lookupAgentProvider checks environment variables for known AI agents.
 //
+// Explicit product-specific env vars always take precedence over the generic
+// agents.md AGENT env var. AGENT is consulted only as a fallback when no
+// explicit matcher fires, so that an explicit signal (e.g. CLAUDECODE=1)
+// always wins over a conflicting AGENT=<name> value.
+//
 // For each agent, it fires if ANY of its matchers fires. The function counts
-// how many distinct agents matched:
+// how many distinct agents matched via explicit matchers:
 //   - Exactly one agent matched: return its product name.
 //   - More than one agent matched: return "" (ambiguity).
 //   - Zero agents matched: if the agents.md standard AGENT env var is set to
@@ -197,7 +202,14 @@ var (
 )
 
 // AgentProvider returns the detected AI agent name, cached for the process lifetime.
-// Returns empty string if no agent or multiple agents detected.
+// Returns one of:
+//   - the known product name when exactly one agent is detected via explicit
+//     env matchers, or when AGENT is set to a known product name and no
+//     explicit matcher fired;
+//   - "unknown" when no explicit matcher fired and AGENT is set to a value
+//     that is not a known product name;
+//   - "" when no agent is detected, or when multiple explicit matchers fire
+//     for different agents (ambiguity).
 func AgentProvider() string {
 	agentOnce.Do(func() {
 		agentName = lookupAgentProvider()

--- a/useragent/agent.go
+++ b/useragent/agent.go
@@ -5,19 +5,12 @@ import (
 	"sync"
 )
 
-// envMatcher matches an environment variable. If value is empty, matching is
-// presence-only (any value, including empty string, counts as a match). If
-// value is non-empty, the env var must be set to exactly that value.
-type envMatcher struct {
-	envVar string
-	value  string
-}
-
-// knownAgent describes a single AI coding agent and the environment matchers
-// that identify it. The agent is detected if ANY matcher in matchAny fires.
+// knownAgent describes a single AI coding agent and the environment variable
+// that identifies it. The agent is detected if envVar is set (any value,
+// including the empty string, counts as a match).
 type knownAgent struct {
-	product  string
-	matchAny []envMatcher
+	envVar  string
+	product string
 }
 
 // agentEnvVar is the agents.md standard env var. When set to a value we
@@ -29,115 +22,22 @@ const agentEnvVar = "AGENT"
 // Agents are listed alphabetically by product name.
 func listKnownAgents() []knownAgent {
 	return []knownAgent{
-		{
-			product: "amp",
-			matchAny: []envMatcher{
-				// https://ampcode.com/ (also sets AGENT=amp, handled by the
-				// central fallback in lookupAgentProvider).
-				{envVar: "AMP_CURRENT_THREAD_ID"},
-			},
-		},
-		{
-			product: "antigravity",
-			matchAny: []envMatcher{
-				{envVar: "ANTIGRAVITY_AGENT"}, // Closed source (Google)
-			},
-		},
-		{
-			product: "augment",
-			matchAny: []envMatcher{
-				{envVar: "AUGMENT_AGENT"}, // https://www.augmentcode.com/
-			},
-		},
-		{
-			product: "claude-code",
-			matchAny: []envMatcher{
-				{envVar: "CLAUDECODE"}, // https://github.com/anthropics/claude-code
-			},
-		},
-		{
-			product: "cline",
-			matchAny: []envMatcher{
-				{envVar: "CLINE_ACTIVE"}, // https://github.com/cline/cline (v3.24.0+)
-			},
-		},
-		{
-			product: "codex",
-			matchAny: []envMatcher{
-				{envVar: "CODEX_CI"}, // https://github.com/openai/codex
-			},
-		},
-		{
-			product: "copilot-cli",
-			matchAny: []envMatcher{
-				{envVar: "COPILOT_CLI"}, // https://github.com/features/copilot
-			},
-		},
-		{
-			product: "copilot-vscode",
-			matchAny: []envMatcher{
-				// VS Code Copilot terminal, best-effort heuristic, not officially identified
-				{envVar: "COPILOT_MODEL"},
-			},
-		},
-		{
-			product: "cursor",
-			matchAny: []envMatcher{
-				{envVar: "CURSOR_AGENT"}, // Closed source
-			},
-		},
-		{
-			product: "gemini-cli",
-			matchAny: []envMatcher{
-				{envVar: "GEMINI_CLI"}, // https://google-gemini.github.io/gemini-cli
-			},
-		},
-		{
-			product: "goose",
-			matchAny: []envMatcher{
-				// https://block.github.io/goose/ (also sets AGENT=goose, handled
-				// by the central fallback in lookupAgentProvider).
-				{envVar: "GOOSE_TERMINAL"},
-			},
-		},
-		{
-			product: "kiro",
-			matchAny: []envMatcher{
-				{envVar: "KIRO"}, // https://kiro.dev/ (Amazon)
-			},
-		},
-		{
-			product: "openclaw",
-			matchAny: []envMatcher{
-				{envVar: "OPENCLAW_SHELL"}, // https://github.com/anthropics/openclaw
-			},
-		},
-		{
-			product: "opencode",
-			matchAny: []envMatcher{
-				{envVar: "OPENCODE"}, // https://github.com/opencode-ai/opencode
-			},
-		},
-		{
-			product: "windsurf",
-			matchAny: []envMatcher{
-				{envVar: "WINDSURF_AGENT"}, // https://codeium.com/windsurf (Codeium)
-			},
-		},
+		{envVar: "AMP_CURRENT_THREAD_ID", product: "amp"},     // https://ampcode.com/ (also sets AGENT=amp, handled by the central fallback in lookupAgentProvider)
+		{envVar: "ANTIGRAVITY_AGENT", product: "antigravity"}, // Closed source (Google)
+		{envVar: "AUGMENT_AGENT", product: "augment"},         // https://www.augmentcode.com/
+		{envVar: "CLAUDECODE", product: "claude-code"},        // https://github.com/anthropics/claude-code
+		{envVar: "CLINE_ACTIVE", product: "cline"},            // https://github.com/cline/cline (v3.24.0+)
+		{envVar: "CODEX_CI", product: "codex"},                // https://github.com/openai/codex
+		{envVar: "COPILOT_CLI", product: "copilot-cli"},       // https://github.com/features/copilot
+		{envVar: "COPILOT_MODEL", product: "copilot-vscode"},  // VS Code Copilot terminal, best-effort heuristic, not officially identified
+		{envVar: "CURSOR_AGENT", product: "cursor"},           // Closed source
+		{envVar: "GEMINI_CLI", product: "gemini-cli"},         // https://google-gemini.github.io/gemini-cli
+		{envVar: "GOOSE_TERMINAL", product: "goose"},          // https://block.github.io/goose/ (also sets AGENT=goose, handled by the central fallback in lookupAgentProvider)
+		{envVar: "KIRO", product: "kiro"},                     // https://kiro.dev/ (Amazon)
+		{envVar: "OPENCLAW_SHELL", product: "openclaw"},       // https://github.com/anthropics/openclaw
+		{envVar: "OPENCODE", product: "opencode"},             // https://github.com/opencode-ai/opencode
+		{envVar: "WINDSURF_AGENT", product: "windsurf"},       // https://codeium.com/windsurf (Codeium)
 	}
-}
-
-// matcherFires returns true if the matcher's env var is set (for presence
-// checks) or set to the exact expected value (for value checks).
-func matcherFires(m envMatcher) bool {
-	v, ok := os.LookupEnv(m.envVar)
-	if !ok {
-		return false
-	}
-	if m.value == "" {
-		return true
-	}
-	return v == m.value
 }
 
 // lookupAgentProvider checks environment variables for known AI agents.
@@ -147,8 +47,7 @@ func matcherFires(m envMatcher) bool {
 // explicit matcher fires, so that an explicit signal (e.g. CLAUDECODE=1)
 // always wins over a conflicting AGENT=<name> value.
 //
-// For each agent, it fires if ANY of its matchers fires. The function counts
-// how many distinct agents matched via explicit matchers:
+// The function counts how many distinct agents matched via explicit env vars:
 //   - Exactly one agent matched: return its product name.
 //   - More than one agent matched: return "" (ambiguity).
 //   - Zero agents matched: if the agents.md standard AGENT env var is set to
@@ -160,40 +59,38 @@ func matcherFires(m envMatcher) bool {
 // Cline inside Cursor).
 func lookupAgentProvider() string {
 	agents := listKnownAgents()
-	var detected string
-	count := 0
+
+	var matches []string
 	for _, a := range agents {
-		fired := false
-		for _, m := range a.matchAny {
-			if matcherFires(m) {
-				fired = true
-				break
-			}
-		}
-		if fired {
-			detected = a.product
-			count++
-			if count > 1 {
-				break
-			}
+		if _, ok := os.LookupEnv(a.envVar); ok {
+			matches = append(matches, a.product)
 		}
 	}
-	if count == 1 {
-		return detected
+
+	switch len(matches) {
+	case 1:
+		return matches[0]
+	case 0:
+		return agentEnvFallback(agents)
+	default:
+		return "" // ambiguity: multiple distinct agents matched
 	}
-	if count == 0 {
-		if v, ok := os.LookupEnv(agentEnvVar); ok && v != "" {
-			// Honor the agents.md standard: if AGENT is set to a known product
-			// name that wasn't caught by any explicit matcher, report it directly.
-			for _, a := range agents {
-				if a.product == v {
-					return v
-				}
-			}
-			return "unknown"
+}
+
+// agentEnvFallback honors the agents.md AGENT=<name> standard.
+// Returns the value if it matches a known product name, "unknown" if AGENT
+// is set to any other non-empty value, and "" if AGENT is unset or empty.
+func agentEnvFallback(agents []knownAgent) string {
+	v, ok := os.LookupEnv(agentEnvVar)
+	if !ok || v == "" {
+		return ""
+	}
+	for _, a := range agents {
+		if a.product == v {
+			return v
 		}
 	}
-	return ""
+	return "unknown"
 }
 
 var (

--- a/useragent/agent_test.go
+++ b/useragent/agent_test.go
@@ -149,10 +149,23 @@ func TestLookupAgentProvider(t *testing.T) {
 			envs:   map[string]string{"AGENT": "somethingunknown", "CLAUDECODE": "1"},
 			expect: "claude-code",
 		},
-		// Cross-agent ambiguity cases.
+		// Explicit env var always wins over the generic AGENT env var.
 		{
-			name:   "AGENT=goose and CLAUDECODE is ambiguous",
+			name:   "explicit CLAUDECODE wins over AGENT=goose",
 			envs:   map[string]string{"AGENT": "goose", "CLAUDECODE": "1"},
+			expect: "claude-code",
+		},
+		{
+			name:   "explicit GOOSE_TERMINAL wins over AGENT=cursor",
+			envs:   map[string]string{"GOOSE_TERMINAL": "1", "AGENT": "cursor"},
+			expect: "goose",
+		},
+		// Cross-agent ambiguity: two explicit matchers fire on different
+		// products. This pins the known ambiguity for Copilot CLI BYOK users
+		// who set COPILOT_MODEL alongside COPILOT_CLI.
+		{
+			name:   "COPILOT_CLI and COPILOT_MODEL together is ambiguous",
+			envs:   map[string]string{"COPILOT_CLI": "1", "COPILOT_MODEL": "gpt-4"},
 			expect: "",
 		},
 	}

--- a/useragent/agent_test.go
+++ b/useragent/agent_test.go
@@ -63,9 +63,14 @@ func TestLookupAgentProvider(t *testing.T) {
 			expect: "openclaw",
 		},
 		{
-			name:   "multiple agents",
+			name:   "multiple agents stacked (e.g. Cursor CLI subagent invoked by Claude Code)",
 			envs:   map[string]string{"CLAUDECODE": "1", "CURSOR_AGENT": "1"},
-			expect: "",
+			expect: "multiple",
+		},
+		{
+			name:   "three stacked agents also report multiple",
+			envs:   map[string]string{"CLAUDECODE": "1", "CURSOR_AGENT": "1", "AUGMENT_AGENT": "1"},
+			expect: "multiple",
 		},
 		{
 			name:   "empty value still counts as set",
@@ -160,13 +165,18 @@ func TestLookupAgentProvider(t *testing.T) {
 			envs:   map[string]string{"GOOSE_TERMINAL": "1", "AGENT": "cursor"},
 			expect: "goose",
 		},
-		// Cross-agent ambiguity: two explicit matchers fire on different
-		// products. This pins the known ambiguity for Copilot CLI BYOK users
-		// who set COPILOT_MODEL alongside COPILOT_CLI.
+		// Known BYOK false positive: Copilot CLI users often set COPILOT_MODEL
+		// alongside COPILOT_CLI. The pair is treated as a single copilot-cli
+		// signal rather than a stacked multi-agent setup.
 		{
-			name:   "COPILOT_CLI and COPILOT_MODEL together is ambiguous",
+			name:   "COPILOT_CLI + COPILOT_MODEL collapses to copilot-cli (BYOK)",
 			envs:   map[string]string{"COPILOT_CLI": "1", "COPILOT_MODEL": "gpt-4"},
-			expect: "",
+			expect: "copilot-cli",
+		},
+		{
+			name:   "COPILOT_CLI + COPILOT_MODEL + CLAUDECODE still reports multiple after BYOK collapse",
+			envs:   map[string]string{"COPILOT_CLI": "1", "COPILOT_MODEL": "gpt-4", "CLAUDECODE": "1"},
+			expect: "multiple",
 		},
 	}
 

--- a/useragent/agent_test.go
+++ b/useragent/agent_test.go
@@ -72,6 +72,74 @@ func TestLookupAgentProvider(t *testing.T) {
 			envs:   map[string]string{"CLAUDECODE": ""},
 			expect: "claude-code",
 		},
+		// New agent detections.
+		{
+			name:   "goose via GOOSE_TERMINAL",
+			envs:   map[string]string{"GOOSE_TERMINAL": "1"},
+			expect: "goose",
+		},
+		{
+			name:   "goose via AGENT",
+			envs:   map[string]string{"AGENT": "goose"},
+			expect: "goose",
+		},
+		{
+			name:   "goose via both GOOSE_TERMINAL and AGENT is not ambiguous",
+			envs:   map[string]string{"GOOSE_TERMINAL": "1", "AGENT": "goose"},
+			expect: "goose",
+		},
+		{
+			name:   "amp via AMP_CURRENT_THREAD_ID",
+			envs:   map[string]string{"AMP_CURRENT_THREAD_ID": "abc123"},
+			expect: "amp",
+		},
+		{
+			name:   "amp via AGENT",
+			envs:   map[string]string{"AGENT": "amp"},
+			expect: "amp",
+		},
+		{
+			name:   "amp via both AMP_CURRENT_THREAD_ID and AGENT is not ambiguous",
+			envs:   map[string]string{"AMP_CURRENT_THREAD_ID": "abc123", "AGENT": "amp"},
+			expect: "amp",
+		},
+		{
+			name:   "augment",
+			envs:   map[string]string{"AUGMENT_AGENT": "1"},
+			expect: "augment",
+		},
+		{
+			name:   "copilot vscode",
+			envs:   map[string]string{"COPILOT_MODEL": "gpt-4"},
+			expect: "copilot-vscode",
+		},
+		{
+			name:   "kiro",
+			envs:   map[string]string{"KIRO": "1"},
+			expect: "kiro",
+		},
+		{
+			name:   "windsurf",
+			envs:   map[string]string{"WINDSURF_AGENT": "1"},
+			expect: "windsurf",
+		},
+		// AGENT fallback behavior.
+		{
+			name:   "AGENT with unknown value falls back to unknown",
+			envs:   map[string]string{"AGENT": "someweirdthing"},
+			expect: "unknown",
+		},
+		{
+			name:   "AGENT empty string does not trigger fallback",
+			envs:   map[string]string{"AGENT": ""},
+			expect: "",
+		},
+		// Cross-agent ambiguity cases.
+		{
+			name:   "AGENT=goose and CLAUDECODE is ambiguous",
+			envs:   map[string]string{"AGENT": "goose", "CLAUDECODE": "1"},
+			expect: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/useragent/agent_test.go
+++ b/useragent/agent_test.go
@@ -134,6 +134,21 @@ func TestLookupAgentProvider(t *testing.T) {
 			envs:   map[string]string{"AGENT": ""},
 			expect: "",
 		},
+		{
+			name:   "AGENT=cursor falls back to cursor via known product name",
+			envs:   map[string]string{"AGENT": "cursor"},
+			expect: "cursor",
+		},
+		{
+			name:   "AGENT=claude-code falls back to claude-code via known product name",
+			envs:   map[string]string{"AGENT": "claude-code"},
+			expect: "claude-code",
+		},
+		{
+			name:   "known matcher wins over AGENT fallback",
+			envs:   map[string]string{"AGENT": "somethingunknown", "CLAUDECODE": "1"},
+			expect: "claude-code",
+		},
 		// Cross-agent ambiguity cases.
 		{
 			name:   "AGENT=goose and CLAUDECODE is ambiguous",


### PR DESCRIPTION
## Why

We identify which AI agent is driving the SDK via the `agent/<name>` user-agent segment. The current list covers 9 agents. This adds 6 more and honors the emerging `AGENT=<name>` standard from agents.md so we can report something useful for agents we haven't individually coded for.

## Changes

Before: presence-only matching on a fixed list of env vars. If any two matched, the result was empty.

Now: each agent has a list of matchers (presence or exact value). An agent fires if any of its matchers fires, and ambiguity is judged by how many distinct agents matched (not how many matchers). An `AGENT=<anything>` env var with no other agent match falls back to `unknown`.

New detections: Goose (`GOOSE_TERMINAL`, `AGENT=goose`), Amp (`AMP_CURRENT_THREAD_ID`, `AGENT=amp`), Augment (`AUGMENT_AGENT`), Copilot VS Code (`COPILOT_MODEL`), Kiro (`KIRO`), Windsurf (`WINDSURF_AGENT`).

Sibling PRs track the same change in the Java and Python SDKs.

## Test plan

- [x] Unit tests cover every new agent
- [x] `AGENT=goose` + `GOOSE_TERMINAL` resolves to a single `goose` (not ambiguity)
- [x] `AGENT=<unrecognized>` falls back to `unknown`
- [x] `AGENT=""` (empty) does not trigger the fallback
- [x] Two distinct agents set simultaneously still return empty
- [x] `make fmt test lint` passes