### PR TITLE
Split trigger-tests job and route workflow dispatch through emu-access runner

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,8 +31,8 @@ jobs:
             echo "has_token=true" >> $GITHUB_OUTPUT
           fi
 
-  trigger-tests:
-    name: Trigger Tests
+  create-check:
+    name: Create Check Run
 
     runs-on:
       group: databricks-deco-testing-runner-group
@@ -41,6 +41,8 @@ jobs:
     needs: check-token
     if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
     environment: "test-trigger-is"
+    outputs:
+      check_run_id: ${{ steps.create-check.outputs.check_run_id }}
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -69,6 +71,20 @@ jobs:
         check_run_id=$(echo "$response" | jq -r .id)
         echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
 
+  trigger-tests:
+    name: Trigger Tests
+
+    runs-on:
+      group: databricks-release-runner-group-emu-access
+      labels: linux-ubuntu-latest-emu-access
+
+    needs: [check-token, create-check]
+    if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
+    environment: "test-trigger-is"
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
     - name: Generate GitHub App Token for Workflow Trigger
       id: generate-token
       uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -86,7 +102,7 @@ jobs:
         --ref main \
         -f pull_request_number=${{ github.event.pull_request.number }} \
         -f commit_sha=${{ github.event.pull_request.head.sha }} \
-        -f check_run_id=${{ steps.create-check.outputs.check_run_id }}
+        -f check_run_id=${{ needs.create-check.outputs.check_run_id }}
 
 
   # The hash for the merge queue may not be the same as the hash for the PR.


### PR DESCRIPTION
## Summary

Fixes automated Integration Tests for PRs on this repo. Splits `trigger-tests`
into `create-check` (stays on deco runners, creates the check run on this
repo) and `trigger-tests` (moves to `databricks-release-runner-group-emu-access`
to perform the cross-org dispatch to `databricks-eng/eng-dev-ecosystem`).

## Why

Since the `databricks` org tightened its IP allow list (between 2026-04-17
and 2026-04-20), the deco runner group can no longer call
`/repos/databricks-eng/.../installation`, so `create-github-app-token` fails
with 403 and no dispatch is sent. Every PR-triggered Integration Tests run
on this repo has failed at that step since. Merges only work because
`merge_group` auto-approves without running tests.

## What changed

Exactly the diff from Hector's #1616, which was already verified green
end-to-end on 2026-04-10.

Supersedes #1616.

## How is this tested

The PR's own Integration Tests run is the test. Confirms:
- `create-check`: success (check run appears on PR head)
- `trigger-tests`: success (`sdk-go-isolated-pr` dispatch appears on
  `databricks-eng/eng-dev-ecosystem`, event `workflow_dispatch`)
- dispatched eng-dev run completes with `mark-as-pending`/`success`/`failure`
  green (post-#1250)
- the Integration Tests check on the PR transitions `in_progress` → `success`

NO_CHANGELOG=true