### PR TITLE
Add WithDiscoveryHost option for discovery login flow

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+ * Add `u2m.WithDiscoveryHost` option to override the default `https://login.databricks.com` host used by the discovery login flow. Intended for testing and development against non-production environments.
+
 ### Bug Fixes
 
 ### Documentation

--- a/credentials/u2m/discovery_token_source.go
+++ b/credentials/u2m/discovery_token_source.go
@@ -8,7 +8,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const loginDatabricksHost = "https://login.databricks.com"
+// defaultLoginDatabricksHost is the production host used for discovery login
+// when no override is configured via WithDiscoveryHost.
+const defaultLoginDatabricksHost = "https://login.databricks.com"
 
 // DeriveHostFromIssuer extracts the workspace host (scheme + host) from an
 // issuer URL returned in the OAuth callback iss parameter.
@@ -50,6 +52,13 @@ func DeriveTokenEndpoint(issuer string) string {
 // the discovery OAuth flow. The OIDC authorize path with all OAuth query params
 // is URL-encoded as the destination_url parameter.
 func BuildDiscoveryAuthorizeURL(redirectAddr, state string, pkce PKCEParams, scopes []string) string {
+	return buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, redirectAddr, state, pkce, scopes)
+}
+
+// buildDiscoveryAuthorizeURL builds the discovery authorize URL against the
+// given host. Trailing slashes on host are trimmed so the result is
+// well-formed regardless of how an override is written.
+func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParams, scopes []string) string {
 	// Build the nested OIDC authorize path with query parameters.
 	authParams := url.Values{}
 	authParams.Set("client_id", appClientID)
@@ -61,11 +70,11 @@ func BuildDiscoveryAuthorizeURL(redirectAddr, state string, pkce PKCEParams, sco
 	authParams.Set("code_challenge_method", pkce.ChallengeMethod)
 	destinationURL := "/oidc/v1/authorize?" + authParams.Encode()
 
-	// Wrap the authorize path as the destination_url query parameter on
-	// login.databricks.com.
+	// Wrap the authorize path as the destination_url query parameter on the
+	// discovery host.
 	topParams := url.Values{}
 	topParams.Set("destination_url", destinationURL)
-	return loginDatabricksHost + "/?" + topParams.Encode()
+	return strings.TrimRight(host, "/") + "/?" + topParams.Encode()
 }
 
 // PKCEParams holds the PKCE challenge parameters used to build the discovery
@@ -82,6 +91,8 @@ type PKCEParams struct {
 // until the callback provides the iss parameter identifying the workspace.
 type discoveryTokenSource struct {
 	pa *PersistentAuth
+	// host overrides defaultLoginDatabricksHost when non-empty.
+	host string
 }
 
 // challenge initiates the discovery OAuth flow through login.databricks.com.
@@ -107,7 +118,11 @@ func (d *discoveryTokenSource) challenge() error {
 		ChallengeMethod: authPKCE.ChallengeMethod,
 		Verifier:        authPKCE.Verifier,
 	}
-	authorizeURL := BuildDiscoveryAuthorizeURL(d.pa.redirectAddr, state, pkce, scopes)
+	host := d.host
+	if host == "" {
+		host = defaultLoginDatabricksHost
+	}
+	authorizeURL := buildDiscoveryAuthorizeURL(host, d.pa.redirectAddr, state, pkce, scopes)
 
 	// Use cb.Handler to open the browser and wait for the callback.
 	code, returnedState, err := cb.Handler(authorizeURL)
@@ -126,7 +141,7 @@ func (d *discoveryTokenSource) challenge() error {
 	}
 
 	// Derive host and token endpoint from the issuer.
-	host, err := DeriveHostFromIssuer(issuer)
+	discoveredHost, err := DeriveHostFromIssuer(issuer)
 	if err != nil {
 		return fmt.Errorf("deriving host from issuer: %w", err)
 	}
@@ -152,7 +167,7 @@ func (d *discoveryTokenSource) challenge() error {
 	if !ok {
 		return fmt.Errorf("discovery login requires DiscoveryOAuthArgument, got %T", d.pa.oAuthArgument)
 	}
-	discoveryArg.SetDiscoveredHost(host)
+	discoveryArg.SetDiscoveredHost(discoveredHost)
 
 	// Cache the token using both the profile key and the discovered host key.
 	if err := d.pa.dualWrite(token); err != nil {

--- a/credentials/u2m/discovery_token_source_test.go
+++ b/credentials/u2m/discovery_token_source_test.go
@@ -165,6 +165,143 @@ func TestBuildDiscoveryAuthorizeURL(t *testing.T) {
 	}
 }
 
+func TestBuildDiscoveryAuthorizeURL_HostOverride(t *testing.T) {
+	pkce := PKCEParams{
+		Challenge:       "c",
+		ChallengeMethod: "S256",
+		Verifier:        "v",
+	}
+	scopes := []string{"offline_access", "all-apis"}
+	tests := []struct {
+		name     string
+		host     string
+		wantHost string
+	}{
+		{
+			name:     "default host",
+			host:     defaultLoginDatabricksHost,
+			wantHost: "login.databricks.com",
+		},
+		{
+			name:     "custom host",
+			host:     "https://login.dev.databricks.com",
+			wantHost: "login.dev.databricks.com",
+		},
+		{
+			name:     "custom host with trailing slash",
+			host:     "https://login.dev.databricks.com/",
+			wantHost: "login.dev.databricks.com",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDiscoveryAuthorizeURL(tc.host, "localhost:8020", "s", pkce, scopes)
+			u, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("parsing URL: %v", err)
+			}
+			if u.Host != tc.wantHost {
+				t.Errorf("host = %q, want %q", u.Host, tc.wantHost)
+			}
+			if u.Query().Get("destination_url") == "" {
+				t.Error("destination_url is empty")
+			}
+		})
+	}
+}
+
+func TestDiscoveryTokenSource_Challenge_HostOverride(t *testing.T) {
+	// Mock token server stands in for the workspace OIDC token endpoint.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":"a","refresh_token":"r","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer tokenServer.Close()
+	issuer := tokenServer.URL + "/oidc"
+
+	browserOpened := make(chan string, 1)
+	browserMock := func(u string) error {
+		browserOpened <- u
+		return nil
+	}
+
+	cacheMock := &tokenCacheMock{
+		store: func(key string, tok *oauth2.Token) error { return nil },
+	}
+
+	arg, err := NewBasicDiscoveryOAuthArgument("test-profile")
+	if err != nil {
+		t.Fatalf("NewBasicDiscoveryOAuthArgument(): %v", err)
+	}
+
+	const override = "https://login.dev.databricks.com"
+	p, err := NewPersistentAuth(
+		context.Background(),
+		WithTokenCache(cacheMock),
+		WithBrowser(browserMock),
+		WithHttpClient(tokenServer.Client()),
+		WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
+		WithOAuthArgument(arg),
+		WithDiscoveryLogin(),
+		WithDiscoveryHost(override),
+	)
+	if err != nil {
+		t.Fatalf("NewPersistentAuth(): %v", err)
+	}
+
+	if p.discoveryHost != override {
+		t.Errorf("discoveryHost = %q, want %q", p.discoveryHost, override)
+	}
+
+	if err := p.startListener(context.Background()); err != nil {
+		t.Fatalf("startListener(): %v", err)
+	}
+	defer p.Close()
+
+	dts := &discoveryTokenSource{pa: p, host: p.discoveryHost}
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- dts.challenge()
+	}()
+
+	var state string
+	select {
+	case authURL := <-browserOpened:
+		u, err := url.Parse(authURL)
+		if err != nil {
+			t.Fatalf("parsing auth URL: %v", err)
+		}
+		if u.Scheme != "https" || u.Host != "login.dev.databricks.com" {
+			t.Errorf("authorize URL host = %s://%s, want https://login.dev.databricks.com", u.Scheme, u.Host)
+		}
+		dest, err := url.Parse(u.Query().Get("destination_url"))
+		if err != nil {
+			t.Fatalf("parsing destination_url: %v", err)
+		}
+		state = dest.Query().Get("state")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for browser to be called")
+	}
+
+	callbackURL := fmt.Sprintf("http://%s?code=test-code&state=%s&iss=%s",
+		p.redirectAddr, url.QueryEscape(state), url.QueryEscape(issuer))
+	resp, err := http.Get(callbackURL)
+	if err != nil {
+		t.Fatalf("callback GET: %v", err)
+	}
+	resp.Body.Close()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("challenge(): %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for challenge to complete")
+	}
+}
+
 func TestDiscoveryTokenSource_Challenge(t *testing.T) {
 	// Create a mock token server that responds to POST /oidc/v1/token.
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/credentials/u2m/discovery_token_source_test.go
+++ b/credentials/u2m/discovery_token_source_test.go
@@ -199,6 +199,28 @@ func TestBuildDiscoveryAuthorizeURL_HostOverride(t *testing.T) {
 	}
 }
 
+func TestWithDiscoveryHost_NormalizesScheme(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty stays empty", input: "", want: ""},
+		{name: "https preserved", input: "https://login.dev.databricks.com", want: "https://login.dev.databricks.com"},
+		{name: "http preserved", input: "http://localhost:8080", want: "http://localhost:8080"},
+		{name: "no scheme gets https", input: "login.dev.databricks.com", want: "https://login.dev.databricks.com"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var a PersistentAuth
+			WithDiscoveryHost(tc.input)(&a)
+			if a.discoveryHost != tc.want {
+				t.Errorf("discoveryHost = %q, want %q", a.discoveryHost, tc.want)
+			}
+		})
+	}
+}
+
 func TestDiscoveryTokenSource_Challenge(t *testing.T) {
 	// Create a mock token server that responds to POST /oidc/v1/token.
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/credentials/u2m/discovery_token_source_test.go
+++ b/credentials/u2m/discovery_token_source_test.go
@@ -173,24 +173,16 @@ func TestBuildDiscoveryAuthorizeURL_HostOverride(t *testing.T) {
 	}
 	scopes := []string{"offline_access", "all-apis"}
 	tests := []struct {
-		name     string
-		host     string
-		wantHost string
+		name string
+		host string
 	}{
 		{
-			name:     "default host",
-			host:     defaultLoginDatabricksHost,
-			wantHost: "login.databricks.com",
+			name: "custom host",
+			host: "https://login.dev.databricks.com",
 		},
 		{
-			name:     "custom host",
-			host:     "https://login.dev.databricks.com",
-			wantHost: "login.dev.databricks.com",
-		},
-		{
-			name:     "custom host with trailing slash",
-			host:     "https://login.dev.databricks.com/",
-			wantHost: "login.dev.databricks.com",
+			name: "custom host with trailing slash",
+			host: "https://login.dev.databricks.com/",
 		},
 	}
 	for _, tc := range tests {
@@ -200,105 +192,10 @@ func TestBuildDiscoveryAuthorizeURL_HostOverride(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parsing URL: %v", err)
 			}
-			if u.Host != tc.wantHost {
-				t.Errorf("host = %q, want %q", u.Host, tc.wantHost)
-			}
-			if u.Query().Get("destination_url") == "" {
-				t.Error("destination_url is empty")
+			if u.Host != "login.dev.databricks.com" {
+				t.Errorf("host = %q, want login.dev.databricks.com", u.Host)
 			}
 		})
-	}
-}
-
-func TestDiscoveryTokenSource_Challenge_HostOverride(t *testing.T) {
-	// Mock token server stands in for the workspace OIDC token endpoint.
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"access_token":"a","refresh_token":"r","token_type":"Bearer","expires_in":3600}`)
-	}))
-	defer tokenServer.Close()
-	issuer := tokenServer.URL + "/oidc"
-
-	browserOpened := make(chan string, 1)
-	browserMock := func(u string) error {
-		browserOpened <- u
-		return nil
-	}
-
-	cacheMock := &tokenCacheMock{
-		store: func(key string, tok *oauth2.Token) error { return nil },
-	}
-
-	arg, err := NewBasicDiscoveryOAuthArgument("test-profile")
-	if err != nil {
-		t.Fatalf("NewBasicDiscoveryOAuthArgument(): %v", err)
-	}
-
-	const override = "https://login.dev.databricks.com"
-	p, err := NewPersistentAuth(
-		context.Background(),
-		WithTokenCache(cacheMock),
-		WithBrowser(browserMock),
-		WithHttpClient(tokenServer.Client()),
-		WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
-		WithOAuthArgument(arg),
-		WithDiscoveryLogin(),
-		WithDiscoveryHost(override),
-	)
-	if err != nil {
-		t.Fatalf("NewPersistentAuth(): %v", err)
-	}
-
-	if p.discoveryHost != override {
-		t.Errorf("discoveryHost = %q, want %q", p.discoveryHost, override)
-	}
-
-	if err := p.startListener(context.Background()); err != nil {
-		t.Fatalf("startListener(): %v", err)
-	}
-	defer p.Close()
-
-	dts := &discoveryTokenSource{pa: p, host: p.discoveryHost}
-
-	errc := make(chan error, 1)
-	go func() {
-		errc <- dts.challenge()
-	}()
-
-	var state string
-	select {
-	case authURL := <-browserOpened:
-		u, err := url.Parse(authURL)
-		if err != nil {
-			t.Fatalf("parsing auth URL: %v", err)
-		}
-		if u.Scheme != "https" || u.Host != "login.dev.databricks.com" {
-			t.Errorf("authorize URL host = %s://%s, want https://login.dev.databricks.com", u.Scheme, u.Host)
-		}
-		dest, err := url.Parse(u.Query().Get("destination_url"))
-		if err != nil {
-			t.Fatalf("parsing destination_url: %v", err)
-		}
-		state = dest.Query().Get("state")
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for browser to be called")
-	}
-
-	callbackURL := fmt.Sprintf("http://%s?code=test-code&state=%s&iss=%s",
-		p.redirectAddr, url.QueryEscape(state), url.QueryEscape(issuer))
-	resp, err := http.Get(callbackURL)
-	if err != nil {
-		t.Fatalf("callback GET: %v", err)
-	}
-	resp.Body.Close()
-
-	select {
-	case err := <-errc:
-		if err != nil {
-			t.Fatalf("challenge(): %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for challenge to complete")
 	}
 }
 

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -106,6 +106,10 @@ type PersistentAuth struct {
 	// When true, Challenge() uses the discovery token source instead of
 	// the standard authhandler flow.
 	discoveryMode bool
+
+	// discoveryHost overrides the default login.databricks.com host used by
+	// the discovery flow. Empty means the production host.
+	discoveryHost string
 }
 
 type PersistentAuthOption func(*PersistentAuth)
@@ -178,6 +182,16 @@ func WithDisableOfflineAccess(disable bool) PersistentAuthOption {
 func WithDiscoveryLogin() PersistentAuthOption {
 	return func(a *PersistentAuth) {
 		a.discoveryMode = true
+	}
+}
+
+// WithDiscoveryHost overrides the default https://login.databricks.com host
+// used by the discovery login flow. Intended for testing and development
+// against non-production environments; has no effect unless WithDiscoveryLogin
+// is also set. Trailing slashes on host are trimmed.
+func WithDiscoveryHost(host string) PersistentAuthOption {
+	return func(a *PersistentAuth) {
+		a.discoveryHost = host
 	}
 }
 
@@ -440,7 +454,7 @@ func (a *PersistentAuth) discoveryChallenge() error {
 		return fmt.Errorf("starting listener: %w", err)
 	}
 	defer a.Close()
-	ds := &discoveryTokenSource{pa: a}
+	ds := &discoveryTokenSource{pa: a, host: a.discoveryHost}
 	return ds.challenge()
 }
 

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	cache "github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
@@ -188,9 +189,13 @@ func WithDiscoveryLogin() PersistentAuthOption {
 // WithDiscoveryHost overrides the default https://login.databricks.com host
 // used by the discovery login flow. Intended for testing and development
 // against non-production environments; has no effect unless WithDiscoveryLogin
-// is also set. Trailing slashes on host are trimmed.
+// is also set. If host has no scheme, https:// is prepended. Trailing slashes
+// are trimmed.
 func WithDiscoveryHost(host string) PersistentAuthOption {
 	return func(a *PersistentAuth) {
+		if host != "" && !strings.Contains(host, "://") {
+			host = "https://" + host
+		}
 		a.discoveryHost = host
 	}
 }


### PR DESCRIPTION
## Why

The discovery login flow (`WithDiscoveryLogin`) opens a browser to `https://login.databricks.com` to let the user authenticate and select a workspace. That host was hardcoded, which makes it impossible to exercise the flow against non-production instances of the login service during development or testing.

## Changes

Before: `discoveryTokenSource` used the `loginDatabricksHost` constant directly, with no way for callers to override.

Now: a new `WithDiscoveryHost(host)` option on `PersistentAuth` threads a host override through to `discoveryTokenSource`. When empty (the default), the production host is used, so existing callers behave identically.

Implementation notes:
- `BuildDiscoveryAuthorizeURL` keeps its public signature for backwards compatibility. It now delegates to an internal `buildDiscoveryAuthorizeURL(host, ...)` helper with the production default.
- Trailing slashes on the override host are trimmed to keep the resulting URL well-formed.
- The constant was renamed `defaultLoginDatabricksHost` to make its role as a fallback explicit.

## Test plan

- [x] New table-driven test covering override host and override host with trailing slash (default host is already covered by the existing `TestBuildDiscoveryAuthorizeURL`)
- [x] Existing `TestBuildDiscoveryAuthorizeURL` and `TestDiscoveryTokenSource_Challenge` still pass unchanged
- [x] `make fmt test lint` passes