### PR TITLE
Remove legacy tag-triggered release workflow

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release Build Check
 
 on:
   merge_group:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "*" 
   merge_group:
     types: [checks_requested]
 
@@ -54,36 +51,8 @@ jobs:
           echo "GONOSUMCHECK=*" >> $GITHUB_ENV
           echo "GONOSUMDB=*" >> $GITHUB_ENV
 
-      - name: Write release notes to file
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            RELEASE_NOTES_DIR=/tmp/release-notes
-            mkdir -p "$RELEASE_NOTES_DIR"
-            RELEASE_NOTES_FILE="$RELEASE_NOTES_DIR/release-notes.md"
-            git for-each-ref --format='%(body)' ${{ github.ref }} > "$RELEASE_NOTES_FILE"
-            echo "Release notes file: $RELEASE_NOTES_FILE"
-            echo "Release notes contents:"
-            cat "$RELEASE_NOTES_FILE"
-          else
-            echo "Not a release tag, skipping release notes"
-          fi
-
-      - name: Run GoReleaser (Release)
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        with:
-          version: ~> v2
-          # Arguments cannot reference environment variables, so we write the release notes
-          # to a well-known location and use that in the goreleaser command.
-          args: release --clean --release-notes=/tmp/release-notes/release-notes.md
-        env:
-          # use GITHUB_TOKEN that is already available in secrets.GITHUB_TOKEN
-          # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run GoReleaser (Snapshot)
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         with:
           version: ~> v2
           args: release --clean --snapshot


### PR DESCRIPTION
NO_CHANGELOG=true

## Summary
The legacy tag-triggered release workflow is superseded by the secure release pipeline in
`databricks/secure-public-registry-releases-eng`, which now dispatches `tagging.yml` here
to create the tag and consumes it via workflow_dispatch. This PR removes the obsolete
tag-trigger path while preserving the `merge_group` CI dry-run that validates the
GoReleaser configuration on every queued merge.

## What changed
- Dropped the `on: push: tags: ['*']` trigger from `.github/workflows/release.yml`.
- Removed the tag-gated "Write release notes to file" step.
- Removed the "Run GoReleaser (Release)" step (gated on `startsWith(github.ref, 'refs/tags/v')`).
- Dropped the `if: !startsWith(github.ref, 'refs/tags/v')` guard on the Snapshot step, since the workflow now only runs in `merge_group` context.

## What's preserved
- `merge_group` trigger for CI.
- GoReleaser snapshot build (dry-run validation) that runs on every queued merge.
- `tagging.yml` (untouched) — the new entry point invoked by the secure release pipeline.

## Blast radius
Nothing consumes this workflow's output outside of GitHub Releases, which the new pipeline
now produces.