### PR TITLE
CurrentWorkspaceID: always call Me and forward org ID for SPOG routing

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
  * Remove the file-based OAuth token cache from `credentials/u2m/cache`. The removed symbols are `cache.NewFileTokenCache`, `cache.FileTokenCacheOption`, `cache.WithFileLocation`, and the private `tokenCacheFile` struct. The `TokenCache` interface, `ErrNotFound` sentinel, `HostCacheKeyProvider`, and `DiscoveryOAuthArgument` remain exported. `NewPersistentAuth` now defaults to a new in-memory cache (`cache.NewInMemoryTokenCache`) when no `WithTokenCache` option is passed; consumers that relied on the previous file-backed default must supply their own persistent cache. See databricks/cli#5056 for the companion CLI change that moves the file cache into the CLI.
+ * `WorkspaceClient.CurrentWorkspaceID` no longer short-circuits when `Config.WorkspaceID` is set; it always fetches the ID from `/api/2.0/preview/scim/v2/Me`. On unified (SPOG) hosts, `Config.WorkspaceID` is sent in the `X-Databricks-Org-Id` request header so the gateway can route the call to the correct workspace. Callers that relied on the short-circuit to avoid the round-trip, or on having a stale `Config.WorkspaceID` echoed back, will now see a different result. On unified hosts with no `Config.WorkspaceID`, the call now fails at the server (no routing info) instead of at client-side `strconv.ParseInt`.
 
 ### New Features and Improvements
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Breaking Changes
 
  * Remove the file-based OAuth token cache from `credentials/u2m/cache`. The removed symbols are `cache.NewFileTokenCache`, `cache.FileTokenCacheOption`, `cache.WithFileLocation`, and the private `tokenCacheFile` struct. The `TokenCache` interface, `ErrNotFound` sentinel, `HostCacheKeyProvider`, and `DiscoveryOAuthArgument` remain exported. `NewPersistentAuth` now defaults to a new in-memory cache (`cache.NewInMemoryTokenCache`) when no `WithTokenCache` option is passed; consumers that relied on the previous file-backed default must supply their own persistent cache. See databricks/cli#5056 for the companion CLI change that moves the file cache into the CLI.
- * `WorkspaceClient.CurrentWorkspaceID` no longer short-circuits when `Config.WorkspaceID` is set; it always fetches the ID from `/api/2.0/preview/scim/v2/Me`. On unified (SPOG) hosts, `Config.WorkspaceID` is sent in the `X-Databricks-Org-Id` request header so the gateway can route the call to the correct workspace. Callers that relied on the short-circuit to avoid the round-trip, or on having a stale `Config.WorkspaceID` echoed back, will now see a different result. On unified hosts with no `Config.WorkspaceID`, the call now fails at the server (no routing info) instead of at client-side `strconv.ParseInt`.
 
 ### New Features and Improvements
 

--- a/workspace_functions.go
+++ b/workspace_functions.go
@@ -10,16 +10,20 @@ import (
 // CurrentWorkspaceID returns the workspace ID of the workspace that this client is
 // connected to.
 //
-// If Config.WorkspaceID is already set (from the databrickscfg profile, the
-// DATABRICKS_WORKSPACE_ID env var, host metadata, or a ?o= query param extracted
-// by the caller), it is returned without an API round-trip. Otherwise the ID is
-// fetched from the X-Databricks-Org-Id response header on /api/2.0/preview/scim/v2/Me.
+// The ID is fetched from the X-Databricks-Org-Id response header on
+// /api/2.0/preview/scim/v2/Me. On unified (SPOG) hosts, Config.WorkspaceID is
+// sent in the X-Databricks-Org-Id request header to route the call to the
+// correct workspace; on unified hosts with no WorkspaceID set, the request has
+// no routing information and will fail.
 func (w *WorkspaceClient) CurrentWorkspaceID(ctx context.Context) (int64, error) {
-	if w.Config != nil && w.Config.WorkspaceID != "" {
-		return strconv.ParseInt(w.Config.WorkspaceID, 10, 64)
-	}
 	var workspaceIdStr string
-	err := w.apiClient.Do(ctx, "GET", "/api/2.0/preview/scim/v2/Me", httpclient.WithResponseHeader("X-Databricks-Org-Id", &workspaceIdStr))
+	opts := []httpclient.DoOption{
+		httpclient.WithResponseHeader("X-Databricks-Org-Id", &workspaceIdStr),
+	}
+	if w.Config != nil && w.Config.WorkspaceID != "" {
+		opts = append(opts, httpclient.WithRequestHeader("X-Databricks-Org-Id", w.Config.WorkspaceID))
+	}
+	err := w.apiClient.Do(ctx, "GET", "/api/2.0/preview/scim/v2/Me", opts...)
 	if err != nil {
 		return 0, err
 	}

--- a/workspace_functions_test.go
+++ b/workspace_functions_test.go
@@ -9,15 +9,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCurrentWorkspaceIDShortCircuitsWhenConfigHasWorkspaceID(t *testing.T) {
-	// When Config.WorkspaceID is already populated (from profile, ?o= query
-	// param, env var, or host metadata), CurrentWorkspaceID returns it without
-	// hitting the API. This avoids a round-trip and sidesteps SPOG's routing
-	// requirement that requests to /api/2.0/preview/scim/v2/Me carry an
-	// X-Databricks-Org-Id header.
+func TestCurrentWorkspaceIDSendsOrgIdHeaderWhenConfigHasWorkspaceID(t *testing.T) {
+	// On unified (SPOG) hosts, requests to /api/2.0/preview/scim/v2/Me must
+	// carry an X-Databricks-Org-Id header so the gateway can route them to the
+	// correct workspace. When Config.WorkspaceID is set we forward it on the
+	// request, and the server echoes it back on the response header.
+	var meCalls int
+	var gotOrgIdHeader string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/2.0/preview/scim/v2/Me" {
-			t.Errorf("Me() should not be called when Config.WorkspaceID is set")
+			meCalls++
+			gotOrgIdHeader = r.Header.Get("X-Databricks-Org-Id")
+			w.Header().Set("X-Databricks-Org-Id", "7474644166319138")
+			w.Write([]byte(`{}`))
+			return
 		}
 		http.NotFound(w, r)
 	}))
@@ -33,13 +38,21 @@ func TestCurrentWorkspaceIDShortCircuitsWhenConfigHasWorkspaceID(t *testing.T) {
 	got, err := w.CurrentWorkspaceID(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, int64(7474644166319138), got)
+	assert.Equal(t, 1, meCalls)
+	assert.Equal(t, "7474644166319138", gotOrgIdHeader)
 }
 
-func TestCurrentWorkspaceIDFallsBackToAPIWhenConfigMissingWorkspaceID(t *testing.T) {
+func TestCurrentWorkspaceIDOmitsOrgIdHeaderWhenConfigMissingWorkspaceID(t *testing.T) {
+	// On legacy workspace hosts the host itself identifies the workspace, so
+	// no routing header is needed. When Config.WorkspaceID is empty we send
+	// the request without X-Databricks-Org-Id and read the ID from the
+	// response header.
 	var meCalls int
+	var gotOrgIdHeader string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/2.0/preview/scim/v2/Me" {
 			meCalls++
+			gotOrgIdHeader = r.Header.Get("X-Databricks-Org-Id")
 			w.Header().Set("X-Databricks-Org-Id", "7474644166319138")
 			w.Write([]byte(`{}`))
 			return
@@ -60,4 +73,5 @@ func TestCurrentWorkspaceIDFallsBackToAPIWhenConfigMissingWorkspaceID(t *testing
 	require.NoError(t, err)
 	assert.Equal(t, int64(7474644166319138), got)
 	assert.Equal(t, 1, meCalls)
+	assert.Empty(t, gotOrgIdHeader)
 }


### PR DESCRIPTION
## Changes

  `WorkspaceClient.CurrentWorkspaceID` used to short-circuit whenever `Config.WorkspaceID` was non-empty, returning the configured value without an API round-trip. That skipped any validation of the ID and — more importantly — was the only workable behavior on unified (SPOG) hosts, since the underlying `/api/2.0/preview/scim/v2/Me` call requires routing information the short-circuit was deliberately avoiding providing.

  This PR drops the short-circuit and always hits the API. On unified hosts, `Config.WorkspaceID` is now forwarded in
  the `X-Databricks-Org-Id` request header so the SPOG gateway can route the call to the correct workspace — the same
  convention used by every generated workspace-level method (see `service/iam/impl.go:451-463`, `service/apps/impl.go:35-37`).

  Behavior matrix after this change:

  | Host type | `Config.WorkspaceID` | Request header | Result |
  |---|---|---|---|
  | Workspace (legacy) | unset | none | server returns host's ID |
  | Workspace (legacy) | set | `X-Databricks-Org-Id: <cfg>` | server returns host's real ID (**may differ from stale config**) |
  | Unified (SPOG) | set | `X-Databricks-Org-Id: <cfg>` | SPOG routes, workspace echoes ID back (round-trip validation) |
  | Unified (SPOG) | unset | none | fails at server (no routing info) |

  This is required for Terraform, which depends on this function to get workspaceID for a workspace host for validation. This shortcircuit was leading to unintended values returned by this function.

  ## Tests

  - [x] `TestCurrentWorkspaceIDSendsOrgIdHeaderWhenConfigHasWorkspaceID` — verifies the API is called and the
  `X-Databricks-Org-Id` request header is forwarded when `Config.WorkspaceID` is set.
  - [x] `TestCurrentWorkspaceIDOmitsOrgIdHeaderWhenConfigMissingWorkspaceID` — verifies the API is called without the
  routing header when `Config.WorkspaceID` is empty (legacy workspace host path).
  - [x] `go test ./...` passes locally; `go vet ./...` clean; `gofmt -d` clean.
  
  NO_CHANGELOG=true