### PR TITLE
config: pin cfg.Profile on the legacy [DEFAULT] fallback

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* `config`: The config-file loader now sets `cfg.Profile` to `"DEFAULT"` on the legacy fallback (no profile requested, no `[__settings__].default_profile` set, `[DEFAULT]` section loaded). Previously the loader silently used `[DEFAULT]`'s values but left `cfg.Profile` empty. Consumers that derive a per-profile identifier from `cfg.Profile` (e.g. the Databricks CLI's U2M OAuth cache key) need the resolved name to match across the login and read flows; without this fix a write under `"DEFAULT"` could not be found by a no-flag read.
+
 ### Documentation
 
 ### Internal Changes

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -100,9 +100,12 @@ func (l configFileLoader) Configure(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("%s %s profile: %w", configFile.Path(), profile, err)
 	}
-	if !isFallback {
-		cfg.Profile = profile
-	}
+	// Pin the resolved profile name on cfg, including the legacy fallback to
+	// [DEFAULT]. Callers (notably the CLI's U2M OAuth cache, which derives a
+	// per-profile keyring entry from cfg.Profile) need to see the same name
+	// that was used to load values, otherwise the cache key drifts between
+	// a `databricks auth login --profile DEFAULT` write and a later read.
+	cfg.Profile = profile
 	return nil
 }
 

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -155,6 +155,26 @@ func TestConfigFile_LegacyFallbackEmptyDefaultProfile(t *testing.T) {
 	}.apply(t)
 }
 
+// Test 4a: The legacy fallback to [DEFAULT] now pins cfg.Profile to
+// "DEFAULT". Callers (e.g. the Databricks CLI's per-profile OAuth cache key)
+// need a non-empty cfg.Profile to derive a stable key across login and
+// read flows. Previously the loader silently loaded [DEFAULT]'s values
+// but left cfg.Profile empty, producing a cache-key drift between an
+// explicit `--profile DEFAULT` write and a no-flag read.
+func TestConfigFile_LegacyFallbackSetsResolvedProfileName(t *testing.T) {
+	env.CleanupEnvironment(t)
+
+	cfg, err := configFixture{
+		Env: map[string]string{
+			"HOME": "testdata",
+		},
+	}.configureProviderAndReturnConfig(t)
+
+	require.NoError(t, err)
+	assert.Equal(t, "DEFAULT", cfg.Profile)
+	assert.Equal(t, "https://dbc-XXXXXXXX-YYYY.cloud.databricks.com", cfg.Host)
+}
+
 // Test 4b: default_profile = DEFAULT is treated as an explicit selection,
 // not as the legacy fallback. cfg.Profile is set to "DEFAULT" and a missing
 // [DEFAULT] section would error (unlike the silent legacy fallback).


### PR DESCRIPTION
## Changes

The config-file loader's `resolveProfile` distinguishes "the caller named this profile" from "we silently fell back to `[DEFAULT]`" via the `isFallback` return. On a fallback, `Configure` loaded the section's values into `cfg` but deliberately left `cfg.Profile` empty (the `if !isFallback { cfg.Profile = profile }` gate at `config/config_file.go:103-105`). The intent was preserving the caller's "I didn't pick a profile" signal.

That signal turns out to be a footgun for consumers that derive a per-profile identifier from `cfg.Profile`. The Databricks CLI's U2M OAuth cache, for example, uses `cfg.Profile` as the cache key. When the CLI runs `databricks auth login --profile DEFAULT --host ...` it writes a token under cache key `"DEFAULT"`. When the user later runs `databricks auth describe` with no flag, the loader silently falls back to `[DEFAULT]` but `cfg.Profile` stays empty, so the OAuthArgument's cache key drifts to the host URL and the lookup misses. The bug is masked when the CLI also dual-writes to a host-keyed entry (its legacy plaintext mode); under secure storage it surfaces as `cache: token not found` or, when a stale host-key entry exists, `InvalidRefreshTokenError`.

This PR drops the `!isFallback` gate so `cfg.Profile` always reflects the section the loader actually read. `isFallback` is still load-bearing earlier in `Configure` (lines 91-95): a missing `[DEFAULT]` section is tolerated only on fallback, and that behavior is preserved.

This is a self-consistency fix for the SDK and a defense-in-depth followup to the CLI's own `resolveDefaultProfile` change (databricks/cli#5280). After the SDK bump, the CLI's pre-population becomes redundant but harmless.

Linked: databricks/cli#5280 (the CLI-side fix that lands ahead of this).

## Tests

- New `TestConfigFile_LegacyFallbackSetsResolvedProfileName` asserts `cfg.Profile == "DEFAULT"` on the legacy fallback path.
- Existing config tests pass unchanged; the previously-untested `cfg.Profile` value on the legacy fallback was the bug.
- `make fmt`, `make lint`, `make test` clean locally.

This pull request and its description were written by Isaac.

Signed-off-by: Isaac