### PR TITLE
config: also extract ?w= from Host URL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -653,6 +653,14 @@ func (c *Config) fixHostIfNeeded() error {
 }
 
 func workspaceIDFromQuery(q url.Values) string {
+	// ?w= is the unified workspace addressing query parameter. It supersedes
+	// the older ?o=/?workspace_id= forms and accepts a broader range of
+	// workspace identifier formats — both classic numeric workspace IDs and
+	// other identifier formats the server understands — so we don't apply the
+	// numeric-only validation that we use for ?o=/?workspace_id=.
+	if v := q.Get("w"); v != "" {
+		return v
+	}
 	for _, key := range []string{"o", "workspace_id"} {
 		v := q.Get(key)
 		if v == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1363,6 +1363,31 @@ func TestConfig_fixHostIfNeeded_extractsWorkspaceIDFromQuery(t *testing.T) {
 			wantHost: "https://acme.databricks.net",
 		},
 		{
+			name:            "?w= with numeric value promoted to WorkspaceID",
+			host:            "https://acme.databricks.net/?w=12345",
+			wantHost:        "https://acme.databricks.net",
+			wantWorkspaceID: "12345",
+		},
+		{
+			name:            "?w= with non-numeric value promoted to WorkspaceID",
+			host:            "https://acme.databricks.net/?w=7a99b43c-b46c-432b-b0a7-814217701909",
+			wantHost:        "https://acme.databricks.net",
+			wantWorkspaceID: "7a99b43c-b46c-432b-b0a7-814217701909",
+		},
+		{
+			name:            "?w= takes precedence over ?o=",
+			host:            "https://acme.databricks.net/?w=12345&o=99999",
+			wantHost:        "https://acme.databricks.net",
+			wantWorkspaceID: "12345",
+		},
+		{
+			name:            "existing WorkspaceID is preserved over ?w=",
+			host:            "https://acme.databricks.net/?w=12345",
+			workspaceID:     "99999",
+			wantHost:        "https://acme.databricks.net",
+			wantWorkspaceID: "99999",
+		},
+		{
 			name:     "host without query is unchanged",
 			host:     "https://acme.databricks.net",
 			wantHost: "https://acme.databricks.net",


### PR DESCRIPTION
## Changes

Follow-up to #1699, which started promoting `?o=`/`?workspace_id=` and `?a=`/`?account_id=` from `Config.Host` into `Config.WorkspaceID`/`Config.AccountID` during `fixHostIfNeeded`.

`?w=` is the unified workspace addressing query parameter that supersedes `?o=`/`?workspace_id=`. It accepts a broader range of workspace identifier formats — both classic numeric workspace IDs and other identifier formats the server understands — so the numeric-only validation applied to `?o=`/`?workspace_id=` is intentionally not applied to `?w=`.

Priority order in `workspaceIDFromQuery` becomes:

1. `?w=` — any non-empty value
2. `?o=` — numeric only
3. `?workspace_id=` — numeric only

Existing `Config.WorkspaceID` is still never overwritten.

## Tests

Four cases added to the existing `TestConfig_fixHostIfNeeded_extractsWorkspaceIDFromQuery` table-driven test:

- `?w=12345` is promoted to `Config.WorkspaceID`.
- `?w=7a99b43c-b46c-432b-b0a7-814217701909` (UUID-shaped) is promoted as-is.
- `?w=` takes precedence over `?o=` when both appear.
- An existing `Config.WorkspaceID` is preserved when `?w=` is present.

`make fmt test lint` clean.

NO_CHANGELOG=true
