### PR TITLE
Add meta-harness user-agent dimension for omnigent

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Added a `meta-harness` user-agent dimension that reports the omnigent meta-harness (detected via the `OMNIGENT` environment variable) independently of agent detection.
+
 ### Bug Fixes
 
 ### Documentation

--- a/config/api_client.go
+++ b/config/api_client.go
@@ -74,6 +74,17 @@ func HTTPClientConfigFromConfig(cfg *Config) (httpclient.ClientConfig, error) {
 			*r = *r.WithContext(ctx) // replace request
 			return nil
 		},
+		func(r *http.Request) error {
+			// Detect if we are running inside a known agent meta-harness.
+			provider := useragent.MetaHarnessProvider()
+			if provider == "" {
+				return nil
+			}
+			// Add the detected meta-harness to the user agent.
+			ctx := useragent.InContext(r.Context(), useragent.MetaHarnessKey, provider)
+			*r = *r.WithContext(ctx) // replace request
+			return nil
+		},
 	}
 
 	return httpclient.ClientConfig{

--- a/useragent/meta_harness.go
+++ b/useragent/meta_harness.go
@@ -1,0 +1,53 @@
+package useragent
+
+import (
+	"os"
+	"sync"
+)
+
+// knownMetaHarness describes a meta-harness that orchestrates AI agents (not
+// itself an agent). Detected if envVar is set (any value, including empty, counts).
+type knownMetaHarness struct {
+	envVar  string
+	product string
+}
+
+// listKnownMetaHarnesses returns the canonical list of agent meta-harnesses.
+// Keep in sync with databricks-sdk-py and databricks-sdk-java.
+func listKnownMetaHarnesses() []knownMetaHarness {
+	return []knownMetaHarness{
+		{envVar: "OMNIGENT", product: "omnigent"}, // https://github.com/omnigent-ai/omnigent
+	}
+}
+
+// lookupMetaHarnessProvider returns the matched meta-harness product, "multiple"
+// if more than one matched, or "" if none matched.
+func lookupMetaHarnessProvider() string {
+	var matches []string
+	for _, h := range listKnownMetaHarnesses() {
+		if _, ok := os.LookupEnv(h.envVar); ok {
+			matches = append(matches, h.product)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0]
+	case 0:
+		return ""
+	default:
+		return "multiple"
+	}
+}
+
+var (
+	metaHarnessOnce sync.Once
+	metaHarnessName string
+)
+
+// MetaHarnessProvider returns the detected meta-harness name, cached for the process lifetime.
+func MetaHarnessProvider() string {
+	metaHarnessOnce.Do(func() {
+		metaHarnessName = lookupMetaHarnessProvider()
+	})
+	return metaHarnessName
+}

--- a/useragent/meta_harness_test.go
+++ b/useragent/meta_harness_test.go
@@ -1,0 +1,66 @@
+package useragent
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/internal/env"
+)
+
+func TestLookupMetaHarnessProvider(t *testing.T) {
+	tests := []struct {
+		name   string
+		envs   map[string]string
+		expect string
+	}{
+		{
+			name:   "no harness",
+			envs:   nil,
+			expect: "",
+		},
+		{
+			name:   "omnigent",
+			envs:   map[string]string{"OMNIGENT": "1"},
+			expect: "omnigent",
+		},
+		{
+			name:   "omnigent empty value still counts as set",
+			envs:   map[string]string{"OMNIGENT": ""},
+			expect: "omnigent",
+		},
+		{
+			name:   "agent env var does not affect harness",
+			envs:   map[string]string{"CLAUDECODE": "1"},
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env.CleanupEnvironment(t)
+			ClearCache()
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+			got := lookupMetaHarnessProvider()
+			if got != tt.expect {
+				t.Errorf("lookupMetaHarnessProvider() = %q, want %q", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestMetaHarnessProviderCached(t *testing.T) {
+	env.CleanupEnvironment(t)
+	ClearCache()
+	t.Setenv("OMNIGENT", "1")
+	got := MetaHarnessProvider()
+	if got != "omnigent" {
+		t.Errorf("MetaHarnessProvider() = %q, want %q", got, "omnigent")
+	}
+	// Change env after caching. Cached result should persist.
+	t.Setenv("OMNIGENT", "")
+	got = MetaHarnessProvider()
+	if got != "omnigent" {
+		t.Errorf("MetaHarnessProvider() after cache = %q, want %q", got, "omnigent")
+	}
+}

--- a/useragent/runtime.go
+++ b/useragent/runtime.go
@@ -13,6 +13,7 @@ func ClearCache() {
 	runtimeOnce = sync.Once{}
 	providerOnce = sync.Once{}
 	agentOnce = sync.Once{}
+	metaHarnessOnce = sync.Once{}
 }
 
 var runtimeOnce sync.Once

--- a/useragent/user_agent.go
+++ b/useragent/user_agent.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	RuntimeKey = "runtime"
-	CicdKey    = "cicd"
-	AuthKey    = "auth"
-	AgentKey   = "agent"
+	RuntimeKey     = "runtime"
+	CicdKey        = "cicd"
+	AuthKey        = "auth"
+	AgentKey       = "agent"
+	MetaHarnessKey = "meta-harness"
 )
 
 // WithProduct sets the product name and product version globally.


### PR DESCRIPTION
## Why

[Omnigent](https://github.com/omnigent-ai/omnigent) is a meta-harness that orchestrates AI coding agents (Claude Code, Codex, Cursor, and others). It is not itself an agent, so it does not belong in the existing `agent/<name>` user-agent dimension. We want telemetry that surfaces both the meta-harness and the underlying agent at the same time. ("meta-harness" matches omnigent's own self-description; "harness" alone is how the field labels the underlying agents like Claude Code.)

## Changes

Before: the SDK reported only `agent/<name>` (e.g. `agent/claude-code`) for the detected AI coding agent.

Now: the SDK also reports an independent `meta-harness/<name>` dimension. When the `OMNIGENT` environment variable is present (omnigent stamps `OMNIGENT=1` into every agent process, see omnigent-ai/omnigent#656), the user agent gains a `meta-harness/omnigent` segment. Because it is a separate dimension from agent detection, running Claude Code under omnigent yields both `agent/claude-code` and `meta-harness/omnigent`, and omnigent never trips the agent "multiple" logic.

Implementation mirrors the existing agent dimension:

- New `useragent/meta_harness.go`: a `knownMetaHarness` table, `lookupMetaHarnessProvider()`, and a cached `MetaHarnessProvider()`; plus `MetaHarnessKey` in `useragent/user_agent.go`.
- New request visitor in `config/api_client.go` that appends the `meta-harness/<name>` segment, mirroring the existing agent visitor.

## Test plan

- [x] `go test ./useragent/...` passes, including new meta-harness tests
- [x] Detection tests: present / absent / empty-value-still-counts / cached
- [x] Independence test: an agent env var (e.g. `CLAUDECODE`) does not affect meta-harness detection, and vice versa
- [x] Full `go build ./...`, `config` package tests, and `make lint` covered by CI
