### PR TITLE
Add group_id support for assuming a group during U2M OAuth login

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### New Features and Improvements
 
+- Added support for assuming a Databricks group during U2M (user-to-machine) OAuth login.
+  A new `group_id` configuration field (also settable via the `DATABRICKS_GROUP_ID` environment
+  variable or a `.databrickscfg` profile) and a `u2m.WithAssumeGroup` option send the numeric
+  group ID as the `assume_group` query parameter on the OAuth authorize request, scoping the
+  minted token to that group. Assuming a group is only supported for workspace-level logins.
+
 ### Bug Fixes
 
 ### Documentation

--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,13 @@ type Config struct {
 	// will disable the fallback mechanism.
 	OAuthCallbackPort int `name:"oauth_callback_port" env:"DATABRICKS_OAUTH_CALLBACK_PORT" auth:"-"`
 
+	// AssumeGroupID is the numeric Databricks group ID to assume during U2M
+	// (user-to-machine) OAuth login. When set, it is sent as the `assume_group`
+	// query parameter on the OAuth authorize request so the resulting token is
+	// scoped to that group. This is only used for U2M authentication and only
+	// for workspace-level logins; it is ignored by other auth types.
+	AssumeGroupID string `name:"group_id" env:"DATABRICKS_GROUP_ID" auth:"-"`
+
 	GoogleServiceAccount string `name:"google_service_account" env:"DATABRICKS_GOOGLE_SERVICE_ACCOUNT" auth:"google" auth_types:"google-id"`
 	GoogleCredentials    string `name:"google_credentials" env:"GOOGLE_CREDENTIALS" auth:"google,sensitive" auth_types:"google-credentials"`
 

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -98,6 +98,42 @@ func TestConfigFile_Scopes(t *testing.T) {
 	}
 }
 
+func TestConfigFile_GroupID(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		want    string
+	}{
+		{
+			name:    "unset group_id",
+			profile: "group-unset",
+			want:    "",
+		},
+		{
+			name:    "group_id set",
+			profile: "group-set",
+			want:    "123456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withMockEnv(t, map[string]string{
+				"HOME": "testdata/group_id",
+			})
+
+			cfg := &Config{Profile: tt.profile}
+			err := cfg.EnsureResolved()
+			if err != nil {
+				t.Fatalf("EnsureResolved failed: %v", err)
+			}
+			if cfg.AssumeGroupID != tt.want {
+				t.Errorf("AssumeGroupID: want %q, got %q", tt.want, cfg.AssumeGroupID)
+			}
+		})
+	}
+}
+
 // Test 1: default_profile resolves correctly (no [DEFAULT] section present)
 func TestConfigFile_DefaultProfileResolves(t *testing.T) {
 	configFixture{

--- a/config/testdata/group_id/.databrickscfg
+++ b/config/testdata/group_id/.databrickscfg
@@ -1,0 +1,6 @@
+[group-unset]
+host = https://example.cloud.databricks.com
+
+[group-set]
+host = https://example.cloud.databricks.com
+group_id = 123456

--- a/credentials/u2m/discovery_token_source.go
+++ b/credentials/u2m/discovery_token_source.go
@@ -58,7 +58,7 @@ const discoveryTargetAccount = "ACCOUNT"
 // the discovery OAuth flow. The OIDC authorize path with all OAuth query params
 // is URL-encoded as the destination_url parameter.
 func BuildDiscoveryAuthorizeURL(redirectAddr, state string, pkce PKCEParams, scopes []string) string {
-	return buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, redirectAddr, state, pkce, scopes, "")
+	return buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, redirectAddr, state, pkce, scopes, "", "")
 }
 
 // buildDiscoveryAuthorizeURL builds the discovery authorize URL against the
@@ -66,8 +66,10 @@ func BuildDiscoveryAuthorizeURL(redirectAddr, state string, pkce PKCEParams, sco
 // well-formed regardless of how an override is written. When target is
 // non-empty it is set as the top-level `target` query parameter, which
 // login.databricks.com uses to route the user to a specific selector page
-// (e.g. "ACCOUNT" for the account selector).
-func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParams, scopes []string, target string) string {
+// (e.g. "ACCOUNT" for the account selector). When assumeGroup is non-empty it
+// is set as the `assume_group` parameter on the nested OIDC authorize path so
+// the minted token is scoped to that group.
+func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParams, scopes []string, target, assumeGroup string) string {
 	// Build the nested OIDC authorize path with query parameters.
 	authParams := url.Values{}
 	authParams.Set("client_id", appClientID)
@@ -77,6 +79,9 @@ func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParam
 	authParams.Set("state", state)
 	authParams.Set("code_challenge", pkce.Challenge)
 	authParams.Set("code_challenge_method", pkce.ChallengeMethod)
+	if assumeGroup != "" {
+		authParams.Set(assumeGroupParamName, assumeGroup)
+	}
 	destinationURL := "/oidc/v1/authorize?" + authParams.Encode()
 
 	// Wrap the authorize path as the destination_url query parameter on the
@@ -138,7 +143,7 @@ func (d *discoveryTokenSource) challenge() error {
 	if host == "" {
 		host = defaultLoginDatabricksHost
 	}
-	authorizeURL := buildDiscoveryAuthorizeURL(host, d.pa.redirectAddr, state, pkce, scopes, d.target)
+	authorizeURL := buildDiscoveryAuthorizeURL(host, d.pa.redirectAddr, state, pkce, scopes, d.target, d.pa.assumeGroup)
 
 	code, returnedState, issuer, err := cb.handlerWithIssuer(authorizeURL)
 	if err != nil {

--- a/credentials/u2m/discovery_token_source_test.go
+++ b/credentials/u2m/discovery_token_source_test.go
@@ -187,7 +187,7 @@ func TestBuildDiscoveryAuthorizeURL_HostOverride(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildDiscoveryAuthorizeURL(tc.host, "localhost:8020", "s", pkce, scopes, "")
+			got := buildDiscoveryAuthorizeURL(tc.host, "localhost:8020", "s", pkce, scopes, "", "")
 			u, err := url.Parse(got)
 			if err != nil {
 				t.Fatalf("parsing URL: %v", err)
@@ -216,7 +216,7 @@ func TestBuildDiscoveryAuthorizeURL_Target(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, "localhost:8020", "s", pkce, scopes, tc.target)
+			got := buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, "localhost:8020", "s", pkce, scopes, tc.target, "")
 			u, err := url.Parse(got)
 			if err != nil {
 				t.Fatalf("parsing URL: %v", err)
@@ -227,6 +227,46 @@ func TestBuildDiscoveryAuthorizeURL_Target(t *testing.T) {
 			// destination_url must still be present in every variant.
 			if u.Query().Get("destination_url") == "" {
 				t.Error("destination_url should be set regardless of target")
+			}
+		})
+	}
+}
+
+func TestBuildDiscoveryAuthorizeURL_AssumeGroup(t *testing.T) {
+	pkce := PKCEParams{
+		Challenge:       "c",
+		ChallengeMethod: "S256",
+		Verifier:        "v",
+	}
+	scopes := []string{"offline_access", "all-apis"}
+	tests := []struct {
+		name        string
+		assumeGroup string
+		wantParam   bool
+		wantValue   string
+	}{
+		{name: "no group", assumeGroup: "", wantParam: false},
+		{name: "with group", assumeGroup: "123456", wantParam: true, wantValue: "123456"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, "localhost:8020", "s", pkce, scopes, "", tc.assumeGroup)
+			u, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("parsing URL: %v", err)
+			}
+			// assume_group lives on the nested destination_url, not the top-level URL.
+			destParsed, err := url.Parse(u.Query().Get("destination_url"))
+			if err != nil {
+				t.Fatalf("parsing destination_url: %v", err)
+			}
+			q := destParsed.Query()
+			_, present := q[assumeGroupParamName]
+			if present != tc.wantParam {
+				t.Errorf("assume_group present = %v, want %v", present, tc.wantParam)
+			}
+			if tc.wantParam && q.Get(assumeGroupParamName) != tc.wantValue {
+				t.Errorf("assume_group = %q, want %q", q.Get(assumeGroupParamName), tc.wantValue)
 			}
 		})
 	}

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -24,6 +25,11 @@ import (
 const (
 	// appClientId is the default client ID used by the SDK for U2M OAuth.
 	appClientID = "databricks-cli"
+
+	// assumeGroupParamName is the query parameter used on the authorize request
+	// to assume a Databricks group during login. Its value is the numeric group
+	// ID to assume. This must match the server-side parameter name.
+	assumeGroupParamName = "assume_group"
 
 	// defaultPort is the default port for the OAuth2 callback server. If the
 	// port is already in use, the next port is tried (8021, 8022, etc.).
@@ -117,6 +123,16 @@ type PersistentAuth struct {
 	// login.databricks.com lands the user on the account selector instead of
 	// the workspace selector. Use for account-only logins.
 	discoveryAccountTarget bool
+
+	// assumeGroup is the numeric Databricks group ID to assume during login.
+	// When set, it is sent as the `assume_group` query parameter on the
+	// authorize request, so the minted access token is scoped to that group.
+	// The value is baked into the authorization code by the server, so it does
+	// not need to be resent on the token exchange or on subsequent API calls.
+	//
+	// Assuming a group is only supported for workspace-level logins; combining
+	// it with an account OAuthArgument is rejected at construction time.
+	assumeGroup string
 }
 
 type PersistentAuthOption func(*PersistentAuth)
@@ -215,6 +231,20 @@ func WithDiscoveryHost(host string) PersistentAuthOption {
 func WithDiscoveryAccountTarget() PersistentAuthOption {
 	return func(a *PersistentAuth) {
 		a.discoveryAccountTarget = true
+	}
+}
+
+// WithAssumeGroup sets the numeric Databricks group ID to assume during login.
+// When set, it is sent as the `assume_group` query parameter on the authorize
+// request; the server validates that the user may assume the group and bakes
+// the claim into the minted access token, so no header or parameter is needed
+// on subsequent API calls.
+//
+// Assuming a group is only supported for workspace-level logins. Pairing this
+// with an account OAuthArgument causes NewPersistentAuth to return an error.
+func WithAssumeGroup(groupID string) PersistentAuthOption {
+	return func(a *PersistentAuth) {
+		a.assumeGroup = groupID
 	}
 }
 
@@ -522,6 +552,17 @@ func (a *PersistentAuth) validateArg() error {
 	if a.discoveryMode && !isDiscoveryArg {
 		return fmt.Errorf("discovery login requires DiscoveryOAuthArgument, got %T", a.oAuthArgument)
 	}
+	// Assuming a group is a workspace-level concept; the server rejects it at
+	// the account authorize endpoint. Fail fast for account arguments and for
+	// discovery logins explicitly targeting the account selector.
+	if a.assumeGroup != "" {
+		if isAccountArg {
+			return fmt.Errorf("assume_group is only supported for workspace-level logins, got account OAuthArgument %T", a.oAuthArgument)
+		}
+		if a.discoveryAccountTarget {
+			return errors.New("assume_group is only supported for workspace-level logins, not with WithDiscoveryAccountTarget")
+		}
+	}
 	return nil
 }
 
@@ -561,16 +602,34 @@ func (a *PersistentAuth) oauth2Config() (*oauth2.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching OAuth endpoints: %w", err)
 	}
+	authURL := endpoints.AuthorizationEndpoint
+	// The oauth2 library builds the authorize URL from AuthURL and only lets us
+	// inject PKCE parameters via authhandler. To carry assume_group we pre-encode
+	// it onto AuthURL; AuthCodeURL appends its own params with the correct
+	// separator whether or not a query string is already present.
+	if a.assumeGroup != "" {
+		authURL = appendQueryParam(authURL, assumeGroupParamName, a.assumeGroup)
+	}
 	return &oauth2.Config{
 		ClientID: appClientID,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:   endpoints.AuthorizationEndpoint,
+			AuthURL:   authURL,
 			TokenURL:  endpoints.TokenEndpoint,
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
 		RedirectURL: fmt.Sprintf("http://%s", a.redirectAddr),
 		Scopes:      scopes,
 	}, nil
+}
+
+// appendQueryParam appends a single query parameter to a URL, preserving any
+// existing query string. The value is URL-encoded.
+func appendQueryParam(rawURL, key, value string) string {
+	sep := "?"
+	if strings.Contains(rawURL, "?") {
+		sep = "&"
+	}
+	return rawURL + sep + url.Values{key: {value}}.Encode()
 }
 
 func (a *PersistentAuth) stateAndPKCE() (string, *authhandler.PKCEParams, error) {

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -553,14 +553,16 @@ func (a *PersistentAuth) validateArg() error {
 		return fmt.Errorf("discovery login requires DiscoveryOAuthArgument, got %T", a.oAuthArgument)
 	}
 	// Assuming a group is a workspace-level concept; the server rejects it at
-	// the account authorize endpoint. Fail fast for account arguments and for
-	// discovery logins explicitly targeting the account selector.
+	// the account authorize endpoint. Allow it only for workspace-level logins:
+	// a workspace argument, or a discovery login (which resolves to a workspace)
+	// that is not explicitly targeting the account selector. Everything else --
+	// account and unified arguments -- is rejected up front. This is an allowlist
+	// rather than a blocklist so new account-capable argument types cannot slip
+	// through by default.
 	if a.assumeGroup != "" {
-		if isAccountArg {
-			return fmt.Errorf("assume_group is only supported for workspace-level logins, got account OAuthArgument %T", a.oAuthArgument)
-		}
-		if a.discoveryAccountTarget {
-			return errors.New("assume_group is only supported for workspace-level logins, not with WithDiscoveryAccountTarget")
+		workspaceLevel := isWorkspaceArg || (isDiscoveryArg && !a.discoveryAccountTarget)
+		if !workspaceLevel {
+			return fmt.Errorf("assume_group is only supported for workspace-level logins, got %T", a.oAuthArgument)
 		}
 	}
 	return nil

--- a/credentials/u2m/persistent_auth_test.go
+++ b/credentials/u2m/persistent_auth_test.go
@@ -1328,21 +1328,75 @@ func TestU2M_AssumeGroup(t *testing.T) {
 	}
 }
 
-func TestWithAssumeGroup_RejectsAccountArgument(t *testing.T) {
-	arg, err := NewBasicAccountOAuthArgument("https://accounts.cloud.databricks.com", "xyz")
+func TestWithAssumeGroup_ArgumentValidation(t *testing.T) {
+	workspaceArg, err := NewBasicWorkspaceOAuthArgument("https://workspace.cloud.databricks.com")
+	if err != nil {
+		t.Fatalf("NewBasicWorkspaceOAuthArgument(): want no error, got %v", err)
+	}
+	accountArg, err := NewBasicAccountOAuthArgument("https://accounts.cloud.databricks.com", "xyz")
 	if err != nil {
 		t.Fatalf("NewBasicAccountOAuthArgument(): want no error, got %v", err)
 	}
-	_, err = NewPersistentAuth(
-		context.Background(),
-		WithOAuthArgument(arg),
-		WithAssumeGroup("123456"),
-	)
-	if err == nil {
-		t.Fatal("NewPersistentAuth(): want error for assume_group with account argument, got nil")
+	unifiedArg, err := NewBasicUnifiedOAuthArgument("https://accounts.cloud.databricks.com", "xyz")
+	if err != nil {
+		t.Fatalf("NewBasicUnifiedOAuthArgument(): want no error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "workspace-level") {
-		t.Errorf("NewPersistentAuth(): want workspace-level error, got %v", err)
+	discoveryArg, err := NewBasicDiscoveryOAuthArgument("my-profile")
+	if err != nil {
+		t.Fatalf("NewBasicDiscoveryOAuthArgument(): want no error, got %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		opts      []PersistentAuthOption
+		wantError bool
+	}{
+		{
+			name:      "workspace argument is allowed",
+			opts:      []PersistentAuthOption{WithOAuthArgument(workspaceArg), WithAssumeGroup("123456")},
+			wantError: false,
+		},
+		{
+			name:      "discovery login is allowed",
+			opts:      []PersistentAuthOption{WithOAuthArgument(discoveryArg), WithDiscoveryLogin(), WithAssumeGroup("123456")},
+			wantError: false,
+		},
+		{
+			name:      "account argument is rejected",
+			opts:      []PersistentAuthOption{WithOAuthArgument(accountArg), WithAssumeGroup("123456")},
+			wantError: true,
+		},
+		{
+			// Unified arguments are account-capable (they carry an account ID and
+			// authenticate via the account/unified endpoint), so assume_group must
+			// be rejected for them as well.
+			name:      "unified argument is rejected",
+			opts:      []PersistentAuthOption{WithOAuthArgument(unifiedArg), WithAssumeGroup("123456")},
+			wantError: true,
+		},
+		{
+			name:      "discovery login targeting the account selector is rejected",
+			opts:      []PersistentAuthOption{WithOAuthArgument(discoveryArg), WithDiscoveryLogin(), WithDiscoveryAccountTarget(), WithAssumeGroup("123456")},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPersistentAuth(context.Background(), tt.opts...)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("NewPersistentAuth(): want error, got nil")
+				}
+				if !strings.Contains(err.Error(), "workspace-level") {
+					t.Errorf("NewPersistentAuth(): want workspace-level error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewPersistentAuth(): want no error, got %v", err)
+			}
+		})
 	}
 }
 

--- a/credentials/u2m/persistent_auth_test.go
+++ b/credentials/u2m/persistent_auth_test.go
@@ -1214,6 +1214,138 @@ func TestU2M_ScopesAndOfflineAccess(t *testing.T) {
 	}
 }
 
+func TestU2M_AssumeGroup(t *testing.T) {
+	const (
+		testWorkspaceHost = "https://workspace.cloud.databricks.com"
+		testTokenEndpoint = "/oidc/v1/token"
+		testCallbackURL   = "http://localhost:8020"
+	)
+
+	tests := []struct {
+		name        string
+		assumeGroup string
+		wantParam   bool
+		wantValue   string
+	}{
+		{name: "no assume_group", assumeGroup: "", wantParam: false},
+		{name: "with assume_group", assumeGroup: "123456", wantParam: true, wantValue: "123456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var assumeGroupReceived string
+			var assumeGroupPresent bool
+			var stateReceived string
+			browserCalled := make(chan struct{})
+			defer close(browserCalled)
+			browser := func(redirect string) error {
+				u, err := url.ParseRequestURI(redirect)
+				if err != nil {
+					return err
+				}
+				query := u.Query()
+				assumeGroupReceived = query.Get(assumeGroupParamName)
+				_, assumeGroupPresent = query[assumeGroupParamName]
+				stateReceived = query.Get("state")
+				browserCalled <- struct{}{}
+				return nil
+			}
+
+			cache := &tokenCacheMock{
+				store: func(key string, tok *oauth2.Token) error {
+					return nil
+				},
+			}
+
+			arg, err := NewBasicWorkspaceOAuthArgument(testWorkspaceHost)
+			if err != nil {
+				t.Fatalf("NewBasicWorkspaceOAuthArgument(): want no error, got %v", err)
+			}
+
+			opts := []PersistentAuthOption{
+				WithTokenCache(cache),
+				WithBrowser(browser),
+				WithHttpClient(&http.Client{
+					Transport: fixtures.SliceTransport{
+						{
+							Method:   "POST",
+							Resource: testTokenEndpoint,
+							Response: `access_token=token&refresh_token=refresh`,
+							ResponseHeaders: map[string][]string{
+								"Content-Type": {"application/x-www-form-urlencoded"},
+							},
+						},
+					},
+				}),
+				WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
+				WithOAuthArgument(arg),
+				WithAssumeGroup(tt.assumeGroup),
+			}
+
+			p, err := NewPersistentAuth(ctx, opts...)
+			if err != nil {
+				t.Fatalf("NewPersistentAuth(): want no error, got %v", err)
+			}
+			defer p.Close()
+
+			errc := make(chan error)
+			defer close(errc)
+			go func() {
+				err := p.Challenge()
+				errc <- err
+			}()
+
+			select {
+			case <-browserCalled:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for browser to be called")
+			}
+
+			if assumeGroupPresent != tt.wantParam {
+				t.Errorf("assume_group present = %v, want %v", assumeGroupPresent, tt.wantParam)
+			}
+			if tt.wantParam && assumeGroupReceived != tt.wantValue {
+				t.Errorf("assume_group = %q, want %q", assumeGroupReceived, tt.wantValue)
+			}
+
+			resp, err := http.Get(fmt.Sprintf("%s?code=__CODE__&state=%s", testCallbackURL, stateReceived))
+			if err != nil {
+				t.Fatalf("http.Get(): want no error, got %v", err)
+			}
+			defer resp.Body.Close()
+
+			select {
+			case err = <-errc:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for Challenge() to complete")
+			}
+			if err != nil {
+				t.Fatalf("p.Challenge(): want no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestWithAssumeGroup_RejectsAccountArgument(t *testing.T) {
+	arg, err := NewBasicAccountOAuthArgument("https://accounts.cloud.databricks.com", "xyz")
+	if err != nil {
+		t.Fatalf("NewBasicAccountOAuthArgument(): want no error, got %v", err)
+	}
+	_, err = NewPersistentAuth(
+		context.Background(),
+		WithOAuthArgument(arg),
+		WithAssumeGroup("123456"),
+	)
+	if err == nil {
+		t.Fatal("NewPersistentAuth(): want error for assume_group with account argument, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace-level") {
+		t.Errorf("NewPersistentAuth(): want workspace-level error, got %v", err)
+	}
+}
+
 func TestChallenge_Discovery(t *testing.T) {
 	// Mock token server that responds to POST /oidc/v1/token.
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Add the ability to assume a Databricks group during the user-to-machine (U2M) OAuth login flow. When configured, the numeric group ID is sent as the `assume_group` query parameter on the `/oidc/v1/authorize` request. The server validates that the user may assume the group and bakes the claim into the minted access token, so no header or parameter needs to be attached to subsequent API calls.

## What changed
- Add `Config.AssumeGroupID` (`group_id` in profiles, `DATABRICKS_GROUP_ID` env var) so `.databrickscfg` profiles can carry an optional group ID.
- Add the `u2m.WithAssumeGroup` PersistentAuth option, injecting `assume_group` into the authorize URL for both the standard PKCE flow (appended to the authorization endpoint) and the discovery flow (set on the nested destination_url).
- Reject assuming a group for account-level logins at construction time, mirroring the server-side workspace-only constraint.

Assuming a group is only supported for workspace-level U2M logins. The value is decided at login time; the SDK's runtime databricks-cli token source is unaffected.

## How is this tested?

Added appropriate unit tests.

Co-authored-by: Isaac

