### PR TITLE
Strip custom credential headers on cross-host redirects

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features and Improvements
 
 ### Bug Fixes
+- Strip custom Databricks credential headers (`X-Databricks-Azure-SP-Management-Token`, `X-Databricks-GCP-SA-Access-Token`) on cross-host redirects, matching how `net/http` handles the `Authorization` header.
 
 ### Documentation
 

--- a/httpclient/api_client.go
+++ b/httpclient/api_client.go
@@ -24,6 +24,15 @@ import (
 
 type RequestVisitor func(*http.Request) error
 
+// sensitiveCrossHostHeaders are custom Databricks auth headers carrying credentials that must
+// not be forwarded across a host boundary on redirect (net/http only strips the standard
+// sensitive headers such as Authorization on cross-host redirects).
+var sensitiveCrossHostHeaders = []string{
+	"X-Databricks-Azure-SP-Management-Token",
+	"X-Databricks-GCP-SA-Access-Token",
+	"X-Databricks-Azure-Workspace-Resource-Id",
+}
+
 type ClientConfig struct {
 	AuthVisitor RequestVisitor
 	Visitors    []RequestVisitor
@@ -157,6 +166,21 @@ func NewApiClient(cfg ClientConfig) *ApiClient {
 			// progress (e.g. on a slower network connection).
 			Timeout:   0,
 			Transport: transport,
+			// net/http strips sensitive headers (Authorization, Cookie, ...) when a redirect
+			// crosses to a different host, but it does not strip our custom cloud-provider token
+			// headers. Drop those on a cross-host redirect so credentials are not sent to a host
+			// other than the one they were intended for.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 10 {
+					return errors.New("stopped after 10 redirects")
+				}
+				if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+					for _, h := range sensitiveCrossHostHeaders {
+						req.Header.Del(h)
+					}
+				}
+				return nil
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

When Azure service-principal or GCP service-account auth is configured, the SDK attaches the cloud-provider token to every request as a custom header (`X-Databricks-Azure-SP-Management-Token`, the Azure ARM management bearer; `X-Databricks-GCP-SA-Access-Token`, the GCP service-account token). These headers are already treated as secrets by the SDK's own log redaction.

The main HTTP client in `httpclient/api_client.go` follows redirects with no `CheckRedirect`. Go's `net/http` strips only the standard sensitive headers (`Authorization`, `Cookie`, `WWW-Authenticate`) when a redirect changes host; it does not strip these custom headers. So on a cross-host redirect the cloud tokens are forwarded to the redirect target host, even though `Authorization` would be stripped.

The SDK already avoids this on the Azure tenant-fetch client (`config/config.go` sets a `CheckRedirect`); this change brings the main request client in line.

## Change

Add a `CheckRedirect` to the main client that drops the custom credential headers when a redirect changes host, preserves the default 10-redirect limit, and leaves same-host redirects untouched.

## Testing

`make fmt test lint`. Verified at runtime that with the change the tokens are stripped on a cross-host redirect (matching `Authorization`) and same-host redirects are unaffected.
