### PR TITLE
Add Pi coding agent to the known-agents table

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements
 
+* Add the Pi coding agent (`PI_CODING_AGENT`) to AI agent detection in the User-Agent header, so CLI usage driven by Pi is attributed to `pi`.
+
 ### Bug Fixes
 
 ### Documentation

--- a/useragent/agent.go
+++ b/useragent/agent.go
@@ -47,6 +47,7 @@ func listKnownAgents() []knownAgent {
 		{envVar: "KIRO", product: "kiro"},                     // https://kiro.dev/ (Amazon)
 		{envVar: "OPENCLAW_SHELL", product: "openclaw"},       // https://github.com/anthropics/openclaw
 		{envVar: "OPENCODE", product: "opencode"},             // https://github.com/opencode-ai/opencode
+		{envVar: "PI_CODING_AGENT", product: "pi"},            // https://pi.dev/ (npm @earendil-works/pi-coding-agent)
 		{envVar: "VSCODE_AGENT", product: "vscode-agent"},     // Set by VS Code 1.121+ for agent-initiated terminal commands (https://code.visualstudio.com/updates/v1_121)
 		{envVar: "WINDSURF_AGENT", product: "windsurf"},       // https://codeium.com/windsurf (Codeium)
 	}

--- a/useragent/agent_test.go
+++ b/useragent/agent_test.go
@@ -129,6 +129,11 @@ func TestLookupAgentProvider(t *testing.T) {
 			envs:   map[string]string{"WINDSURF_AGENT": "1"},
 			expect: "windsurf",
 		},
+		{
+			name:   "pi",
+			envs:   map[string]string{"PI_CODING_AGENT": "true"},
+			expect: "pi",
+		},
 		// AGENT fallback behavior.
 		{
 			name:   "AGENT=cursor falls back to cursor",


### PR DESCRIPTION
## Summary

Pi (https://pi.dev/, npm @earendil-works/pi-coding-agent) sets PI_CODING_AGENT in the environment of every subprocess its bash/exec tool spawns, but does not set the generic AGENT/AI_AGENT var, so it needs an explicit matcher. Without it, CLI usage driven by Pi is attributed to unknown instead of "pi".
