### PR TITLE
Recover from concurrent OAuth token cache writes

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- Recover from concurrent OAuth token cache writes by using the fresh token stored by another process.
+
 ### Documentation
 
 ### Internal Changes

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -41,6 +41,17 @@ const (
 	// token is proactively refreshed. This prevents callers from receiving
 	// near-expired tokens that may expire before the next request.
 	tokenRefreshBuffer = 5 * time.Minute
+
+	// Cache update recovery checks immediately and then waits for 25, 50, 100,
+	// and 200 milliseconds. This gives a concurrent cache writer time to finish
+	// while bounding the delay for persistent storage failures to 375 milliseconds.
+	cacheUpdateRecoveryAttempts = 5
+
+	cacheUpdateRecoveryInitialDelay = 25 * time.Millisecond
+
+	// Concurrent refreshes can finish at slightly different times, so their
+	// expiration times need not be identical.
+	cacheUpdateRecoveryExpiryDelta = time.Minute
 )
 
 var (
@@ -316,6 +327,41 @@ func needsRefresh(t *oauth2.Token) bool {
 	return !t.Expiry.IsZero() && time.Until(t.Expiry) < tokenRefreshBuffer
 }
 
+// isFreshReplacement reports whether cached changed from old and has
+// approximately the same lifetime as candidate.
+func isFreshReplacement(old, candidate, cached *oauth2.Token) bool {
+	if cached.AccessToken == old.AccessToken || !cached.Valid() {
+		return false
+	}
+	if candidate.Expiry.IsZero() || cached.Expiry.IsZero() {
+		return true
+	}
+	return !cached.Expiry.Before(candidate.Expiry.Add(-cacheUpdateRecoveryExpiryDelta))
+}
+
+// recoverCacheUpdate checks whether a concurrent cache update completed.
+// Retrying reads instead of writes avoids recreating the write race.
+func (a *PersistentAuth) recoverCacheUpdate(old, candidate *oauth2.Token) *oauth2.Token {
+	for attempt := 0; attempt < cacheUpdateRecoveryAttempts; attempt++ {
+		if attempt > 0 {
+			delay := cacheUpdateRecoveryInitialDelay << (attempt - 1)
+			timer := time.NewTimer(delay)
+			select {
+			case <-a.ctx.Done():
+				timer.Stop()
+				return nil
+			case <-timer.C:
+			}
+		}
+
+		cached, err := a.cache.Lookup(a.oAuthArgument.GetCacheKey())
+		if err == nil && isFreshReplacement(old, candidate, cached) {
+			return cached
+		}
+	}
+	return nil
+}
+
 // refresh refreshes the token for the given OAuthArgument, storing the new
 // token in the cache.
 //
@@ -382,6 +428,9 @@ func (a *PersistentAuth) refresh(oldToken *oauth2.Token) (*oauth2.Token, error) 
 	}
 	err = a.cache.Store(a.oAuthArgument.GetCacheKey(), t)
 	if err != nil {
+		if cached := a.recoverCacheUpdate(oldToken, t); cached != nil {
+			return cached, nil
+		}
 		return nil, fmt.Errorf("cache update: %w", err)
 	}
 	return t, nil

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -328,14 +328,17 @@ func needsRefresh(t *oauth2.Token) bool {
 	return !t.Expiry.IsZero() && time.Until(t.Expiry) < tokenRefreshBuffer
 }
 
-// isFreshReplacement reports whether cached changed from old and has
-// approximately the same lifetime as candidate.
+// isFreshReplacement reports whether cached changed from old, is valid, and
+// does not expire significantly sooner than candidate.
 func isFreshReplacement(old, candidate, cached *oauth2.Token) bool {
 	if cached.AccessToken == old.AccessToken || !cached.Valid() {
 		return false
 	}
-	if candidate.Expiry.IsZero() || cached.Expiry.IsZero() {
+	if cached.Expiry.IsZero() {
 		return true
+	}
+	if candidate.Expiry.IsZero() {
+		return false
 	}
 	return !cached.Expiry.Before(candidate.Expiry.Add(-cacheUpdateRecoveryExpiryDelta))
 }

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -48,6 +48,7 @@ const (
 	cacheUpdateRecoveryAttempts = 5
 
 	cacheUpdateRecoveryInitialDelay = 25 * time.Millisecond
+	cacheUpdateRecoveryDelayFactor  = 2
 
 	// Concurrent refreshes can finish at slightly different times, so their
 	// expiration times need not be identical.
@@ -342,9 +343,9 @@ func isFreshReplacement(old, candidate, cached *oauth2.Token) bool {
 // recoverCacheUpdate checks whether a concurrent cache update completed.
 // Retrying reads instead of writes avoids recreating the write race.
 func (a *PersistentAuth) recoverCacheUpdate(old, candidate *oauth2.Token) *oauth2.Token {
+	delay := cacheUpdateRecoveryInitialDelay
 	for attempt := 0; attempt < cacheUpdateRecoveryAttempts; attempt++ {
 		if attempt > 0 {
-			delay := cacheUpdateRecoveryInitialDelay << (attempt - 1)
 			timer := time.NewTimer(delay)
 			select {
 			case <-a.ctx.Done():
@@ -352,6 +353,7 @@ func (a *PersistentAuth) recoverCacheUpdate(old, candidate *oauth2.Token) *oauth
 				return nil
 			case <-timer.C:
 			}
+			delay *= cacheUpdateRecoveryDelayFactor
 		}
 
 		cached, err := a.cache.Lookup(a.oAuthArgument.GetCacheKey())

--- a/credentials/u2m/persistent_auth_test.go
+++ b/credentials/u2m/persistent_auth_test.go
@@ -694,37 +694,64 @@ func TestIsFreshReplacement(t *testing.T) {
 	candidate := &oauth2.Token{AccessToken: "candidate", Expiry: now.Add(time.Hour)}
 
 	tests := []struct {
-		name   string
-		cached *oauth2.Token
-		want   bool
+		name      string
+		candidate *oauth2.Token
+		cached    *oauth2.Token
+		want      bool
 	}{
 		{
-			name:   "same token",
-			cached: &oauth2.Token{AccessToken: "old", Expiry: now.Add(time.Hour)},
+			name:      "same token",
+			candidate: candidate,
+			cached:    &oauth2.Token{AccessToken: "old", Expiry: now.Add(time.Hour)},
+			want:      false,
 		},
 		{
-			name:   "expired replacement",
-			cached: &oauth2.Token{AccessToken: "winner", Expiry: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			name:      "expired replacement",
+			candidate: candidate,
+			cached:    &oauth2.Token{AccessToken: "winner", Expiry: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			want:      false,
 		},
 		{
-			name:   "replacement expires too soon",
-			cached: &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(-time.Minute - time.Second)},
+			name:      "replacement expires too soon",
+			candidate: candidate,
+			cached:    &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(-time.Minute - time.Second)},
+			want:      false,
 		},
 		{
-			name:   "replacement expiry within tolerance",
-			cached: &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(-time.Minute)},
-			want:   true,
+			name:      "replacement expiry within tolerance",
+			candidate: candidate,
+			cached:    &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(-time.Minute)},
+			want:      true,
 		},
 		{
-			name:   "replacement expires later",
-			cached: &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(time.Minute)},
-			want:   true,
+			name:      "replacement expires later",
+			candidate: candidate,
+			cached:    &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(time.Minute)},
+			want:      true,
+		},
+		{
+			name:      "expiring candidate and non-expiring replacement",
+			candidate: candidate,
+			cached:    &oauth2.Token{AccessToken: "winner"},
+			want:      true,
+		},
+		{
+			name:      "non-expiring candidate and replacement inside refresh buffer",
+			candidate: &oauth2.Token{AccessToken: "candidate"},
+			cached:    &oauth2.Token{AccessToken: "winner", Expiry: now.Add(time.Minute)},
+			want:      false,
+		},
+		{
+			name:      "non-expiring candidate and replacement",
+			candidate: &oauth2.Token{AccessToken: "candidate"},
+			cached:    &oauth2.Token{AccessToken: "winner"},
+			want:      true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isFreshReplacement(old, candidate, tt.cached); got != tt.want {
+			if got := isFreshReplacement(old, tt.candidate, tt.cached); got != tt.want {
 				t.Errorf("isFreshReplacement(): want %t, got %t", tt.want, got)
 			}
 		})

--- a/credentials/u2m/persistent_auth_test.go
+++ b/credentials/u2m/persistent_auth_test.go
@@ -618,6 +618,119 @@ func TestForceRefreshToken_RefreshesValidToken(t *testing.T) {
 	}
 }
 
+func TestForceRefreshToken_RecoversConcurrentCacheUpdate(t *testing.T) {
+	now := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
+	old := &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       now.Add(time.Hour),
+	}
+	winner := &oauth2.Token{
+		AccessToken:  "winner-access",
+		RefreshToken: "winner-refresh",
+		Expiry:       now.Add(time.Hour - 30*time.Second),
+	}
+	lookupCalls := 0
+	c := &tokenCacheMock{
+		lookup: func(key string) (*oauth2.Token, error) {
+			lookupCalls++
+			if lookupCalls <= 2 {
+				return old, nil
+			}
+			return winner, nil
+		},
+		store: func(key string, tok *oauth2.Token) error {
+			if tok.AccessToken != "candidate-access" {
+				t.Fatalf("store(): want candidate access token, got %q", tok.AccessToken)
+			}
+			return errors.New("concurrent cache update")
+		},
+	}
+	arg, err := NewBasicAccountOAuthArgument("https://accounts.cloud.databricks.com", "xyz")
+	if err != nil {
+		t.Fatalf("NewBasicAccountOAuthArgument(): %v", err)
+	}
+	p, err := NewPersistentAuth(
+		context.Background(),
+		WithTokenCache(c),
+		WithHttpClient(&http.Client{
+			Transport: fixtures.SliceTransport{
+				{
+					Method:   "POST",
+					Resource: "/oidc/accounts/xyz/v1/token",
+					Response: `access_token=candidate-access&refresh_token=candidate-refresh&expires_in=3600`,
+					ResponseHeaders: map[string][]string{
+						"Content-Type": {"application/x-www-form-urlencoded"},
+					},
+				},
+			},
+		}),
+		WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
+		WithOAuthArgument(arg),
+	)
+	if err != nil {
+		t.Fatalf("NewPersistentAuth(): %v", err)
+	}
+	defer p.Close()
+
+	tok, err := p.ForceRefreshToken()
+	if err != nil {
+		t.Fatalf("ForceRefreshToken(): want no error, got %v", err)
+	}
+	if tok.AccessToken != winner.AccessToken {
+		t.Errorf("ForceRefreshToken(): want winner access token %q, got %q", winner.AccessToken, tok.AccessToken)
+	}
+	if tok.RefreshToken != "" {
+		t.Errorf("ForceRefreshToken(): want refresh token redacted, got %q", tok.RefreshToken)
+	}
+	if lookupCalls != 3 {
+		t.Errorf("Lookup(): want 3 calls, got %d", lookupCalls)
+	}
+}
+
+func TestIsFreshReplacement(t *testing.T) {
+	now := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
+	old := &oauth2.Token{AccessToken: "old", Expiry: now.Add(time.Hour)}
+	candidate := &oauth2.Token{AccessToken: "candidate", Expiry: now.Add(time.Hour)}
+
+	tests := []struct {
+		name   string
+		cached *oauth2.Token
+		want   bool
+	}{
+		{
+			name:   "same token",
+			cached: &oauth2.Token{AccessToken: "old", Expiry: now.Add(time.Hour)},
+		},
+		{
+			name:   "expired replacement",
+			cached: &oauth2.Token{AccessToken: "winner", Expiry: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		{
+			name:   "replacement expires too soon",
+			cached: &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(-time.Minute - time.Second)},
+		},
+		{
+			name:   "replacement expiry within tolerance",
+			cached: &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(-time.Minute)},
+			want:   true,
+		},
+		{
+			name:   "replacement expires later",
+			cached: &oauth2.Token{AccessToken: "winner", Expiry: candidate.Expiry.Add(time.Minute)},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFreshReplacement(old, candidate, tt.cached); got != tt.want {
+				t.Errorf("isFreshReplacement(): want %t, got %t", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestForceRefreshToken_WithInMemoryCachePreservesCachedRefreshToken(t *testing.T) {
 	tokenCache := cache.NewInMemoryTokenCache()
 	arg, err := NewBasicAccountOAuthArgument("https://accounts.cloud.databricks.com", "xyz")


### PR DESCRIPTION
## Summary

Recovers U2M OAuth refreshes when another process wins a concurrent token cache write. The process whose write fails briefly reloads the cache and returns the fresh token stored by the winner.

## Why

Multiple CLI or SDK processes can read the same cached OAuth token, refresh it concurrently, and then race to replace the cache entry. On macOS, concurrent Keychain writes can cause one process to fail with `exit status 45`, even though another process successfully stored a valid token.

This addresses [databricks/cli#6051](https://github.com/databricks/cli/issues/6051) without adding cross-platform process locks. It does not prevent concurrent refreshes; it prevents a losing cache write from becoming an authentication failure when a fresh winner is available.

## What changed

### Interface changes

None.

### Behavioral changes

- After a refreshed token fails to be stored, `PersistentAuth` reloads the cache immediately and then after 25, 50, 100, and 200 milliseconds.
- A changed, valid cached token is returned when its expiry is within one minute of the token obtained by the current process.
- The original cache update error is preserved when no suitable token appears within the bounded 375-millisecond recovery window.

### Internal changes

- Added freshness comparison and cache update recovery helpers.
- Added tests covering delayed winner discovery, changed-token detection, validity, and expiry tolerance.
- Added a bug-fix changelog entry.

## How is this tested?

- `make test` (race-enabled full unit test suite)
- `make lint`
- `go test -count=1 ./credentials/u2m/...`

The real macOS Keychain race has not yet been stress-tested on macOS. The unit test models the observed sequence: the cache write fails, the first reload still sees the original token, and a later reload sees the fresh token stored by another process.
