### PR TITLE
Raise Minimum Go Version to 1.25

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+    - name: Setup Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      with:
+        go-version-file: go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         goVersion:
-          - "1.24"
           - "1.25"
           - "1.26"
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ For scoped coding rules, skills, and prompt templates, see the `.agent/` directo
 
 ## Development
 
-Prerequisites: Go 1.24+ (see `go.mod`), `goimports`, `staticcheck`, `gotestsum`.
+Prerequisites: Go 1.25+ (see `go.mod`), `goimports`, `staticcheck`, `gotestsum`.
 
 ```bash
 make build      # go build ./...
@@ -32,8 +32,8 @@ make coverage   # View HTML coverage report
 make codegen    # Regenerate service/ from OpenAPI specs
 ```
 
-CI runs `make test` across Go 1.24, 1.25, and 1.26; lint and fmt run on Go 1.26.
-Code must compile on all CI versions — do not use stdlib APIs newer than Go 1.24
+CI runs `make test` across Go 1.25 and 1.26; lint and fmt run on Go 1.26.
+Code must compile on all CI versions — do not use stdlib APIs newer than Go 1.25
 (the module's minimum version in `go.mod`) without a local shim.
 
 ## Architecture

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+ * Raise the minimum supported Go version from 1.24 to 1.25
+
 ### New Features and Improvements
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Databricks SDK for Go includes functionality to accelerate development with 
    ```go
    module sample
 
-   go 1.24
+   go 1.25
 
    require github.com/databricks/databricks-sdk-go v0.9.0
 

--- a/examples/slog/go.mod
+++ b/examples/slog/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/databricks/databricks-sdk-go v0.0.0 => ../..
 

--- a/examples/zerolog/go.mod
+++ b/examples/zerolog/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/databricks/databricks-sdk-go v0.0.0 => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databricks/databricks-sdk-go
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Summary

This PR raises the minimum supported Go version from 1.24 to 1.25. It unblocks the existing `golang.org/x/crypto` security updates in #1756, #1757, and #1758, which require Go 1.25.

## Why

The SDK still declares and tests Go 1.24, so Dependabot cannot land the patched `golang.org/x/crypto` release without first changing the supported toolchain. We will handle the next support-window shift separately by moving to Go 1.26 after Go 1.27 is released.

## What changed

### Interface changes

None.

### Behavioral changes

- Consumers must use Go 1.25 or newer to build the SDK.

### Internal changes

- Raise the root and example module directives to Go 1.25.
- Remove Go 1.24 from the CI test matrix.
- Update the README, contributor guidance, and breaking-change changelog entry.

## How is this tested?

- `make fmt`
- `make test`
- `make lint`


[DECO-27993]: https://databricks.atlassian.net/browse/DECO-27993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ