### PR TITLE
[DECO-28072] Fix Major-Only Runtime Version Selection

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - Recover from concurrent OAuth token cache writes by using the fresh token stored by another process.
+- Fix Spark runtime selection for major-only runtime versions.
 
 ### Documentation
 

--- a/service/compute/ext_spark_version.go
+++ b/service/compute/ext_spark_version.go
@@ -34,7 +34,7 @@ func (s sparkVersionsType) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-var dbrVersionRegex = regexp.MustCompile(`^(\d+\.\d+)\.x-.*`)
+var dbrVersionRegex = regexp.MustCompile(`^(\d+(?:\.\d+)?)\.x-.*`)
 
 func extractDbrVersions(s string) string {
 	m := dbrVersionRegex.FindStringSubmatch(s)

--- a/service/compute/ext_spark_version_test.go
+++ b/service/compute/ext_spark_version_test.go
@@ -37,3 +37,22 @@ func TestGetSparkVersionsResponse_Select_WithDuplicateSparkVersionsDifferentScal
 	require.NoError(t, err)
 	require.Equal(t, "16.4.x-scala2.13", selected)
 }
+
+func TestGetSparkVersionsResponse_Select_WithMajorOnlyRuntimeVersion(t *testing.T) {
+	resp := GetSparkVersionsResponse{
+		Versions: []SparkVersion{
+			{
+				Key:  "17.3.x-scala2.13",
+				Name: "17.3 LTS (includes Apache Spark 4.0.0, Scala 2.13)",
+			},
+			{
+				Key:  "18.x-scala2.13",
+				Name: "18 LTS (includes Apache Spark 4.1.0, Scala 2.13)",
+			},
+		},
+	}
+
+	selected, err := resp.Select(SparkVersionRequest{LongTermSupport: true, Latest: true, Scala: "2.13"})
+	require.NoError(t, err)
+	require.Equal(t, "18.x-scala2.13", selected)
+}


### PR DESCRIPTION
## Summary

Fixes Spark runtime selection so major-only runtime keys such as `18.x` sort correctly alongside legacy major-minor keys.

## Why

This behavior was originally reported in [terraform-provider-databricks#5866](https://github.com/databricks/terraform-provider-databricks/issues/5866).

`SelectSparkVersion` normalizes runtime keys before comparing them as semantic versions. The existing normalization only recognized `major.minor.x`, leaving `major.x` keys invalid and sorting them behind older valid versions.

## What changed

### Interface changes

None.

### Behavioral changes

Latest-version queries now correctly prefer newer major-only runtime versions when they match the requested filters.

### Internal changes

The runtime-version parser accepts both numbering formats, with a regression test covering LTS selection across `17.3.x` and `18.x`.