### PR TITLE
Accept numeric strings for int64 response fields

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Recover from concurrent OAuth token cache writes by using the fresh token stored by another process.
 - Fix Spark runtime selection for major-only runtime versions.
+- Accept JSON numbers and decimal strings when unmarshalling `int64` API response fields.
 
 ### Documentation
 

--- a/marshal/int64.go
+++ b/marshal/int64.go
@@ -1,0 +1,248 @@
+package marshal
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+var (
+	int64Type      = reflect.TypeFor[int64]()
+	rawMessageType = reflect.TypeFor[json.RawMessage]()
+)
+
+type jsonReplacement struct {
+	start int
+	end   int
+	value []byte
+}
+
+type int64Normalizer struct {
+	data         []byte
+	decoder      *json.Decoder
+	replacements []jsonReplacement
+}
+
+// normalizeInt64Strings rewrites quoted integers as JSON numbers wherever the
+// destination type expects an int64. It uses only the destination's type and
+// does not modify the destination value. This preprocessing is necessary
+// because encoding/json cannot accept both quoted and unquoted integers for a
+// plain int64 field. JSON values that do not require normalization preserve
+// their original bytes.
+func normalizeInt64Strings(data []byte, destination any) ([]byte, error) {
+	normalizer := int64Normalizer{
+		data:    data,
+		decoder: json.NewDecoder(bytes.NewReader(data)),
+	}
+	if err := normalizer.normalizeValue(reflect.TypeOf(destination)); err != nil {
+		return nil, err
+	}
+	if err := normalizer.decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("multiple JSON values")
+		}
+		return nil, err
+	}
+	if len(normalizer.replacements) == 0 {
+		return data, nil
+	}
+
+	normalized := make([]byte, 0, len(data))
+	last := 0
+	for _, replacement := range normalizer.replacements {
+		normalized = append(normalized, data[last:replacement.start]...)
+		normalized = append(normalized, replacement.value...)
+		last = replacement.end
+	}
+	normalized = append(normalized, data[last:]...)
+	return normalized, nil
+}
+
+func (n *int64Normalizer) normalizeValue(target reflect.Type) error {
+	for target != nil && target.Kind() == reflect.Pointer {
+		target = target.Elem()
+	}
+	if target == rawMessageType {
+		return n.skipValue()
+	}
+	if target == int64Type {
+		return n.normalizeInt64()
+	}
+	if target == nil {
+		return n.skipValue()
+	}
+
+	switch target.Kind() {
+	case reflect.Struct:
+		return n.normalizeStruct(target)
+	case reflect.Array, reflect.Slice:
+		return n.normalizeArray(target.Elem())
+	case reflect.Map:
+		return n.normalizeMap(target.Elem())
+	default:
+		return n.skipValue()
+	}
+}
+
+func (n *int64Normalizer) normalizeInt64() error {
+	raw, start, end, err := n.decodeRawMessage()
+	if err != nil || len(raw) == 0 || raw[0] != '"' {
+		return err
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return err
+	}
+	value, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return err
+	}
+	n.replacements = append(n.replacements, jsonReplacement{
+		start: start,
+		end:   end,
+		value: strconv.AppendInt(nil, value, 10),
+	})
+	return nil
+}
+
+func (n *int64Normalizer) normalizeStruct(target reflect.Type) error {
+	if n.nextValueByte() != '{' {
+		return n.skipValue()
+	}
+	if _, err := n.decoder.Token(); err != nil {
+		return err
+	}
+	for n.decoder.More() {
+		keyStart := n.nextValuePosition()
+		token, err := n.decoder.Token()
+		if err != nil {
+			return err
+		}
+		name, ok := token.(string)
+		if !ok {
+			return errors.New("invalid JSON object name")
+		}
+
+		field, ok := findJSONField(target, name)
+		if !ok || field.asString {
+			if err := n.skipValue(); err != nil {
+				return err
+			}
+			continue
+		}
+		if field.name != name {
+			encodedName, err := json.Marshal(field.name)
+			if err != nil {
+				return err
+			}
+			n.replacements = append(n.replacements, jsonReplacement{
+				start: keyStart,
+				end:   int(n.decoder.InputOffset()),
+				value: encodedName,
+			})
+		}
+		if err := n.normalizeValue(field.fieldType); err != nil {
+			return err
+		}
+	}
+	_, err := n.decoder.Token()
+	return err
+}
+
+func (n *int64Normalizer) normalizeArray(elementType reflect.Type) error {
+	if n.nextValueByte() != '[' {
+		return n.skipValue()
+	}
+	if _, err := n.decoder.Token(); err != nil {
+		return err
+	}
+	for n.decoder.More() {
+		if err := n.normalizeValue(elementType); err != nil {
+			return err
+		}
+	}
+	_, err := n.decoder.Token()
+	return err
+}
+
+func (n *int64Normalizer) normalizeMap(elementType reflect.Type) error {
+	if n.nextValueByte() != '{' {
+		return n.skipValue()
+	}
+	if _, err := n.decoder.Token(); err != nil {
+		return err
+	}
+	for n.decoder.More() {
+		if _, err := n.decoder.Token(); err != nil {
+			return err
+		}
+		if err := n.normalizeValue(elementType); err != nil {
+			return err
+		}
+	}
+	_, err := n.decoder.Token()
+	return err
+}
+
+func (n *int64Normalizer) skipValue() error {
+	_, _, _, err := n.decodeRawMessage()
+	return err
+}
+
+func (n *int64Normalizer) decodeRawMessage() (json.RawMessage, int, int, error) {
+	var raw json.RawMessage
+	if err := n.decoder.Decode(&raw); err != nil {
+		return nil, 0, 0, err
+	}
+	end := int(n.decoder.InputOffset())
+	return raw, end - len(raw), end, nil
+}
+
+func (n *int64Normalizer) nextValueByte() byte {
+	position := n.nextValuePosition()
+	if position >= len(n.data) {
+		return 0
+	}
+	return n.data[position]
+}
+
+func (n *int64Normalizer) nextValuePosition() int {
+	position := int(n.decoder.InputOffset())
+	for position < len(n.data) {
+		switch n.data[position] {
+		case ' ', '\t', '\r', '\n', ',', ':':
+			position++
+		default:
+			return position
+		}
+	}
+	return position
+}
+
+type jsonField struct {
+	name      string
+	fieldType reflect.Type
+	asString  bool
+}
+
+func findJSONField(target reflect.Type, name string) (jsonField, bool) {
+	var folded jsonField
+	for _, field := range reflect.VisibleFields(target) {
+		tag := parseJSONTag(field)
+		if tag.ignore || field.Anonymous || field.PkgPath != "" {
+			continue
+		}
+		if tag.name == name {
+			return jsonField{tag.name, field.Type, tag.asString}, true
+		}
+		if folded.fieldType == nil && strings.EqualFold(tag.name, name) {
+			folded = jsonField{tag.name, field.Type, tag.asString}
+		}
+	}
+	return folded, folded.fieldType != nil
+}

--- a/marshal/int64_test.go
+++ b/marshal/int64_test.go
@@ -1,0 +1,149 @@
+package marshal
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshal_int64NumberOrString(t *testing.T) {
+	type nested struct {
+		ID int64 `json:"id"`
+	}
+	type response struct {
+		ID     int64            `json:"id"`
+		IDs    []int64          `json:"ids"`
+		Nested nested           `json:"nested"`
+		ByName map[string]int64 `json:"by_name"`
+		Name   string           `json:"name"`
+	}
+
+	input := []byte(`{
+		"id": "9223372036854775807",
+		"ids": [1, "-9223372036854775808"],
+		"nested": {"id": "3"},
+		"by_name": {"four": "4"},
+		"name": "5"
+	}`)
+	want := response{
+		ID:     math.MaxInt64,
+		IDs:    []int64{1, math.MinInt64},
+		Nested: nested{ID: 3},
+		ByName: map[string]int64{"four": 4},
+		Name:   "5",
+	}
+
+	var got response
+	if err := Unmarshal(input, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Unmarshal() = %#v, want %#v", got, want)
+	}
+}
+
+func TestUnmarshal_invalidInt64String(t *testing.T) {
+	type response struct {
+		ID int64 `json:"id"`
+	}
+
+	err := Unmarshal([]byte(`{"id":"not-an-int"}`), &response{})
+	if err == nil {
+		t.Fatal("Unmarshal() error = nil, want non-nil")
+	}
+}
+
+func TestUnmarshal_int64NullPreservesValue(t *testing.T) {
+	type response struct {
+		ID int64 `json:"id"`
+	}
+
+	got := response{ID: 7}
+	if err := Unmarshal([]byte(`{"id":null}`), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.ID != 7 {
+		t.Errorf("Unmarshal() ID = %d, want 7", got.ID)
+	}
+}
+
+func TestUnmarshal_int64StringPreservesRawMessage(t *testing.T) {
+	type response struct {
+		Created int64             `json:"created"`
+		Outputs []json.RawMessage `json:"outputs"`
+	}
+
+	input := []byte(`{
+		"created": "7",
+		"outputs": [{ "escaped": "<value>", "numbers" : [1, 2] }]
+	}`)
+	var baseline struct {
+		Outputs []json.RawMessage `json:"outputs"`
+	}
+	if err := json.Unmarshal(input, &baseline); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	var got response
+	if err := Unmarshal(input, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Created != 7 {
+		t.Errorf("Unmarshal() Created = %d, want 7", got.Created)
+	}
+	if !reflect.DeepEqual(got.Outputs, baseline.Outputs) {
+		t.Errorf("Unmarshal() Outputs = %q, want %q", got.Outputs, baseline.Outputs)
+	}
+}
+
+func TestUnmarshal_int64StringInAnonymousField(t *testing.T) {
+	type Embedded struct {
+		ID int64 `json:"id"`
+	}
+	type response struct {
+		Embedded
+	}
+
+	var got response
+	if err := Unmarshal([]byte(`{"id":"7"}`), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.ID != 7 {
+		t.Errorf("Unmarshal() ID = %d, want 7", got.ID)
+	}
+}
+
+func TestUnmarshal_customUnmarshalerInt64String(t *testing.T) {
+	got := int64FieldsWithForceSend{}
+	if err := json.Unmarshal([]byte(`{"id":"7"}`), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.ID != 7 {
+		t.Errorf("json.Unmarshal() ID = %d, want 7", got.ID)
+	}
+}
+
+func TestUnmarshal_caseInsensitiveFieldName(t *testing.T) {
+	type response struct {
+		Value string
+	}
+
+	var got response
+	if err := Unmarshal([]byte(`{"value":"test"}`), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Value != "test" {
+		t.Errorf("Unmarshal() Value = %q, want %q", got.Value, "test")
+	}
+}
+
+type int64FieldsWithForceSend struct {
+	ID int64 `json:"id,omitempty"`
+
+	ForceSendFields []string `json:"-"`
+}
+
+func (s *int64FieldsWithForceSend) UnmarshalJSON(data []byte) error {
+	return Unmarshal(data, s)
+}

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -12,9 +12,13 @@ func Unmarshal(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
-	var jsonFields map[string]json.RawMessage
-	err := json.Unmarshal([]byte(data), &jsonFields)
+	data, err := normalizeInt64Strings(data, v)
 	if err != nil {
+		return err
+	}
+
+	var jsonFields map[string]json.RawMessage
+	if err = json.Unmarshal([]byte(data), &jsonFields); err != nil {
 		return err
 	}
 
@@ -22,7 +26,6 @@ func Unmarshal(data []byte, v any) error {
 	value = reflect.Indirect(value)
 
 	objectType := value.Type()
-
 	foundFields := []string{}
 
 	for _, field := range getTypeFields(objectType) {


### PR DESCRIPTION
## Summary

Accepts API `int64` fields encoded as either JSON numbers or decimal strings when generated models use `marshal.Unmarshal`.

## Why

Databricks services do not consistently encode 64-bit integers: the same field may be returned as `123` or `"123"`. Go's `encoding/json` cannot accept both representations for a plain `int64`, and changing generated fields to a custom type would break the public API.

This change normalizes quoted integers before the existing model unmarshalling logic runs. It uses destination type information to rewrite only matching `int64` tokens, preserving unrelated JSON bytes such as `json.RawMessage` payloads. A companion code-generator change will make all generated model structs use `marshal.Unmarshal`.

## What changed

### Interface changes

None.

### Behavioral changes

- `marshal.Unmarshal` accepts numeric and decimal-string representations of `int64` fields, including nested slices and maps.
- JSON `null` continues to leave populated scalar `int64` values unchanged.
- Invalid and overflowing decimal strings return an error.

### Internal changes

- Adds a type-aware normalization pass using `json.Decoder` offsets so only quoted `int64` tokens are replaced.
- Handles promoted fields from anonymous embedded structs.
- Preserves raw JSON values byte-for-byte when they do not require normalization.
- Updates `NEXT_CHANGELOG.md`.

## How is this tested?

- `make test`
- `make lint`
- `go test -race ./marshal`
- `go test ./marshal ./httpclient ./httpclient/fixtures ./config/experimental/auth/oidc`
