### PR TITLE
Add U2M group role assumption support

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,4 +12,8 @@
 
 ### Internal Changes
 
+- Added group ID configuration and U2M OAuth support for CLI role assumption.
+  Account authentication is rejected, while unified authentication passes the
+  group ID to the OAuth server for compatibility with future support.
+
 ### API Changes

--- a/config/config.go
+++ b/config/config.go
@@ -129,6 +129,14 @@ type Config struct {
 	// server disambiguates.
 	WorkspaceID string `name:"workspace_id" env:"DATABRICKS_WORKSPACE_ID"`
 
+	// GroupID is the ID of the Databricks group whose role is assumed through
+	// role-based access control (RBAC).
+	//
+	// Warning: Group role assumption currently works only for workspace
+	// authorization. Unified authentication passes the group ID to the OAuth
+	// server for compatibility with future support.
+	GroupID string `name:"group_id" env:"DATABRICKS_GROUP_ID"`
+
 	Token    string `name:"token" env:"DATABRICKS_TOKEN" auth:"pat,sensitive"`
 	Username string `name:"username" env:"DATABRICKS_USERNAME" auth:"basic"`
 	Password string `name:"password" env:"DATABRICKS_PASSWORD" auth:"basic,sensitive"`

--- a/config/config.go
+++ b/config/config.go
@@ -132,9 +132,9 @@ type Config struct {
 	// GroupID is the ID of the Databricks group whose role is assumed through
 	// role-based access control (RBAC).
 	//
-	// Warning: Group role assumption currently works only for workspace
-	// authorization. Unified authentication passes the group ID to the OAuth
-	// server for compatibility with future support.
+	// Warning: As of August 2026, group role assumption works only for workspace
+	// authorization. Unified authentication still passes the group ID to the OAuth
+	// server and may work in the future if server support is added.
 	GroupID string `name:"group_id" env:"DATABRICKS_GROUP_ID"`
 
 	Token    string `name:"token" env:"DATABRICKS_TOKEN" auth:"pat,sensitive"`

--- a/config/config_auth_details_test.go
+++ b/config/config_auth_details_test.go
@@ -20,6 +20,7 @@ func TestConfigAuthDetails(t *testing.T) {
 
 	ConfigAttributes.ResolveFromStringMapWithSource(c, map[string]string{
 		"azure_client_id": "1234",
+		"group_id":        "group-A",
 	}, Source{Type: SourceFile, Name: "test.file"})
 
 	authDetails := c.GetAuthDetails()
@@ -36,6 +37,10 @@ func TestConfigAuthDetails(t *testing.T) {
 	assert.Equal(t, "1234", authDetails.Configuration["azure_client_id"].Value)
 	assert.Equal(t, "test.file config file", authDetails.Configuration["azure_client_id"].Source.String())
 	assert.True(t, authDetails.Configuration["azure_client_id"].AuthTypeMismatch)
+
+	assert.Equal(t, "group-A", authDetails.Configuration["group_id"].Value)
+	assert.Equal(t, "test.file config file", authDetails.Configuration["group_id"].Source.String())
+	assert.False(t, authDetails.Configuration["group_id"].AuthTypeMismatch)
 }
 
 func TestConfigAuthDetailsToString(t *testing.T) {

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -98,6 +98,65 @@ func TestConfigFile_Scopes(t *testing.T) {
 	}
 }
 
+func TestConfigFile_GroupIDLoadingAndPrecedence(t *testing.T) {
+	testCases := []struct {
+		name        string
+		profile     string
+		direct      string
+		environment string
+		want        string
+	}{
+		{
+			name:    "loads group ID from selected profile",
+			profile: "group",
+			want:    "profile-group",
+		},
+		{
+			name:    "profile without group ID leaves value empty",
+			profile: "normal",
+			want:    "",
+		},
+		{
+			name:        "environment group ID overrides profile",
+			profile:     "group",
+			environment: "environment-group",
+			want:        "environment-group",
+		},
+		{
+			name:        "direct group ID overrides environment and profile",
+			profile:     "group",
+			direct:      "direct-group",
+			environment: "environment-group",
+			want:        "direct-group",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			withMockEnv(t, map[string]string{
+				"HOME":                "testdata/group_id",
+				"DATABRICKS_GROUP_ID": testCase.environment,
+			})
+
+			cfg := &Config{
+				Profile: testCase.profile,
+				GroupID: testCase.direct,
+			}
+
+			if err := ConfigAttributes.Configure(cfg); err != nil {
+				t.Fatalf("ConfigAttributes.Configure(): %v", err)
+			}
+			if err := ConfigFile.Configure(cfg); err != nil {
+				t.Fatalf("ConfigFile.Configure(): %v", err)
+			}
+
+			if cfg.GroupID != testCase.want {
+				t.Errorf("GroupID = %q, want %q", cfg.GroupID, testCase.want)
+			}
+		})
+	}
+}
+
 // Test 1: default_profile resolves correctly (no [DEFAULT] section present)
 func TestConfigFile_DefaultProfileResolves(t *testing.T) {
 	configFixture{

--- a/config/testdata/group_id/.databrickscfg
+++ b/config/testdata/group_id/.databrickscfg
@@ -1,0 +1,8 @@
+[group]
+host = https://workspace.cloud.databricks.com
+auth_type = databricks-cli
+group_id = profile-group
+
+[normal]
+host = https://workspace.cloud.databricks.com
+auth_type = databricks-cli

--- a/credentials/u2m/discovery_token_source.go
+++ b/credentials/u2m/discovery_token_source.go
@@ -58,7 +58,7 @@ const discoveryTargetAccount = "ACCOUNT"
 // the discovery OAuth flow. The OIDC authorize path with all OAuth query params
 // is URL-encoded as the destination_url parameter.
 func BuildDiscoveryAuthorizeURL(redirectAddr, state string, pkce PKCEParams, scopes []string) string {
-	return buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, redirectAddr, state, pkce, scopes, "")
+	return buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, redirectAddr, state, pkce, scopes, "", "")
 }
 
 // buildDiscoveryAuthorizeURL builds the discovery authorize URL against the
@@ -67,7 +67,7 @@ func BuildDiscoveryAuthorizeURL(redirectAddr, state string, pkce PKCEParams, sco
 // non-empty it is set as the top-level `target` query parameter, which
 // login.databricks.com uses to route the user to a specific selector page
 // (e.g. "ACCOUNT" for the account selector).
-func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParams, scopes []string, target string) string {
+func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParams, scopes []string, target, groupID string) string {
 	// Build the nested OIDC authorize path with query parameters.
 	authParams := url.Values{}
 	authParams.Set("client_id", appClientID)
@@ -77,6 +77,11 @@ func buildDiscoveryAuthorizeURL(host, redirectAddr, state string, pkce PKCEParam
 	authParams.Set("state", state)
 	authParams.Set("code_challenge", pkce.Challenge)
 	authParams.Set("code_challenge_method", pkce.ChallengeMethod)
+
+	if groupID != "" {
+		authParams.Set("assume_group", groupID)
+	}
+
 	destinationURL := "/oidc/v1/authorize?" + authParams.Encode()
 
 	// Wrap the authorize path as the destination_url query parameter on the
@@ -138,7 +143,7 @@ func (d *discoveryTokenSource) challenge() error {
 	if host == "" {
 		host = defaultLoginDatabricksHost
 	}
-	authorizeURL := buildDiscoveryAuthorizeURL(host, d.pa.redirectAddr, state, pkce, scopes, d.target)
+	authorizeURL := buildDiscoveryAuthorizeURL(host, d.pa.redirectAddr, state, pkce, scopes, d.target, d.pa.groupID)
 
 	code, returnedState, issuer, err := cb.handlerWithIssuer(authorizeURL)
 	if err != nil {

--- a/credentials/u2m/discovery_token_source_test.go
+++ b/credentials/u2m/discovery_token_source_test.go
@@ -187,7 +187,7 @@ func TestBuildDiscoveryAuthorizeURL_HostOverride(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildDiscoveryAuthorizeURL(tc.host, "localhost:8020", "s", pkce, scopes, "")
+			got := buildDiscoveryAuthorizeURL(tc.host, "localhost:8020", "s", pkce, scopes, "", "")
 			u, err := url.Parse(got)
 			if err != nil {
 				t.Fatalf("parsing URL: %v", err)
@@ -216,7 +216,7 @@ func TestBuildDiscoveryAuthorizeURL_Target(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, "localhost:8020", "s", pkce, scopes, tc.target)
+			got := buildDiscoveryAuthorizeURL(defaultLoginDatabricksHost, "localhost:8020", "s", pkce, scopes, tc.target, "")
 			u, err := url.Parse(got)
 			if err != nil {
 				t.Fatalf("parsing URL: %v", err)
@@ -229,6 +229,43 @@ func TestBuildDiscoveryAuthorizeURL_Target(t *testing.T) {
 				t.Error("destination_url should be set regardless of target")
 			}
 		})
+	}
+}
+
+// A hostless CLI login forwards destination_url to the selected workspace, so
+// assume_group must be nested there for the workspace authorization endpoint.
+func TestBuildDiscoveryAuthorizeURL_GroupIDIsNested(t *testing.T) {
+	pkce := PKCEParams{
+		Challenge:       "challenge",
+		ChallengeMethod: "S256",
+		Verifier:        "verifier",
+	}
+	authorizationURL := buildDiscoveryAuthorizeURL(
+		defaultLoginDatabricksHost,
+		"localhost:8020",
+		"state",
+		pkce,
+		[]string{"offline_access", "all-apis"},
+		"",
+		"group-123",
+	)
+
+	topLevelURL, err := url.Parse(authorizationURL)
+	if err != nil {
+		t.Fatalf("url.Parse(): %v", err)
+	}
+
+	if got := topLevelURL.Query().Get("assume_group"); got != "" {
+		t.Errorf("top-level assume_group = %q, want empty", got)
+	}
+
+	destinationURL, err := url.Parse(topLevelURL.Query().Get("destination_url"))
+	if err != nil {
+		t.Fatalf("url.Parse(destination_url): %v", err)
+	}
+
+	if got := destinationURL.Query()["assume_group"]; len(got) != 1 || got[0] != "group-123" {
+		t.Errorf("nested assume_group = %v, want [group-123]", got)
 	}
 }
 
@@ -274,6 +311,12 @@ func TestDiscoveryTokenSource_Challenge(t *testing.T) {
 		if r.URL.Path != "/oidc/v1/token" {
 			t.Errorf("token server: want path /oidc/v1/token, got %s", r.URL.Path)
 		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("token server: ParseForm(): %v", err)
+		}
+		if _, ok := r.Form["assume_group"]; ok {
+			t.Error("code exchange must not include assume_group")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"access_token":"test-access-token","refresh_token":"test-refresh-token","token_type":"Bearer","expires_in":3600}`)
 	}))
@@ -309,6 +352,7 @@ func TestDiscoveryTokenSource_Challenge(t *testing.T) {
 		WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
 		WithOAuthArgument(arg),
 		WithDiscoveryLogin(),
+		WithGroupID("group-123"),
 	)
 	if err != nil {
 		t.Fatalf("NewPersistentAuth(): %v", err)
@@ -340,6 +384,9 @@ func TestDiscoveryTokenSource_Challenge(t *testing.T) {
 		dest, err := url.Parse(destURL)
 		if err != nil {
 			t.Fatalf("parsing destination_url: %v", err)
+		}
+		if got := dest.Query()["assume_group"]; len(got) != 1 || got[0] != "group-123" {
+			t.Errorf("nested assume_group = %v, want [group-123]", got)
 		}
 		state = dest.Query().Get("state")
 		if state == "" {

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -229,8 +229,9 @@ func WithDiscoveryAccountTarget() PersistentAuthOption {
 // exchange, refresh, and API requests do not resend it.
 //
 // Warning: Account authentication does not support group role assumption.
-// Unified authentication passes the group ID to the OAuth server, which may
-// reject it until unified group role assumption is supported.
+// As of August 2026, unified authentication rejects the group ID. The SDK still
+// passes it to the OAuth server so unified role assumption may work in the future
+// if server support is added.
 func WithGroupID(groupID string) PersistentAuthOption {
 	return func(a *PersistentAuth) {
 		a.groupID = groupID
@@ -566,7 +567,8 @@ func (a *PersistentAuth) resolveScopes() []string {
 	return scopes
 }
 
-// oauth2Config returns the OAuth2 configuration for the given OAuthArgument.
+// oauth2Config returns the common OAuth2 configuration used for authorization
+// and token refresh.
 func (a *PersistentAuth) oauth2Config() (*oauth2.Config, error) {
 	scopes := a.resolveScopes()
 
@@ -600,7 +602,8 @@ func (a *PersistentAuth) oauth2Config() (*oauth2.Config, error) {
 	}, nil
 }
 
-// authorizationConfig adds parameters used only by the OAuth authorization request.
+// authorizationConfig extends the common OAuth2 configuration with parameters
+// used only for the initial authorization request, such as group role assumption.
 func (a *PersistentAuth) authorizationConfig() (*oauth2.Config, error) {
 	config, err := a.oauth2Config()
 	if err != nil {

--- a/credentials/u2m/persistent_auth.go
+++ b/credentials/u2m/persistent_auth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -117,6 +118,10 @@ type PersistentAuth struct {
 	// login.databricks.com lands the user on the account selector instead of
 	// the workspace selector. Use for account-only logins.
 	discoveryAccountTarget bool
+
+	// groupID is the ID of the Databricks group whose role is assumed through
+	// RBAC. The authorization code and refresh token retain this selection.
+	groupID string
 }
 
 type PersistentAuthOption func(*PersistentAuth)
@@ -215,6 +220,20 @@ func WithDiscoveryHost(host string) PersistentAuthOption {
 func WithDiscoveryAccountTarget() PersistentAuthOption {
 	return func(a *PersistentAuth) {
 		a.discoveryAccountTarget = true
+	}
+}
+
+// WithGroupID configures the ID of the Databricks group whose role is assumed
+// during a new U2M browser authorization through role-based access control
+// (RBAC). The group ID is sent only on the authorization request; code
+// exchange, refresh, and API requests do not resend it.
+//
+// Warning: Account authentication does not support group role assumption.
+// Unified authentication passes the group ID to the OAuth server, which may
+// reject it until unified group role assumption is supported.
+func WithGroupID(groupID string) PersistentAuthOption {
+	return func(a *PersistentAuth) {
+		a.groupID = groupID
 	}
 }
 
@@ -404,9 +423,9 @@ func (a *PersistentAuth) Challenge() error {
 	// the callback server is not created, we need to close the listener manually.
 	defer a.Close()
 
-	cfg, err := a.oauth2Config()
+	cfg, err := a.authorizationConfig()
 	if err != nil {
-		return fmt.Errorf("fetching oauth config: %w", err)
+		return fmt.Errorf("building authorization config: %w", err)
 	}
 	cb, err := a.newCallbackServer()
 	if err != nil {
@@ -522,6 +541,14 @@ func (a *PersistentAuth) validateArg() error {
 	if a.discoveryMode && !isDiscoveryArg {
 		return fmt.Errorf("discovery login requires DiscoveryOAuthArgument, got %T", a.oAuthArgument)
 	}
+	// Account authentication does not support group role assumption.
+	if a.groupID != "" && isAccountArg {
+		return errors.New("group ID is not supported for account authentication")
+	}
+	// Account-target discovery does not support group role assumption.
+	if a.groupID != "" && isDiscoveryArg && a.discoveryAccountTarget {
+		return errors.New("group ID is not supported for account discovery")
+	}
 	return nil
 }
 
@@ -571,6 +598,38 @@ func (a *PersistentAuth) oauth2Config() (*oauth2.Config, error) {
 		RedirectURL: fmt.Sprintf("http://%s", a.redirectAddr),
 		Scopes:      scopes,
 	}, nil
+}
+
+// authorizationConfig adds parameters used only by the OAuth authorization request.
+func (a *PersistentAuth) authorizationConfig() (*oauth2.Config, error) {
+	config, err := a.oauth2Config()
+	if err != nil {
+		return nil, err
+	}
+
+	if a.groupID == "" {
+		return config, nil
+	}
+
+	config.Endpoint.AuthURL, err = authorizationURLWithGroupID(config.Endpoint.AuthURL, a.groupID)
+	if err != nil {
+		return nil, fmt.Errorf("adding group ID to authorization endpoint: %w", err)
+	}
+
+	return config, nil
+}
+
+func authorizationURLWithGroupID(rawURL, groupID string) (string, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing authorization endpoint %q: %w", rawURL, err)
+	}
+
+	query := parsedURL.Query()
+	query.Set("assume_group", groupID)
+	parsedURL.RawQuery = query.Encode()
+
+	return parsedURL.String(), nil
 }
 
 func (a *PersistentAuth) stateAndPKCE() (string, *authhandler.PKCEParams, error) {

--- a/credentials/u2m/persistent_auth_test.go
+++ b/credentials/u2m/persistent_auth_test.go
@@ -901,6 +901,189 @@ func TestChallenge(t *testing.T) {
 	}
 }
 
+func TestAuthorizationConfig_GroupIDOnlyChangesAuthorizationEndpoint(t *testing.T) {
+	argument, err := NewBasicWorkspaceOAuthArgument("https://workspace.cloud.databricks.com")
+	if err != nil {
+		t.Fatalf("NewBasicWorkspaceOAuthArgument(): %v", err)
+	}
+
+	persistentAuth, err := NewPersistentAuth(
+		context.Background(),
+		WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
+		WithOAuthArgument(argument),
+		WithGroupID("group-A"),
+	)
+	if err != nil {
+		t.Fatalf("NewPersistentAuth(): %v", err)
+	}
+
+	baseConfig, err := persistentAuth.oauth2Config()
+	if err != nil {
+		t.Fatalf("oauth2Config(): %v", err)
+	}
+
+	if strings.Contains(baseConfig.Endpoint.AuthURL, "assume_group") {
+		t.Errorf("oauth2Config() AuthURL = %q, want no assume_group", baseConfig.Endpoint.AuthURL)
+	}
+
+	config, err := persistentAuth.authorizationConfig()
+	if err != nil {
+		t.Fatalf("authorizationConfig(): %v", err)
+	}
+
+	authorizationURL, err := url.Parse(config.Endpoint.AuthURL)
+	if err != nil {
+		t.Fatalf("url.Parse(AuthURL): %v", err)
+	}
+
+	if got := authorizationURL.Query()["assume_group"]; len(got) != 1 || got[0] != "group-A" {
+		t.Errorf("authorization assume_group = %v, want [group-A]", got)
+	}
+	if strings.Contains(config.Endpoint.TokenURL, "assume_group") {
+		t.Errorf("TokenURL = %q, want no assume_group", config.Endpoint.TokenURL)
+	}
+}
+
+func TestChallenge_GroupIDStoresTokenUnderProfileKey(t *testing.T) {
+	const profile = "prod"
+
+	var storedKey string
+	tokenCache := &tokenCacheMock{
+		store: func(key string, _ *oauth2.Token) error {
+			storedKey = key
+			return nil
+		},
+	}
+
+	browserOpened := make(chan string, 1)
+	argument, err := NewProfileWorkspaceOAuthArgument("https://workspace.cloud.databricks.com", profile)
+	if err != nil {
+		t.Fatalf("NewProfileWorkspaceOAuthArgument(): %v", err)
+	}
+
+	persistentAuth, err := NewPersistentAuth(
+		context.Background(),
+		WithTokenCache(tokenCache),
+		WithBrowser(func(authorizationURL string) error {
+			browserOpened <- authorizationURL
+			return nil
+		}),
+		WithHttpClient(&http.Client{
+			Transport: fixtures.SliceTransport{
+				{
+					Method:   "POST",
+					Resource: "/oidc/v1/token",
+					Response: `{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":3600}`,
+					ResponseHeaders: map[string][]string{
+						"Content-Type": {"application/json"},
+					},
+				},
+			},
+		}),
+		WithOAuthEndpointSupplier(MockOAuthEndpointSupplier{}),
+		WithOAuthArgument(argument),
+		WithGroupID("group-A"),
+	)
+	if err != nil {
+		t.Fatalf("NewPersistentAuth(): %v", err)
+	}
+	defer persistentAuth.Close()
+
+	completeChallenge(t, persistentAuth, browserOpened)
+
+	if storedKey != profile {
+		t.Errorf("Store() key = %q, want %q", storedKey, profile)
+	}
+}
+
+func TestWithGroupID_ArgumentValidation(t *testing.T) {
+	workspaceArgument, err := NewBasicWorkspaceOAuthArgument("https://workspace.cloud.databricks.com")
+	if err != nil {
+		t.Fatalf("NewBasicWorkspaceOAuthArgument(): %v", err)
+	}
+
+	accountArgument, err := NewBasicAccountOAuthArgument("https://accounts.cloud.databricks.com", "account")
+	if err != nil {
+		t.Fatalf("NewBasicAccountOAuthArgument(): %v", err)
+	}
+
+	unifiedAccountArgument, err := NewBasicUnifiedOAuthArgument("https://unified.cloud.databricks.com", "account")
+	if err != nil {
+		t.Fatalf("NewBasicUnifiedOAuthArgument(): %v", err)
+	}
+
+	discoveryArgument, err := NewBasicDiscoveryOAuthArgument("profile")
+	if err != nil {
+		t.Fatalf("NewBasicDiscoveryOAuthArgument(): %v", err)
+	}
+
+	testCases := []struct {
+		name      string
+		options   []PersistentAuthOption
+		groupID   string
+		wantError string
+	}{
+		{
+			name:    "workspace",
+			options: []PersistentAuthOption{WithOAuthArgument(workspaceArgument)},
+			groupID: "group-A",
+		},
+		{
+			name:      "account",
+			options:   []PersistentAuthOption{WithOAuthArgument(accountArgument)},
+			groupID:   "group-A",
+			wantError: "group ID is not supported for account authentication",
+		},
+		{
+			name:    "unified is passed to the OAuth server",
+			options: []PersistentAuthOption{WithOAuthArgument(unifiedAccountArgument)},
+			groupID: "group-A",
+		},
+		{
+			name: "discovery",
+			options: []PersistentAuthOption{
+				WithOAuthArgument(discoveryArgument),
+				WithDiscoveryLogin(),
+			},
+			groupID: "group-A",
+		},
+		{
+			name: "account discovery",
+			options: []PersistentAuthOption{
+				WithOAuthArgument(discoveryArgument),
+				WithDiscoveryLogin(),
+				WithDiscoveryAccountTarget(),
+			},
+			groupID:   "group-A",
+			wantError: "group ID is not supported for account discovery",
+		},
+		{
+			name: "empty group does not change discovery",
+			options: []PersistentAuthOption{
+				WithOAuthArgument(discoveryArgument),
+				WithDiscoveryLogin(),
+			},
+			groupID: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			options := append(testCase.options, WithGroupID(testCase.groupID))
+			_, err := NewPersistentAuth(context.Background(), options...)
+			if testCase.wantError != "" {
+				if err == nil || err.Error() != testCase.wantError {
+					t.Fatalf("NewPersistentAuth() error = %v, want %q", err, testCase.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewPersistentAuth(): %v", err)
+			}
+		})
+	}
+}
+
 func TestChallenge_ReturnsErrorOnFailure(t *testing.T) {
 	ctx := context.Background()
 	browserOpened := make(chan string)
@@ -1332,5 +1515,54 @@ func TestChallenge_Discovery(t *testing.T) {
 	}
 	if storedToken.RefreshToken != "discovery-refresh-token" {
 		t.Errorf("refresh token = %q, want %q", storedToken.RefreshToken, "discovery-refresh-token")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Test helper functions
+// ----------------------------------------------------------------------------
+
+// completeChallenge simulates the callback for a browser authorization URL and
+// waits for the OAuth challenge to finish.
+func completeChallenge(t *testing.T, persistentAuth *PersistentAuth, browserOpened <-chan string) {
+	t.Helper()
+
+	errorChannel := make(chan error, 1)
+	go func() {
+		errorChannel <- persistentAuth.Challenge()
+	}()
+
+	var authorizationURL string
+	select {
+	case authorizationURL = <-browserOpened:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for browser authorization")
+	}
+
+	parsedAuthorizationURL, err := url.ParseRequestURI(authorizationURL)
+	if err != nil {
+		t.Fatalf("url.ParseRequestURI(): %v", err)
+	}
+
+	state := parsedAuthorizationURL.Query().Get("state")
+	callbackClient := &http.Client{Timeout: 5 * time.Second}
+	callbackURL := fmt.Sprintf("http://%s?code=code&state=%s", persistentAuth.redirectAddr, url.QueryEscape(state))
+	response, err := callbackClient.Get(callbackURL)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("callback status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+
+	select {
+	case err := <-errorChannel:
+		if err != nil {
+			t.Fatalf("Challenge(): %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Challenge() to complete")
 	}
 }


### PR DESCRIPTION
## Summary

Adds Go SDK support for workspace group role assumption during U2M OAuth. This unblocks the CLI from authenticating a profile as a selected Databricks group.

## Why

The CLI can collect and persist a group choice, but the SDK owns the OAuth flow that must turn that choice into a role-bound token. Without SDK support, CLI RBAC login cannot work.

## Decisions

- A group is part of a profile's state. Logging in again with the same profile but a different group will override the previous settings.
- The selected group information is passed during authorization such that the refresh token contains the assumed group. Further refreshes will retain the role.
- Workspace authentication is supported. Account authentication fails early. Discovery works when it resolves to a workspace, while unified authentication forwards the request for compatibility with future server support.
- Existing authentication behavior is unchanged when no group is configured.

## How is this tested?

- Unit tests, formatting, and linting pass.
- Live workspace authorization produced a token for the requested group, and refreshing it preserved the same assumed group.
